### PR TITLE
Refine filters, media modal, and mobile typography

### DIFF
--- a/App.js
+++ b/App.js
@@ -107,20 +107,17 @@ const InnerApp = () => {
             href="https://www.paypal.com/paypalme/MicheleMerelli"
             target="_blank"
             rel="noopener noreferrer"
+            aria-label="Supporto PayPal"
             className="px-4 py-3 border-3 border-black bg-[var(--ff-blue)] text-black brutal-shadow font-heading text-xs uppercase tracking-[0.2em] hover:-translate-y-1 transition-transform"
           >
-            Supporto PayPal
+            ☕
           </a>
         </div>
       </header>
 
       <section className="brutal-card mobile-unboxed accent-bar accent-yellow no-round">
         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-          <div className="space-y-1">
-            <p className="mono-label text-xs text-black">Cerca nell'archivio</p>
-            <p className="text-sm md:text-base max-w-2xl">Trova capitoli e storie per parola chiave: i risultati compaiono in un pannello dedicato con evidenziazione nei contenuti.</p>
-          </div>
-          <div className="w-full md:w-1/2 flex flex-col gap-3">
+          <div className="w-full md:w-1/2 flex flex-col gap-3 md:ml-auto">
             <div className="relative">
               <input
                 type="text"

--- a/components/ChapterItem.js
+++ b/components/ChapterItem.js
@@ -6,12 +6,12 @@ const ChapterItem = ({ chapter }) => {
     <div className="mb-4 border-b-4 border-black pb-3 flex items-start gap-3">
       <span className="text-2xl select-none leading-none">${chapter.originalEmoji}</span>
       <div>
-        <h2 className="font-heading text-2xl font-bold text-black leading-none">
+        <h2 className="font-heading text-xl md:text-2xl font-bold text-black leading-none">
           <a href=${chapter.url} target="_blank" rel="noopener noreferrer" className="hover:underline decoration-4">
             ${chapter.cleanTitle}
           </a>
         </h2>
-        <p className="text-sm text-black/70 font-medium mt-2">${chapter.subtitle}</p>
+        <p className="text-xs md:text-sm text-black/70 font-medium mt-2">${chapter.subtitle}</p>
       </div>
     </div>
 
@@ -19,7 +19,7 @@ const ChapterItem = ({ chapter }) => {
       ? html`<div className="mb-4">
           <ul className="space-y-2">
             ${chapter.keypoints.map(
-              (point, idx) => html`<li key=${idx} className="text-sm text-black font-medium flex items-start gap-2 leading-snug">
+              (point, idx) => html`<li key=${idx} className="text-xs md:text-sm text-black font-medium flex items-start gap-2 leading-snug">
                   <span className="mt-1 w-2 h-2 bg-black shrink-0"></span>
                   <span>${point}</span>
                 </li>`

--- a/components/MediaSlider.js
+++ b/components/MediaSlider.js
@@ -49,12 +49,12 @@ const MediaSlider = ({ chapters }) => {
   const goToNext = () => setCurrentIndex((prev) => (prev + 1) % mediaItems.length);
   const goToPrev = () => setCurrentIndex((prev) => (prev - 1 + mediaItems.length) % mediaItems.length);
 
-  const overlayLabel = currentItem.caption?.trim() ? currentItem.caption : currentItem.reference;
+  const captionText = currentItem.caption?.trim();
 
   return html`<section className="mb-12 md:mb-16">
     <div className="relative overflow-hidden brutal-card no-round bg-white accent-bar accent-yellow">
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_1px_1px,#000_1px,transparent_0)] [background-size:22px_22px] opacity-10 pointer-events-none"></div>
-      <div className="relative p-6 md:p-8 flex flex-col gap-6">
+      <div className="relative p-5 md:p-8 flex flex-col gap-6">
         <div className="flex items-center justify-between gap-4">
           <h2 className="font-heading font-black text-xl md:text-2xl tracking-tight text-black">Media dall'archivio</h2>
           <div className="flex gap-2">
@@ -64,36 +64,33 @@ const MediaSlider = ({ chapters }) => {
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-[1.1fr_0.9fr] gap-6 md:gap-8 items-center">
-          <div className="overflow-hidden border-4 border-black bg-white brutal-shadow flex items-center justify-center">
-            <div className="relative w-full">
+          <figure className="overflow-hidden border-4 border-black bg-white brutal-shadow flex flex-col">
+            <div className="relative w-full flex items-center justify-center bg-white">
               <img
                 src=${currentItem.src}
-                alt=${currentItem.caption || currentItem.subTitle}
-                className="w-full max-h-[70vh] object-contain bg-white"
+                alt=${captionText || currentItem.subTitle}
+                className="w-full max-h-[60vh] md:max-h-[70vh] object-contain bg-white"
                 loading="lazy"
               />
-              ${overlayLabel
-                ? html`<div className="absolute bottom-3 left-3 right-3 px-3 py-2 border-3 border-black bg-white text-black text-xs font-heading uppercase tracking-[0.12em] brutal-shadow">${overlayLabel}</div>`
-                : null}
             </div>
-          </div>
-
-          <div className="flex flex-col gap-4 bg-white border-4 border-black brutal-shadow p-4 md:p-6">
-            <h3 className="font-heading text-2xl md:text-3xl font-black text-black leading-tight">${currentItem.subTitle}</h3>
-            <p className="text-sm md:text-base text-black/80">${currentItem.chapterTitle}</p>
-            ${currentItem.reference
-              ? html`<span className="px-3 py-1 border-3 border-black bg-yellow-100 text-xs font-heading uppercase tracking-[0.18em] inline-flex w-fit">${currentItem.reference}</span>`
+            ${captionText
+              ? html`<figcaption className="px-4 py-3 border-t-4 border-black bg-white text-xs md:text-sm font-heading uppercase tracking-[0.12em]">${captionText}</figcaption>`
               : null}
-            <div className="flex flex-wrap gap-2 text-sm font-heading uppercase tracking-[0.2em]">
-              <a
-                href=${currentItem.link || currentItem.chapterUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="px-3 py-2 border-3 border-black bg-[var(--ff-blue)] text-black hover:-translate-y-0.5 transition-transform"
-              >
-                Apri sezione
-              </a>
-            </div>
+          </figure>
+
+          <div className="flex flex-col gap-3 bg-white border-4 border-black brutal-shadow p-4 md:p-6">
+            <h3 className="font-heading text-xl md:text-2xl font-black text-black leading-tight">${currentItem.subTitle}</h3>
+            <p className="text-xs md:text-sm text-black/80">${currentItem.chapterTitle}</p>
+            ${captionText && currentItem.reference
+              ? html`<a
+                  href=${currentItem.link || currentItem.chapterUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="px-3 py-1 border-3 border-black bg-yellow-100 text-[10px] md:text-xs font-heading uppercase tracking-[0.18em] inline-flex w-fit hover:-translate-y-0.5 transition-transform"
+                >
+                  ${currentItem.reference}
+                </a>`
+              : null}
           </div>
         </div>
       </div>

--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -2,14 +2,21 @@ import { React, html } from '../runtime.js';
 import { TopicEmoji } from '../types.js';
 
 const Sidebar = ({ selectedEmoji, onSelect, vertical = true }) => {
-  const topics = Object.entries(TopicEmoji);
+  const prioritizedKeys = ['NATURE', 'TECH', 'WELLNESS'];
+  const topicsMap = Object.entries(TopicEmoji).filter(([key]) => key !== 'UNKNOWN');
+
+  const prioritizedTopics = prioritizedKeys
+    .map((key) => topicsMap.find(([candidate]) => candidate === key))
+    .filter(Boolean);
+  const remainingTopics = topicsMap.filter(([key]) => !prioritizedKeys.includes(key));
+  const topics = [...prioritizedTopics, ...remainingTopics];
 
   const containerClasses = vertical
     ? 'flex-col items-center gap-3'
     : 'flex-row flex-wrap items-center gap-3 px-2 justify-center';
 
   const itemClasses =
-    'w-12 h-12 flex-shrink-0 flex items-center justify-center border-3 border-black bg-white text-black font-heading text-lg transition-all duration-150 shadow-[6px_6px_0_#000] hover:-translate-y-0.5';
+    'w-12 h-12 flex-shrink-0 flex items-center justify-center border-3 border-black text-black font-heading text-lg transition-all duration-150 shadow-[6px_6px_0_#000] hover:-translate-y-0.5';
 
   return html`<nav className=${`flex ${containerClasses} ${vertical ? 'sticky top-8' : ''}`}>
     <button
@@ -24,22 +31,23 @@ const Sidebar = ({ selectedEmoji, onSelect, vertical = true }) => {
       <span className="text-lg">♾️</span>
     </button>
 
-    ${vertical
-      ? html`<div className="w-px h-6 bg-black"></div>`
-      : html`<div className="h-px w-6 bg-black"></div>`}
+    ${topics.map(([key, emoji], index) => {
+      const palette = ['bg-blue-100', 'bg-green-100', 'bg-red-100'];
+      const backgroundClass = palette[index] || 'bg-white';
 
-    ${topics.map(([key, emoji]) => html`<button
-      key=${key}
-      onClick=${() => onSelect(emoji)}
-      title=${key.toLowerCase()}
-      className=${`${itemClasses} ${
-        selectedEmoji === emoji
-          ? 'bg-yellow-300 text-black scale-105'
-          : 'bg-white text-gray-700'
-      }`}
-    >
-      <span className="text-xl leading-none">${emoji}</span>
-    </button>`)}
+      return html`<button
+        key=${key}
+        onClick=${() => onSelect(emoji)}
+        title=${key.toLowerCase()}
+        className=${`${itemClasses} ${backgroundClass} ${
+          selectedEmoji === emoji
+            ? 'scale-105 shadow-[8px_8px_0_#000]'
+            : 'text-gray-700'
+        }`}
+      >
+        <span className="text-xl leading-none">${emoji}</span>
+      </button>`;
+    })}
   </nav>`;
 };
 

--- a/components/SubChapterItem.js
+++ b/components/SubChapterItem.js
@@ -70,7 +70,7 @@ const SubChapterItem = ({ subchapter }) => {
           href=${subchapter.link}
           target="_blank"
           rel="noopener noreferrer"
-          className="font-heading text-xl font-bold text-black mr-2 break-words hover:underline decoration-4"
+          className="font-heading text-lg md:text-xl font-bold text-black mr-2 break-words hover:underline decoration-4"
           onClick=${(e) => {
             e.stopPropagation();
             incrementInteraction();
@@ -131,7 +131,7 @@ const SubChapterItem = ({ subchapter }) => {
                   isCross ? 'bg-blue-100' : 'bg-gray-50'
                 }`}
               >
-                <span className="text-sm font-bold font-heading break-all">
+                <span className="text-xs md:text-sm font-bold font-heading break-all">
                   ${displayText}
                 </span>
                 ${!isCross ? html`<span className="text-black text-xs">↗</span>` : null}
@@ -145,7 +145,7 @@ const SubChapterItem = ({ subchapter }) => {
       isExpanded ? 'grid-rows-[1fr] opacity-100 mt-2 mb-4' : 'grid-rows-[0fr] opacity-0 mt-0 mb-0'
     }`}>
       <div className="overflow-hidden pl-0 md:pl-[2.5rem]">
-        <div className="prose prose-sm max-w-none text-black leading-normal font-medium break-words">
+        <div className="prose prose-sm max-w-none text-black leading-normal font-medium break-words text-[13px] md:text-sm">
           ${subchapter.content
             .split('\n')
             .map((paragraph, idx) => (paragraph.trim() ? html`<p key=${idx} className="mb-2 last:mb-0">

--- a/types.js
+++ b/types.js
@@ -8,7 +8,7 @@ export const TopicEmoji = {
   TRANSPORT: '🚕',
   VR: '🥽',
   SOCIETY: '👥',
-  WELLNESS: '💆',
+  WELLNESS: '❤️',
   TECH: '💻',
   NATURE: '🍃',
   UNKNOWN: '✨'


### PR DESCRIPTION
## Summary
- replace the PayPal button label with a coffee emoji and remove the archive search helper text
- reorder and recolor the topic filters while trimming mobile chapter/subchapter typography
- redesign the media popup so captions sit beneath images and the reference badge replaces the old action button

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933e9f76eec8320b1b2126dfe234908)