### PR TITLE
Improve search placement and media slider layout

### DIFF
--- a/App.js
+++ b/App.js
@@ -12,7 +12,7 @@ const InnerApp = () => {
   const [processedData, setProcessedData] = React.useState([]);
   const [selectedEmoji, setSelectedEmoji] = React.useState(null);
   const [isMediaOpen, setIsMediaOpen] = React.useState(false);
-  const { incrementInteraction } = useNavigation();
+  const { incrementInteraction, searchQuery, setSearchQuery } = useNavigation();
 
   React.useEffect(() => {
     const processed = rawData.map(processChapter);
@@ -42,6 +42,10 @@ const InnerApp = () => {
   const handleTopicSelect = (emoji) => {
     incrementInteraction();
     setSelectedEmoji(emoji);
+  };
+
+  const handleSearchChange = (e) => {
+    setSearchQuery(e.target.value);
   };
 
   const handleOpenMedia = () => {
@@ -76,6 +80,35 @@ const InnerApp = () => {
           </button>
         </div>
       </header>
+
+      <section className="brutal-card accent-bar accent-yellow no-round">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div className="space-y-1">
+            <p className="mono-label text-xs text-black">Cerca nell'archivio</p>
+            <p className="text-sm md:text-base max-w-2xl">Trova capitoli e storie per parola chiave, poi apri il media deck per vedere le immagini correlate.</p>
+          </div>
+          <div className="w-full md:w-1/2 flex flex-col gap-3">
+            <div className="relative">
+              <input
+                type="text"
+                value=${searchQuery}
+                onInput=${handleSearchChange}
+                placeholder="Cerca storie..."
+                className="w-full px-4 py-3 pr-12 bg-white border-3 border-black font-heading uppercase tracking-[0.15em] placeholder:text-gray-400 focus:outline-none focus:ring-0"
+                aria-label="Cerca storie"
+              />
+              <span aria-hidden="true" className="absolute right-4 top-1/2 -translate-y-1/2 text-black">🔍</span>
+            </div>
+            <button
+              type="button"
+              onClick=${handleOpenMedia}
+              className="px-4 py-3 border-3 border-black bg-white brutal-shadow font-heading text-xs uppercase tracking-[0.2em] hover:-translate-y-1 transition-transform"
+            >
+              Apri media
+            </button>
+          </div>
+        </div>
+      </section>
 
       <section className="brutal-card no-round">
         <div className="grid grid-cols-1 lg:grid-cols-[140px_1fr_320px] gap-6 items-start">

--- a/components/MediaSlider.js
+++ b/components/MediaSlider.js
@@ -18,14 +18,16 @@ const MediaSlider = ({ chapters }) => {
               id: `${sub.link}-${index}`,
               chapterTitle: chapter.cleanTitle,
               subTitle: sub.cleanTitle,
-              reference: extractReference(sub.title)
+              reference: extractReference(sub.title),
+              link: sub.link,
+              chapterUrl: chapter.url
             });
           });
         }
       });
     });
 
-    return items.sort(() => Math.random() - 0.5);
+    return items;
   }, [chapters]);
 
   const [currentIndex, setCurrentIndex] = React.useState(0);
@@ -35,7 +37,7 @@ const MediaSlider = ({ chapters }) => {
 
     const interval = setInterval(() => {
       setCurrentIndex((prev) => (prev + 1) % mediaItems.length);
-    }, 4200);
+    }, 10000);
 
     return () => clearInterval(interval);
   }, [mediaItems.length]);
@@ -47,18 +49,14 @@ const MediaSlider = ({ chapters }) => {
   const goToNext = () => setCurrentIndex((prev) => (prev + 1) % mediaItems.length);
   const goToPrev = () => setCurrentIndex((prev) => (prev - 1 + mediaItems.length) % mediaItems.length);
 
+  const overlayLabel = currentItem.caption?.trim() ? currentItem.caption : currentItem.reference;
+
   return html`<section className="mb-12 md:mb-16">
     <div className="relative overflow-hidden brutal-card no-round bg-white accent-bar accent-yellow">
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_1px_1px,#000_1px,transparent_0)] [background-size:22px_22px] opacity-10 pointer-events-none"></div>
       <div className="relative p-6 md:p-8 flex flex-col gap-6">
         <div className="flex items-center justify-between gap-4">
-          <div className="flex items-center gap-3">
-            <div className="px-3 py-1 border-3 border-black bg-[var(--ff-blue)] text-black font-heading text-xs uppercase tracking-[0.2em]">MicMer mood</div>
-            <h2 className="font-heading font-black text-xl md:text-2xl tracking-tight text-black flex items-center gap-2">
-              Media pop-up deck
-              <span className="text-xs font-semibold text-black/70">randomized</span>
-            </h2>
-          </div>
+          <h2 className="font-heading font-black text-xl md:text-2xl tracking-tight text-black">Media dall'archivio</h2>
           <div className="flex gap-2">
             <button aria-label="Previous media" onClick=${goToPrev} className="h-10 w-10 border-3 border-black bg-white brutal-shadow hover:-translate-y-1 transition-transform">⟵</button>
             <button aria-label="Next media" onClick=${goToNext} className="h-10 w-10 border-3 border-black bg-white brutal-shadow hover:-translate-y-1 transition-transform">⟶</button>
@@ -66,22 +64,35 @@ const MediaSlider = ({ chapters }) => {
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-[1.1fr_0.9fr] gap-6 md:gap-8 items-center">
-          <div className="overflow-hidden border-4 border-black bg-gradient-to-br from-yellow-100 via-white to-blue-100 brutal-shadow">
-            <div className="relative">
-              <img src=${currentItem.src} alt=${currentItem.caption || currentItem.subTitle} className="w-full h-80 md:h-[22rem] object-cover" loading="lazy" />
-              <div className="absolute bottom-3 left-3 px-3 py-1 border-3 border-black bg-white text-black text-xs font-heading uppercase tracking-[0.15em]">
-                ${currentItem.reference}
-              </div>
+          <div className="overflow-hidden border-4 border-black bg-white brutal-shadow flex items-center justify-center">
+            <div className="relative w-full">
+              <img
+                src=${currentItem.src}
+                alt=${currentItem.caption || currentItem.subTitle}
+                className="w-full max-h-[70vh] object-contain bg-white"
+                loading="lazy"
+              />
+              ${overlayLabel
+                ? html`<div className="absolute bottom-3 left-3 right-3 px-3 py-2 border-3 border-black bg-white text-black text-xs font-heading uppercase tracking-[0.12em] brutal-shadow">${overlayLabel}</div>`
+                : null}
             </div>
           </div>
 
           <div className="flex flex-col gap-4 bg-white border-4 border-black brutal-shadow p-4 md:p-6">
-            <div className="text-xs uppercase font-heading tracking-[0.25em] text-black">FF MEDIA</div>
             <h3 className="font-heading text-2xl md:text-3xl font-black text-black leading-tight">${currentItem.subTitle}</h3>
-            <p className="text-black/80 text-sm md:text-base">${currentItem.caption || 'Appunti visivi dall’archivio, sfoglia le ispirazioni legate agli episodi ff.x.y.'}</p>
+            <p className="text-sm md:text-base text-black/80">${currentItem.chapterTitle}</p>
+            ${currentItem.reference
+              ? html`<span className="px-3 py-1 border-3 border-black bg-yellow-100 text-xs font-heading uppercase tracking-[0.18em] inline-flex w-fit">${currentItem.reference}</span>`
+              : null}
             <div className="flex flex-wrap gap-2 text-sm font-heading uppercase tracking-[0.2em]">
-              <span className="px-3 py-1 border-3 border-black bg-white">${currentItem.chapterTitle}</span>
-              <span className="px-3 py-1 border-3 border-black bg-[var(--ff-blue)] text-black">${currentItem.reference}</span>
+              <a
+                href=${currentItem.link || currentItem.chapterUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="px-3 py-2 border-3 border-black bg-[var(--ff-blue)] text-black hover:-translate-y-0.5 transition-transform"
+              >
+                Apri sezione
+              </a>
             </div>
           </div>
         </div>

--- a/components/RightSidebar.js
+++ b/components/RightSidebar.js
@@ -3,11 +3,7 @@ import { slugify } from '../utils.js';
 import { useNavigation } from '../NavigationContext.js';
 
 const RightSidebar = ({ chapters, isMobileMode = false, onOpenMedia }) => {
-  const { searchQuery, setSearchQuery, debouncedSearchQuery, setActiveId, incrementInteraction, setIsMobileMenuOpen } = useNavigation();
-
-  const handleSearchChange = (e) => {
-    setSearchQuery(e.target.value);
-  };
+  const { searchQuery, debouncedSearchQuery, setActiveId, incrementInteraction, setIsMobileMenuOpen } = useNavigation();
 
   const handleItemClick = (id) => {
     setActiveId(id);
@@ -41,26 +37,20 @@ const RightSidebar = ({ chapters, isMobileMode = false, onOpenMedia }) => {
   }).filter(Boolean);
 
   return html`<div className="space-y-4">
-    <div className="relative flex items-center gap-2">
-      <input
-        type="text"
-        value=${searchQuery}
-        onInput=${handleSearchChange}
-        placeholder="Cerca storie..."
-        className="w-full px-4 py-3 pr-28 bg-white border-3 border-black font-heading uppercase tracking-[0.15em] placeholder:text-gray-400 focus:outline-none focus:ring-0"
-        aria-label="Cerca storie"
-      />
-      <div className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-2">
-        <span aria-hidden="true" className="text-black">🔍</span>
-        <button
-          type="button"
-          onClick=${() => onOpenMedia && onOpenMedia()}
-          className="px-3 py-1 border-2 border-black bg-white font-heading text-[11px] uppercase tracking-[0.18em] hover:-translate-y-0.5 transition-transform"
-          aria-label="Apri media deck"
-        >
-          Media
-        </button>
+    <div className="flex items-center justify-between gap-2">
+      <div className="font-heading text-[11px] uppercase tracking-[0.18em] text-black">
+        ${searchQuery ? `Risultati per “${searchQuery}”` : 'Naviga tra i capitoli'}
       </div>
+      ${onOpenMedia
+        ? html`<button
+            type="button"
+            onClick=${() => onOpenMedia()}
+            className="px-3 py-1 border-2 border-black bg-white font-heading text-[11px] uppercase tracking-[0.18em] hover:-translate-y-0.5 transition-transform"
+            aria-label="Apri media"
+          >
+            Media
+          </button>`
+        : null}
     </div>
 
     <div className="max-h-[70vh] overflow-y-auto pr-1 space-y-6 no-scrollbar">

--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -6,7 +6,7 @@ const Sidebar = ({ selectedEmoji, onSelect, vertical = true }) => {
 
   const containerClasses = vertical
     ? 'flex-col items-center gap-3'
-    : 'flex-row items-center gap-3 px-2';
+    : 'flex-row flex-wrap items-center gap-3 px-2 justify-center';
 
   const itemClasses =
     'w-12 h-12 flex-shrink-0 flex items-center justify-center border-3 border-black bg-white text-black font-heading text-lg transition-all duration-150 shadow-[6px_6px_0_#000] hover:-translate-y-0.5';


### PR DESCRIPTION
## Summary
- Move the search bar beneath the intro card so queries filter the archive regardless of sidebar state
- Prevent topic filter icons from overflowing on small screens by allowing wrapping
- Refresh the media slider to show full images with caption overlays, slower timing, stable order, and direct links back to sections

## Testing
- Attempted `npm run build` *(failed: npm not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933bd1af1e08320a21779973546fe30)