### PR TITLE
Fix books JSON import for module loading

### DIFF
--- a/components/BooksModal.js
+++ b/components/BooksModal.js
@@ -1,6 +1,6 @@
 import { React, html } from '../runtime.js';
 import { TopicEmoji } from '../types.js';
-import booksData from '../books.json';
+import booksData from '../books.json' assert { type: 'json' };
 
 const normalizeUrl = (url = '') => url.replace(/\/$/, '');
 


### PR DESCRIPTION
## Summary
- adjust books modal to load the books JSON file as a proper JSON module

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935ac79dd688320b6a87d424fbb6297)