### PR TITLE
Refine layout and media access

### DIFF
--- a/App.js
+++ b/App.js
@@ -11,6 +11,7 @@ import { NavigationProvider, useNavigation } from './NavigationContext.js';
 const InnerApp = () => {
   const [processedData, setProcessedData] = React.useState([]);
   const [selectedEmoji, setSelectedEmoji] = React.useState(null);
+  const [isMediaOpen, setIsMediaOpen] = React.useState(false);
   const { incrementInteraction } = useNavigation();
 
   React.useEffect(() => {
@@ -43,6 +44,13 @@ const InnerApp = () => {
     setSelectedEmoji(emoji);
   };
 
+  const handleOpenMedia = () => {
+    incrementInteraction();
+    setIsMediaOpen(true);
+  };
+
+  const handleCloseMedia = () => setIsMediaOpen(false);
+
   return html`<div className="min-h-screen text-black selection:bg-yellow-200 selection:text-black">
     <${SupportPopup} />
 
@@ -53,7 +61,7 @@ const InnerApp = () => {
           <h1 className="text-4xl md:text-5xl font-heading font-black leading-none">Futuro Fortissimo</h1>
           <p className="mt-3 text-base max-w-2xl">Brutalist, technical, retro. Un archivio cronologico di idee, media e collegamenti sul futuro sostenibile.</p>
         </div>
-        <div className="flex gap-3">
+        <div className="flex flex-wrap gap-3">
           <button
             onClick=${() => handleTopicSelect(null)}
             className="px-4 py-3 border-3 border-black bg-white brutal-shadow font-heading text-xs uppercase tracking-[0.2em] hover:-translate-y-1 transition-transform"
@@ -69,106 +77,8 @@ const InnerApp = () => {
         </div>
       </header>
 
-      <div className="grid gap-6 lg:grid-cols-[1.4fr_1fr]">
-        <section className="brutal-card accent-bar accent-blue no-round">
-          <div className="bg-[var(--ff-blue)] border-3 border-black p-3 flex items-center justify-between mb-4">
-            <div className="bg-white border-3 border-black px-3 py-1 font-heading text-sm">Profile</div>
-            <span className="font-heading text-xs tracking-[0.2em] text-white">Retro Computing Mood</span>
-          </div>
-          <div className="grid grid-cols-[140px_1fr] gap-6 items-start">
-            <div className="border-3 border-black bg-white brutal-shadow h-36 flex items-center justify-center text-center">
-              <span className="font-heading text-xl leading-tight">MIC<br />MER</span>
-            </div>
-            <div className="grid grid-cols-2 gap-4">
-              <div className="border-3 border-black p-3 accent-bar accent-red no-round">
-                <p className="mono-label text-[10px] text-black">Location</p>
-                <p className="mt-2 font-heading text-lg flex items-center gap-2">📍 Bergamo</p>
-              </div>
-              <div className="border-3 border-black p-3 accent-bar accent-yellow no-round">
-                <p className="mono-label text-[10px] text-black">Born</p>
-                <p className="mt-2 font-heading text-lg flex items-center gap-2">📅 1990</p>
-              </div>
-              <div className="border-3 border-black p-3 accent-bar accent-green no-round">
-                <p className="mono-label text-[10px] text-black">Email</p>
-                <p className="mt-2 font-heading text-lg flex items-center gap-2">✉️ micmer@pm.me</p>
-              </div>
-              <div className="border-3 border-black p-3 accent-bar accent-blue no-round">
-                <p className="mono-label text-[10px] text-black">MSC</p>
-                <p className="mt-2 font-heading text-lg flex items-center gap-2">💻 PoliMi</p>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <section className="brutal-card no-round">
-          <p className="mono-label text-[10px] text-black mb-3">Social + Links</p>
-          <div className="space-y-3">
-            ${[
-              { label: 'Newsletter', href: 'https://fortissimo.substack.com', icon: '➡️' },
-              { label: 'WhatsApp', href: 'https://api.whatsapp.com/send?text=https://futurofortissimo.github.io', icon: '↗' },
-              { label: 'Supporta', href: 'https://www.paypal.com/paypalme/michelemerelli', icon: '💙' },
-              { label: 'English', href: 'https://futurofortissimo.github.io/ff_en.html', icon: 'EN' }
-            ].map((item) => html`<a
-                key=${item.label}
-                href=${item.href}
-                className="flex items-center justify-between border-3 border-black px-4 py-3 bg-white brutal-shadow hover:-translate-y-1 transition-transform no-round"
-              >
-                <span className="font-heading text-lg">${item.icon}</span>
-                <span className="font-heading text-base flex-1 text-left ml-3">${item.label}</span>
-                <span className="font-heading text-lg">→</span>
-              </a>`)}
-          </div>
-        </section>
-      </div>
-
-      <div className="grid gap-6 md:grid-cols-3">
-        <div className="brutal-card accent-bar accent-blue no-round flex flex-col gap-2">
-          <div className="flex items-center gap-3">
-            <div className="w-12 h-12 border-3 border-black flex items-center justify-center font-heading">📚</div>
-            <div>
-              <p className="mono-label text-[10px] text-black">Feature</p>
-              <h3 className="font-heading text-2xl">Archive Stories</h3>
-            </div>
-          </div>
-          <p className="text-sm">Cronologia di capitoli ff.x.y con filtri per emoji e ricerca diretta.</p>
-        </div>
-        <div className="brutal-card accent-bar accent-yellow no-round flex flex-col gap-2 relative">
-          <span className="absolute right-3 top-2 mono-label text-[10px]">Knowledge Base</span>
-          <div className="flex items-center gap-3">
-            <div className="w-12 h-12 border-3 border-black flex items-center justify-center font-heading">🧠</div>
-            <div>
-              <p className="mono-label text-[10px] text-black">Feature</p>
-              <h3 className="font-heading text-2xl">Connections</h3>
-            </div>
-          </div>
-          <p className="text-sm">Ogni sottocapitolo porta a riferimenti e collegamenti incrociati.</p>
-        </div>
-        <div className="brutal-card accent-bar accent-green no-round flex flex-col gap-2">
-          <div className="flex items-center gap-3">
-            <div className="w-12 h-12 border-3 border-black flex items-center justify-center font-heading">🛰️</div>
-            <div>
-              <p className="mono-label text-[10px] text-black">Feature</p>
-              <h3 className="font-heading text-2xl">Media deck</h3>
-            </div>
-          </div>
-          <p className="text-sm">Slider visivo randomizzato ispirato al mood tecnico neo-brutalista.</p>
-        </div>
-      </div>
-
-      <section className="brutal-card no-round accent-bar accent-blue relative">
-        <span className="absolute right-5 top-3 mono-label text-[10px]">Knowledge Base</span>
-        <div className="flex items-center gap-4">
-          <div className="w-16 h-16 border-3 border-black flex items-center justify-center font-heading">🗂️</div>
-          <div className="flex-1">
-            <h3 className="font-heading text-3xl leading-none">Futuro Fortissimo</h3>
-            <p className="mt-2 text-sm max-w-2xl">Archivio digitale di storie, note e immagini che miscelano tecnologia, sostenibilità e comunità.</p>
-          </div>
-          <a href="https://futurofortissimo.github.io/" className="px-4 py-3 border-3 border-black bg-white brutal-shadow font-heading text-xs uppercase tracking-[0.2em] hover:-translate-y-1 transition-transform">→ Apri</a>
-        </div>
-      </section>
-
       <section className="brutal-card no-round">
-        <div className="grid lg:grid-cols-[140px_1fr_320px] gap-6 items-start">
+        <div className="grid grid-cols-1 lg:grid-cols-[140px_1fr_320px] gap-6 items-start">
           <div className="hidden lg:block">
             <${Sidebar} selectedEmoji=${selectedEmoji} onSelect=${handleTopicSelect} vertical=${true} />
           </div>
@@ -178,7 +88,7 @@ const InnerApp = () => {
               <${Sidebar} selectedEmoji=${selectedEmoji} onSelect=${handleTopicSelect} vertical=${false} />
             </div>
 
-            <div className="border-3 border-black p-3 bg-white brutal-shadow flex items-center justify-between">
+            <div className="border-3 border-black p-3 bg-white flex items-center justify-between">
               <div className="font-heading text-sm">Archivio • ${filteredData.length} capitoli</div>
               ${selectedEmoji
                 ? html`<button
@@ -189,8 +99,6 @@ const InnerApp = () => {
                   </button>`
                 : html`<span className="font-heading text-xs uppercase tracking-[0.2em]">Tutti i temi</span>`}
             </div>
-
-            <${MediaSlider} chapters=${processedData} />
 
             <div className="space-y-8">
               ${filteredData.length > 0
@@ -208,16 +116,32 @@ const InnerApp = () => {
             </div>
           </div>
 
-          <div className="hidden lg:block border-3 border-black bg-white brutal-shadow p-4">
-            <${RightSidebar} chapters=${filteredData} />
+          <div className="hidden lg:block border-3 border-black bg-white p-4">
+            <${RightSidebar} chapters=${filteredData} onOpenMedia=${handleOpenMedia} />
           </div>
         </div>
       </section>
 
       <div className="lg:hidden brutal-card no-round">
-        <${RightSidebar} chapters=${filteredData} isMobileMode=${true} />
+        <${RightSidebar} chapters=${filteredData} isMobileMode=${true} onOpenMedia=${handleOpenMedia} />
       </div>
     </div>
+
+    ${isMediaOpen
+      ? html`<div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
+          <div role="dialog" aria-modal="true" aria-label="Media deck" className="relative max-w-5xl w-full">
+            <div className="absolute right-4 top-4 z-10">
+              <button
+                onClick=${handleCloseMedia}
+                className="px-4 py-2 border-3 border-black bg-white font-heading text-xs uppercase tracking-[0.2em] hover:-translate-y-0.5 transition-transform"
+              >
+                Chiudi media
+              </button>
+            </div>
+            <${MediaSlider} chapters=${processedData} />
+          </div>
+        </div>`
+      : null}
   </div>`;
 };
 

--- a/components/RightSidebar.js
+++ b/components/RightSidebar.js
@@ -2,7 +2,7 @@ import { React, html } from '../runtime.js';
 import { slugify } from '../utils.js';
 import { useNavigation } from '../NavigationContext.js';
 
-const RightSidebar = ({ chapters, isMobileMode = false }) => {
+const RightSidebar = ({ chapters, isMobileMode = false, onOpenMedia }) => {
   const { searchQuery, setSearchQuery, debouncedSearchQuery, setActiveId, incrementInteraction, setIsMobileMenuOpen } = useNavigation();
 
   const handleSearchChange = (e) => {
@@ -41,15 +41,26 @@ const RightSidebar = ({ chapters, isMobileMode = false }) => {
   }).filter(Boolean);
 
   return html`<div className="space-y-4">
-    <div className="relative">
+    <div className="relative flex items-center gap-2">
       <input
         type="text"
         value=${searchQuery}
         onInput=${handleSearchChange}
         placeholder="Cerca storie..."
-        className="w-full px-4 py-3 bg-white border-3 border-black font-heading uppercase tracking-[0.15em] placeholder:text-gray-400 focus:outline-none focus:ring-0"
+        className="w-full px-4 py-3 pr-28 bg-white border-3 border-black font-heading uppercase tracking-[0.15em] placeholder:text-gray-400 focus:outline-none focus:ring-0"
+        aria-label="Cerca storie"
       />
-      <div className="absolute right-3 top-1/2 -translate-y-1/2 text-black">🔍</div>
+      <div className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-2">
+        <span aria-hidden="true" className="text-black">🔍</span>
+        <button
+          type="button"
+          onClick=${() => onOpenMedia && onOpenMedia()}
+          className="px-3 py-1 border-2 border-black bg-white font-heading text-[11px] uppercase tracking-[0.18em] hover:-translate-y-0.5 transition-transform"
+          aria-label="Apri media deck"
+        >
+          Media
+        </button>
+      </div>
     </div>
 
     <div className="max-h-[70vh] overflow-y-auto pr-1 space-y-6 no-scrollbar">

--- a/components/SubChapterItem.js
+++ b/components/SubChapterItem.js
@@ -60,7 +60,7 @@ const SubChapterItem = ({ subchapter }) => {
 
   return html`<div id=${id} className="relative pl-0 group mb-6 scroll-mt-32 transition-all duration-300">
     <div
-      className="flex items-baseline gap-2 cursor-pointer bg-white border-3 border-black p-3 hover:-translate-y-1 transition-transform brutal-shadow"
+      className="flex items-baseline gap-2 cursor-pointer bg-white border-3 border-black p-3 hover:-translate-y-1 transition-transform"
       onClick=${toggleExpand}
     >
       <span className="text-xl opacity-100 shrink-0 self-center leading-none">${subchapter.originalEmoji}</span>
@@ -127,7 +127,7 @@ const SubChapterItem = ({ subchapter }) => {
                   e.stopPropagation();
                   incrementInteraction();
                 }}
-                className=${`inline-flex items-center gap-1.5 px-3 py-1 border-2 border-black bg-white text-black brutal-shadow hover:-translate-y-0.5 transition-transform ${
+                className=${`inline-flex items-center gap-1.5 px-3 py-1 border-2 border-black bg-white text-black hover:-translate-y-0.5 transition-transform ${
                   isCross ? 'bg-blue-100' : 'bg-gray-50'
                 }`}
               >
@@ -162,7 +162,7 @@ const SubChapterItem = ({ subchapter }) => {
                   <img
                     src=${img.src}
                     alt=${img.caption || 'Subchapter image'}
-                    className="w-full h-auto border-3 border-black bg-white brutal-shadow"
+                    className="w-full h-auto border-3 border-black bg-white"
                     loading="lazy"
                   />
                   ${img.caption

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
       .brutal-card {
         border: 4px solid var(--ff-black);
         background: #ffffff;
-        box-shadow: 10px 10px 0 var(--ff-black);
+        box-shadow: 6px 6px 0 var(--ff-black);
         padding: 24px;
       }
 
@@ -61,7 +61,7 @@
       }
 
       .brutal-shadow {
-        box-shadow: 10px 10px 0 var(--ff-black);
+        box-shadow: 4px 4px 0 var(--ff-black);
       }
 
       .accent-bar { position: relative; }


### PR DESCRIPTION
## Summary
- streamline the landing layout by removing profile, social, and knowledge feature blocks while softening primary card shadows
- improve archive responsiveness and remove shadows from subchapter content and links to keep boxes fitting on all screen sizes
- move the media deck into a modal opened from a new Media button near the search input instead of always showing inline

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933bb9ad6648320ad16874142f5e356)