### PR TITLE
Add micmer-inspired support popup and media slider

### DIFF
--- a/App.js
+++ b/App.js
@@ -5,6 +5,7 @@ import ChapterItem from './components/ChapterItem.js';
 import Sidebar from './components/Sidebar.js';
 import RightSidebar from './components/RightSidebar.js';
 import SupportPopup from './components/SupportPopup.js';
+import MediaSlider from './components/MediaSlider.js';
 import { NavigationProvider, useNavigation } from './NavigationContext.js';
 
 const InnerApp = () => {
@@ -105,6 +106,8 @@ const InnerApp = () => {
                 : null}
             </p>
           </header>
+
+          <${MediaSlider} chapters=${processedData} />
 
           <div className="space-y-12">
             ${filteredData.length > 0

--- a/components/MediaSlider.js
+++ b/components/MediaSlider.js
@@ -1,0 +1,93 @@
+import { React, html } from '../runtime.js';
+
+const extractReference = (title = '') => {
+  const match = title.match(/ff\.?\d+(\.\d+)?/i);
+  return match ? match[0].replace(/\s+/g, '') : 'ff';
+};
+
+const MediaSlider = ({ chapters }) => {
+  const mediaItems = React.useMemo(() => {
+    const items = [];
+
+    chapters.forEach((chapter) => {
+      chapter.processedSubchapters.forEach((sub) => {
+        if (Array.isArray(sub.images)) {
+          sub.images.forEach((image, index) => {
+            items.push({
+              ...image,
+              id: `${sub.link}-${index}`,
+              chapterTitle: chapter.cleanTitle,
+              subTitle: sub.cleanTitle,
+              reference: extractReference(sub.title)
+            });
+          });
+        }
+      });
+    });
+
+    return items.sort(() => Math.random() - 0.5);
+  }, [chapters]);
+
+  const [currentIndex, setCurrentIndex] = React.useState(0);
+
+  React.useEffect(() => {
+    if (!mediaItems.length) return undefined;
+
+    const interval = setInterval(() => {
+      setCurrentIndex((prev) => (prev + 1) % mediaItems.length);
+    }, 4200);
+
+    return () => clearInterval(interval);
+  }, [mediaItems.length]);
+
+  if (!mediaItems.length) return null;
+
+  const currentItem = mediaItems[currentIndex];
+
+  const goToNext = () => setCurrentIndex((prev) => (prev + 1) % mediaItems.length);
+  const goToPrev = () => setCurrentIndex((prev) => (prev - 1 + mediaItems.length) % mediaItems.length);
+
+  return html`<section className="mb-14 md:mb-20">
+    <div className="relative overflow-hidden rounded-3xl border-2 border-black shadow-[8px_8px_0px_#0f172a] bg-white">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_1px_1px,#e5e7eb_1px,transparent_0)] [background-size:18px_18px] opacity-80 pointer-events-none"></div>
+      <div className="relative p-6 md:p-8 flex flex-col gap-6">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <div className="px-3 py-1 rounded-lg bg-blue-100 text-blue-900 font-heading text-xs uppercase tracking-[0.2em] border border-blue-200">MicMer mood</div>
+            <h2 className="font-heading font-black text-xl md:text-2xl tracking-tight text-gray-900 flex items-center gap-2">
+              Media pop-up deck
+              <span className="text-xs font-semibold text-gray-500">randomized</span>
+            </h2>
+          </div>
+          <div className="flex gap-2">
+            <button aria-label="Previous media" onClick=${goToPrev} className="h-9 w-9 rounded-xl border-2 border-black bg-yellow-200 hover:-translate-y-0.5 transition-transform shadow-[4px_4px_0px_#0f172a] active:translate-y-0">⟵</button>
+            <button aria-label="Next media" onClick=${goToNext} className="h-9 w-9 rounded-xl border-2 border-black bg-yellow-200 hover:-translate-y-0.5 transition-transform shadow-[4px_4px_0px_#0f172a] active:translate-y-0">⟶</button>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-[1.1fr_0.9fr] gap-6 md:gap-8 items-center">
+          <div className="overflow-hidden rounded-2xl border-2 border-black bg-gradient-to-br from-orange-50 via-white to-sky-50 shadow-[6px_6px_0px_#0f172a]">
+            <div className="relative">
+              <img src=${currentItem.src} alt=${currentItem.caption || currentItem.subTitle} className="w-full h-80 md:h-[22rem] object-cover" loading="lazy" />
+              <div className="absolute bottom-3 left-3 px-3 py-1 rounded-lg bg-black/80 text-white text-xs font-heading uppercase tracking-[0.15em]">
+                ${currentItem.reference}
+              </div>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-4 bg-white/90 rounded-2xl border-2 border-black shadow-[6px_6px_0px_#0f172a] p-4 md:p-6">
+            <div className="text-xs uppercase font-heading tracking-[0.25em] text-gray-500">FF MEDIA</div>
+            <h3 className="font-heading text-2xl md:text-3xl font-black text-gray-900 leading-tight">${currentItem.subTitle}</h3>
+            <p className="text-gray-600 text-sm md:text-base">${currentItem.caption || 'Appunti visivi dall’archivio, sfoglia le ispirazioni legate agli episodi ff.x.y.'}</p>
+            <div className="flex flex-wrap gap-2 text-sm font-heading uppercase tracking-[0.2em]">
+              <span className="px-3 py-1 rounded-lg border border-gray-200 bg-gray-50 text-gray-700">${currentItem.chapterTitle}</span>
+              <span className="px-3 py-1 rounded-lg border border-gray-200 bg-blue-50 text-blue-700">${currentItem.reference}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>`;
+};
+
+export default MediaSlider;

--- a/components/SupportPopup.js
+++ b/components/SupportPopup.js
@@ -18,42 +18,71 @@ const SupportPopup = () => {
   if (!showSupportPopup) return null;
 
   return html`<div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/40 backdrop-blur-sm">
-    <div className="bg-white rounded-2xl shadow-2xl max-w-md w-full border border-gray-100 overflow-hidden animate-in fade-in zoom-in-95 duration-300">
-      <div className="p-6 space-y-4">
-        <div className="flex justify-between items-start">
-          <div>
-            <div className="text-xs font-heading uppercase tracking-widest text-gray-400 mb-2">Support Futuro Fortissimo</div>
-            <h3 className="text-2xl font-heading font-extrabold text-gray-900">Enjoying the archive?</h3>
-            <p className="text-gray-500 mt-1">If this work is useful to you, consider supporting it. Even a small gesture keeps the project alive.</p>
-          </div>
-          <button onClick=${closeSupportPopup} className="text-gray-400 hover:text-black transition-colors">✕</button>
-        </div>
-
-        <div className="bg-gradient-to-r from-yellow-100 to-orange-100 rounded-xl p-4 border border-yellow-200">
-          <div className="flex items-center gap-3">
-            <div className="text-2xl">☕</div>
+    <div className="bg-white rounded-[30px] border-2 border-black shadow-[10px_10px_0px_#0f172a] max-w-xl w-full overflow-hidden animate-in fade-in zoom-in-95 duration-300">
+      <div className="relative p-6 md:p-8 bg-gradient-to-br from-orange-50 via-white to-sky-50">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_1px_1px,#e5e7eb_1px,transparent_0)] [background-size:18px_18px] opacity-70 pointer-events-none"></div>
+        <div className="relative space-y-5">
+          <div className="flex justify-between items-start gap-4">
             <div>
-              <div className="font-heading font-bold text-gray-900">Buy me a coffee</div>
-              <p className="text-sm text-gray-600">Your support helps maintain and expand the archive.</p>
+              <div className="text-[11px] font-heading uppercase tracking-[0.3em] text-gray-500 mb-2">Support Futuro Fortissimo</div>
+              <h3 className="text-3xl font-heading font-black text-gray-900 leading-tight">Pop up powered like micmer</h3>
+              <p className="text-gray-600 mt-2 text-sm md:text-base max-w-xl">Se ti piace l’archivio, regalagli energia. Ho preso in prestito il mood di micmer.giT per festeggiare ogni ff.x.y: scegli PayPal o passa dal sito per scoprire di più.</p>
             </div>
+            <button onClick=${closeSupportPopup} className="h-10 w-10 rounded-xl border-2 border-black bg-white hover:-translate-y-0.5 transition-transform shadow-[4px_4px_0px_#0f172a] active:translate-y-0">✕</button>
           </div>
-        </div>
 
-        <div className="flex gap-3">
-          <a
-            href="https://www.buymeacoffee.com/michelemerelli"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex-1 text-center bg-black text-white py-2.5 rounded-lg font-heading font-bold uppercase tracking-widest hover:bg-gray-800 transition-colors shadow-lg"
-          >
-            Support Now
-          </a>
-          <button
-            onClick=${closeSupportPopup}
-            className="px-4 py-2.5 border border-gray-200 rounded-lg text-gray-700 hover:bg-gray-50 font-heading font-semibold"
-          >
-            Maybe Later
-          </button>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <a
+              href="https://www.paypal.com/paypalme/MicheleMerelli"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="relative overflow-hidden rounded-2xl border-2 border-black bg-white p-4 flex flex-col gap-3 shadow-[6px_6px_0px_#0f172a] hover:-translate-y-1 transition-transform"
+            >
+              <div className="absolute inset-0 bg-blue-50 opacity-70"></div>
+              <div className="relative flex items-center gap-3">
+                <span className="text-3xl">💙</span>
+                <div>
+                  <div className="font-heading font-black text-gray-900 text-lg">PayPal pop</div>
+                  <p className="text-xs text-gray-600">Il modo più rapido per mandare un grazie.</p>
+                </div>
+              </div>
+              <div className="relative mt-auto text-sm font-heading uppercase tracking-[0.2em] text-blue-900">paypal.me/MicheleMerelli</div>
+            </a>
+
+            <a
+              href="https://micmer-git.github.io/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="relative overflow-hidden rounded-2xl border-2 border-black bg-white p-4 flex flex-col gap-3 shadow-[6px_6px_0px_#0f172a] hover:-translate-y-1 transition-transform"
+            >
+              <div className="absolute inset-0 bg-yellow-100 opacity-70"></div>
+              <div className="relative flex items-center gap-3">
+                <span className="text-3xl">🟦</span>
+                <div>
+                  <div className="font-heading font-black text-gray-900 text-lg">micmer.giT</div>
+                  <p className="text-xs text-gray-600">Visita il sito gemello per vibrazioni extra.</p>
+                </div>
+              </div>
+              <div className="relative mt-auto text-sm font-heading uppercase tracking-[0.2em] text-gray-900">stile pop-up, griglia, blocky</div>
+            </a>
+          </div>
+
+          <div className="flex flex-wrap gap-3">
+            <a
+              href="https://www.buymeacoffee.com/michelemerelli"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex-1 min-w-[140px] text-center bg-black text-white py-3 rounded-xl font-heading font-bold uppercase tracking-[0.25em] hover:bg-gray-800 transition-colors shadow-[6px_6px_0px_#0f172a]"
+            >
+              Coffee boost
+            </a>
+            <button
+              onClick=${closeSupportPopup}
+              className="px-5 py-3 border-2 border-black rounded-xl text-gray-800 bg-white hover:-translate-y-0.5 transition-transform shadow-[6px_6px_0px_#0f172a] active:translate-y-0 font-heading font-semibold"
+            >
+              Più tardi
+            </button>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- restyle the support popup with micmer-style blocks and add PayPal and micmer site CTAs
- introduce a randomized media slider that surfaces ff.x.y visuals with references
- embed the new slider into the archive landing area alongside existing content

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933b69413d883209518fb79fba9890a)