### PR TITLE
Improve search overlay and streamline support

### DIFF
--- a/App.js
+++ b/App.js
@@ -6,12 +6,15 @@ import Sidebar from './components/Sidebar.js';
 import RightSidebar from './components/RightSidebar.js';
 import SupportPopup from './components/SupportPopup.js';
 import MediaSlider from './components/MediaSlider.js';
+import SearchResultsModal from './components/SearchResultsModal.js';
 import { NavigationProvider, useNavigation } from './NavigationContext.js';
 
 const InnerApp = () => {
   const [processedData, setProcessedData] = React.useState([]);
   const [selectedEmoji, setSelectedEmoji] = React.useState(null);
   const [isMediaOpen, setIsMediaOpen] = React.useState(false);
+  const [isSearchOverlayOpen, setIsSearchOverlayOpen] = React.useState(false);
+  const [hasManuallyClosedSearch, setHasManuallyClosedSearch] = React.useState(false);
   const { incrementInteraction, searchQuery, setSearchQuery } = useNavigation();
 
   React.useEffect(() => {
@@ -45,7 +48,36 @@ const InnerApp = () => {
   };
 
   const handleSearchChange = (e) => {
+    setHasManuallyClosedSearch(false);
     setSearchQuery(e.target.value);
+  };
+
+  React.useEffect(() => {
+    if (searchQuery.trim()) {
+      if (!hasManuallyClosedSearch) {
+        setIsSearchOverlayOpen(true);
+      }
+    } else {
+      setIsSearchOverlayOpen(false);
+      setHasManuallyClosedSearch(false);
+    }
+  }, [searchQuery, hasManuallyClosedSearch]);
+
+  const handleHideSearchOverlay = () => {
+    setIsSearchOverlayOpen(false);
+    setHasManuallyClosedSearch(true);
+  };
+
+  const handleClearSearch = () => {
+    setSearchQuery('');
+    setHasManuallyClosedSearch(false);
+  };
+
+  const handleShowSearchOverlay = () => {
+    if (searchQuery.trim()) {
+      setHasManuallyClosedSearch(false);
+      setIsSearchOverlayOpen(true);
+    }
   };
 
   const handleOpenMedia = () => {
@@ -57,35 +89,36 @@ const InnerApp = () => {
 
   return html`<div className="min-h-screen text-black selection:bg-yellow-200 selection:text-black">
     <${SupportPopup} />
+    <${SearchResultsModal}
+      chapters=${processedData}
+      isOpen=${isSearchOverlayOpen}
+      onHide=${handleHideSearchOverlay}
+      onClear=${handleClearSearch}
+      onNavigate=${handleHideSearchOverlay}
+    />
 
     <div className="max-w-6xl mx-auto px-4 md:px-8 py-10 space-y-10">
-      <header className="brutal-card accent-bar accent-blue flex flex-col md:flex-row justify-between items-start gap-4 no-round">
+      <header className="brutal-card mobile-unboxed accent-bar accent-blue flex flex-col md:flex-row justify-between items-start gap-4 no-round">
         <div>
-          <p className="mono-label text-xs text-black">Mic Mer Archive</p>
           <h1 className="text-4xl md:text-5xl font-heading font-black leading-none">Futuro Fortissimo</h1>
-          <p className="mt-3 text-base max-w-2xl">Brutalist, technical, retro. Un archivio cronologico di idee, media e collegamenti sul futuro sostenibile.</p>
         </div>
         <div className="flex flex-wrap gap-3">
-          <button
-            onClick=${() => handleTopicSelect(null)}
-            className="px-4 py-3 border-3 border-black bg-white brutal-shadow font-heading text-xs uppercase tracking-[0.2em] hover:-translate-y-1 transition-transform"
-          >
-            Reset filtri
-          </button>
-          <button
-            onClick=${() => incrementInteraction()}
+          <a
+            href="https://www.paypal.com/paypalme/MicheleMerelli"
+            target="_blank"
+            rel="noopener noreferrer"
             className="px-4 py-3 border-3 border-black bg-[var(--ff-blue)] text-black brutal-shadow font-heading text-xs uppercase tracking-[0.2em] hover:-translate-y-1 transition-transform"
           >
-            Supporto
-          </button>
+            Supporto PayPal
+          </a>
         </div>
       </header>
 
-      <section className="brutal-card accent-bar accent-yellow no-round">
+      <section className="brutal-card mobile-unboxed accent-bar accent-yellow no-round">
         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div className="space-y-1">
             <p className="mono-label text-xs text-black">Cerca nell'archivio</p>
-            <p className="text-sm md:text-base max-w-2xl">Trova capitoli e storie per parola chiave, poi apri il media deck per vedere le immagini correlate.</p>
+            <p className="text-sm md:text-base max-w-2xl">Trova capitoli e storie per parola chiave: i risultati compaiono in un pannello dedicato con evidenziazione nei contenuti.</p>
           </div>
           <div className="w-full md:w-1/2 flex flex-col gap-3">
             <div className="relative">
@@ -106,11 +139,31 @@ const InnerApp = () => {
             >
               Apri media
             </button>
+            ${searchQuery
+              ? html`<div className="flex flex-wrap gap-2">
+                  ${!isSearchOverlayOpen
+                    ? html`<button
+                        type="button"
+                        onClick=${handleShowSearchOverlay}
+                        className="px-3 py-2 border-3 border-black bg-white brutal-shadow font-heading text-[11px] uppercase tracking-[0.2em] hover:-translate-y-0.5 transition-transform"
+                      >
+                        Mostra risultati
+                      </button>`
+                    : null}
+                  <button
+                    type="button"
+                    onClick=${handleClearSearch}
+                    className="px-3 py-2 border-3 border-black bg-[var(--ff-yellow)] brutal-shadow font-heading text-[11px] uppercase tracking-[0.2em] hover:-translate-y-0.5 transition-transform"
+                  >
+                    Svuota ricerca
+                  </button>
+                </div>`
+              : null}
           </div>
         </div>
       </section>
 
-      <section className="brutal-card no-round">
+      <section className="brutal-card mobile-unboxed no-round">
         <div className="grid grid-cols-1 lg:grid-cols-[140px_1fr_320px] gap-6 items-start">
           <div className="hidden lg:block">
             <${Sidebar} selectedEmoji=${selectedEmoji} onSelect=${handleTopicSelect} vertical=${true} />
@@ -155,7 +208,7 @@ const InnerApp = () => {
         </div>
       </section>
 
-      <div className="lg:hidden brutal-card no-round">
+      <div className="lg:hidden brutal-card mobile-unboxed no-round">
         <${RightSidebar} chapters=${filteredData} isMobileMode=${true} onOpenMedia=${handleOpenMedia} />
       </div>
     </div>

--- a/NavigationContext.js
+++ b/NavigationContext.js
@@ -16,7 +16,7 @@ export const NavigationProvider = ({ children }) => {
   React.useEffect(() => {
     const timer = setTimeout(() => {
       setDebouncedSearchQuery(searchQuery);
-    }, 1000);
+    }, 400);
 
     return () => clearTimeout(timer);
   }, [searchQuery]);

--- a/components/SearchResultsModal.js
+++ b/components/SearchResultsModal.js
@@ -1,0 +1,149 @@
+import { React, html } from '../runtime.js';
+import { HighlightText, slugify } from '../utils.js';
+import { useNavigation } from '../NavigationContext.js';
+
+const createSnippet = (content, query) => {
+  if (!content) return '';
+  const normalizedContent = content.replace(/\n+/g, ' ');
+  const lowerContent = normalizedContent.toLowerCase();
+  const lowerQuery = query.toLowerCase();
+  const index = lowerContent.indexOf(lowerQuery);
+
+  if (index === -1) {
+    return normalizedContent.slice(0, 160);
+  }
+
+  const start = Math.max(0, index - 60);
+  const end = Math.min(normalizedContent.length, index + lowerQuery.length + 90);
+  const prefix = start > 0 ? '…' : '';
+  const suffix = end < normalizedContent.length ? '…' : '';
+
+  return `${prefix}${normalizedContent.slice(start, end)}${suffix}`;
+};
+
+const buildSearchResults = (chapters, query) => {
+  if (!query.trim()) return [];
+  const lowerQuery = query.toLowerCase();
+
+  return chapters
+    .map((chapter) => {
+      const results = [];
+      const chapterMatches =
+        chapter.cleanTitle.toLowerCase().includes(lowerQuery) ||
+        (chapter.subtitle && chapter.subtitle.toLowerCase().includes(lowerQuery)) ||
+        (chapter.keypoints || []).some((point) => point.toLowerCase().includes(lowerQuery));
+
+      if (chapterMatches) {
+        results.push({
+          type: 'chapter',
+          id: chapter.url,
+          emoji: chapter.originalEmoji,
+          title: chapter.cleanTitle,
+          subtitle: chapter.subtitle
+        });
+      }
+
+      chapter.processedSubchapters.forEach((sub) => {
+        if (
+          sub.cleanTitle.toLowerCase().includes(lowerQuery) ||
+          sub.content.toLowerCase().includes(lowerQuery)
+        ) {
+          results.push({
+            type: 'subchapter',
+            id: slugify(sub.cleanTitle),
+            emoji: sub.originalEmoji,
+            title: sub.cleanTitle,
+            chapterTitle: chapter.cleanTitle,
+            snippet: createSnippet(sub.content, query)
+          });
+        }
+      });
+
+      return results;
+    })
+    .flat();
+};
+
+const SearchResultsModal = ({ chapters, isOpen, onHide, onClear, onNavigate }) => {
+  const { debouncedSearchQuery, searchQuery, setActiveId } = useNavigation();
+
+  if (!isOpen || !debouncedSearchQuery.trim()) return null;
+
+  const results = buildSearchResults(chapters, debouncedSearchQuery);
+
+  const handleNavigate = (id) => {
+    setActiveId(id);
+    if (typeof onNavigate === 'function') {
+      onNavigate();
+    }
+    const element = document.getElementById(id);
+    if (element) {
+      element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  };
+
+  return html`<div className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm overflow-y-auto p-4 sm:p-6">
+    <div className="max-w-4xl mx-auto bg-white border-4 border-black brutal-shadow no-round"> 
+      <div className="p-4 sm:p-6 flex flex-col gap-4">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <div>
+            <div className="text-[11px] font-heading uppercase tracking-[0.3em] text-black">Ricerca</div>
+            <h3 className="text-2xl font-heading font-black leading-tight">Risultati per “${searchQuery}”</h3>
+            <p className="text-sm text-black/70 max-w-2xl">Apri il risultato per scorrere alla card corrispondente. I testi coincidono con l’evidenziazione già visibile nelle schede.</p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <button
+              onClick=${onHide}
+              className="px-3 py-2 border-3 border-black bg-white font-heading text-[11px] uppercase tracking-[0.2em] brutal-shadow hover:-translate-y-0.5 transition-transform"
+            >
+              Nascondi
+            </button>
+            <button
+              onClick=${onClear}
+              className="px-3 py-2 border-3 border-black bg-[var(--ff-yellow)] font-heading text-[11px] uppercase tracking-[0.2em] brutal-shadow hover:-translate-y-0.5 transition-transform"
+            >
+              Azzera ricerca
+            </button>
+          </div>
+        </div>
+
+        ${results.length === 0
+          ? html`<div className="border-3 border-black p-6 text-center brutal-shadow bg-white">
+              <p className="font-heading text-base">Nessun contenuto corrisponde alla ricerca.</p>
+            </div>`
+          : html`<ol className="space-y-3">
+              ${results.map(
+                (item, idx) => html`<li key=${idx}>
+                  <button
+                    className="w-full text-left border-3 border-black bg-white brutal-shadow p-4 sm:p-5 hover:-translate-y-1 transition-transform"
+                    onClick=${() => handleNavigate(item.id)}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="flex items-start gap-2">
+                        <span className="text-lg leading-none">${item.emoji}</span>
+                        <div>
+                          <div className="font-heading font-bold text-base sm:text-lg text-black">
+                            <${HighlightText} text=${item.title} highlight=${debouncedSearchQuery} />
+                          </div>
+                          <div className="text-[11px] uppercase tracking-[0.2em] text-black/70">${item.type === 'chapter'
+                            ? 'Capitolo'
+                            : `Sottocapitolo · ${item.chapterTitle}`}</div>
+                        </div>
+                      </div>
+                      <span className="text-xs font-heading px-2 py-1 border-2 border-black bg-white">Apri</span>
+                    </div>
+                    ${item.snippet
+                      ? html`<p className="mt-3 text-sm text-black/80 leading-snug">
+                          <${HighlightText} text=${item.snippet} highlight=${debouncedSearchQuery} />
+                        </p>`
+                      : null}
+                  </button>
+                </li>`
+              )}
+            </ol>`}
+      </div>
+    </div>
+  </div>`;
+};
+
+export default SearchResultsModal;

--- a/components/SupportPopup.js
+++ b/components/SupportPopup.js
@@ -24,63 +24,36 @@ const SupportPopup = () => {
         <div className="relative space-y-5">
           <div className="flex justify-between items-start gap-4">
             <div>
-              <div className="text-[11px] font-heading uppercase tracking-[0.3em] text-black mb-2">Support Futuro Fortissimo</div>
-              <h3 className="text-3xl font-heading font-black text-black leading-tight">Pop up powered like micmer</h3>
-              <p className="text-black mt-2 text-sm md:text-base max-w-xl">Se ti piace l’archivio, regalagli energia. Ho preso in prestito il mood di micmer.giT per festeggiare ogni ff.x.y: scegli PayPal o passa dal sito per scoprire di più.</p>
+              <div className="text-[11px] font-heading uppercase tracking-[0.3em] text-black mb-2">Supporto</div>
+              <h3 className="text-3xl font-heading font-black text-black leading-tight">Sostieni Futuro Fortissimo</h3>
+              <p className="text-black mt-2 text-sm md:text-base max-w-xl">Se ti piace l’archivio, puoi dargli energia con un contributo via PayPal. Ogni gesto aiuta a mantenere aggiornate le storie e i media.</p>
             </div>
             <button onClick=${closeSupportPopup} className="h-12 w-12 border-3 border-black bg-white brutal-shadow hover:-translate-y-1 transition-transform">✕</button>
           </div>
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <a
-              href="https://www.paypal.com/paypalme/MicheleMerelli"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="relative overflow-hidden border-3 border-black bg-white p-4 flex flex-col gap-3 brutal-shadow hover:-translate-y-1 transition-transform no-round"
-            >
-              <div className="absolute inset-0 bg-blue-50 opacity-70"></div>
-              <div className="relative flex items-center gap-3">
-                <span className="text-3xl">💙</span>
-                <div>
-                  <div className="font-heading font-black text-black text-lg">PayPal pop</div>
-                  <p className="text-xs text-black/80">Il modo più rapido per mandare un grazie.</p>
-                </div>
+          <a
+            href="https://www.paypal.com/paypalme/MicheleMerelli"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="relative overflow-hidden border-3 border-black bg-white p-5 flex flex-col gap-3 brutal-shadow hover:-translate-y-1 transition-transform no-round"
+          >
+            <div className="absolute inset-0 bg-blue-50 opacity-70"></div>
+            <div className="relative flex items-center gap-3">
+              <span className="text-3xl">💙</span>
+              <div>
+                <div className="font-heading font-black text-black text-lg">PayPal</div>
+                <p className="text-sm text-black/80">Il modo più rapido per mandare un grazie e supportare l’archivio.</p>
               </div>
-              <div className="relative mt-auto text-sm font-heading uppercase tracking-[0.2em] text-black">paypal.me/MicheleMerelli</div>
-            </a>
-
-            <a
-              href="https://micmer-git.github.io/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="relative overflow-hidden border-3 border-black bg-white p-4 flex flex-col gap-3 brutal-shadow hover:-translate-y-1 transition-transform no-round"
-            >
-              <div className="absolute inset-0 bg-yellow-100 opacity-70"></div>
-              <div className="relative flex items-center gap-3">
-                <span className="text-3xl">🟦</span>
-                <div>
-                  <div className="font-heading font-black text-black text-lg">micmer.giT</div>
-                  <p className="text-xs text-black/80">Visita il sito gemello per vibrazioni extra.</p>
-                </div>
-              </div>
-              <div className="relative mt-auto text-sm font-heading uppercase tracking-[0.2em] text-black">stile pop-up, griglia, blocky</div>
-            </a>
-          </div>
+            </div>
+            <div className="relative mt-auto text-sm font-heading uppercase tracking-[0.2em] text-black">paypal.me/MicheleMerelli</div>
+          </a>
 
           <div className="flex flex-wrap gap-3">
-            <a
-              href="https://www.buymeacoffee.com/michelemerelli"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex-1 min-w-[140px] text-center bg-black text-white py-3 font-heading font-bold uppercase tracking-[0.25em] brutal-shadow hover:-translate-y-1 transition-transform"
-            >
-              Coffee boost
-            </a>
             <button
               onClick=${closeSupportPopup}
-              className="px-5 py-3 border-3 border-black text-black bg-white brutal-shadow hover:-translate-y-1 transition-transform font-heading font-semibold"
+              className="flex-1 min-w-[140px] px-5 py-3 border-3 border-black text-black bg-white brutal-shadow hover:-translate-y-1 transition-transform font-heading font-semibold"
             >
-              Più tardi
+              Chiudi
             </button>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -56,6 +56,14 @@
         padding: 24px;
       }
 
+      @media (max-width: 640px) {
+        .mobile-unboxed {
+          border-width: 2px;
+          box-shadow: none;
+          padding: 16px;
+        }
+      }
+
       .border-3 {
         border-width: 3px !important;
       }


### PR DESCRIPTION
## Summary
- focus the Supporto entry point on PayPal and simplify the hero copy
- add a search results modal that highlights matches across chapters and subchapters
- speed up search highlighting and soften brutal card styling on small screens

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933c081e9288320bcff5e9800c7b76b)