### PR TITLE
Show all cards randomly on landing

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,7 +233,9 @@ function render(){
   // —— HOME (no filter, no search) ——
   if(!hasFilter && !hasQuery){
     stack=[
-      ...PUBS.flatMap(p=>p.cards.map(c=>pubCard(p,c,false))),
+      ...PUBS.flatMap(p=>p.cards
+        .filter(c=>!c.title.startsWith('📖'))
+        .map(c=>pubCard(p,c,false))),
       ...BOOKSARR.map(b=>bookCard(b,false)),
       ...NOTESARR.map(n=>noteCard(n,false))
     ];


### PR DESCRIPTION
## Summary
- filter out overview cards for the landing page

## Testing
- `node -e "require('./notes.json'); console.log('notes ok')"`
- `node -e "require('fs').readFileSync('index.html'); console.log('html ok');"`


------
https://chatgpt.com/codex/tasks/task_e_6870da5bb9048320a19b7b27c9a64f3e