### PR TITLE
Adjust subchapter styling and remove topic badges

### DIFF
--- a/components/RightSidebar.js
+++ b/components/RightSidebar.js
@@ -80,8 +80,7 @@ const RightSidebar = ({ chapters, isMobileMode = false, onOpenMedia }) => {
                 <div className="flex items-start gap-2">
                   <span className="text-base leading-none mt-0.5">${sub.originalEmoji}</span>
                   <div>
-                    <div className="font-heading text-[13px] font-semibold text-black group-hover:underline break-words">${sub.cleanTitle}</div>
-                    <div className="text-[11px] text-gray-600 font-medium uppercase tracking-widest">${sub.secondaryEmoji}</div>
+                    <div className="font-heading text-[12px] font-semibold text-black group-hover:underline break-words">${sub.cleanTitle}</div>
                   </div>
                 </div>
               </button>`;

--- a/components/SubChapterItem.js
+++ b/components/SubChapterItem.js
@@ -60,7 +60,7 @@ const SubChapterItem = ({ subchapter }) => {
 
   return html`<div id=${id} className="relative pl-0 group mb-6 scroll-mt-32 transition-all duration-300">
     <div
-      className="flex items-baseline gap-2 cursor-pointer bg-white p-3 hover:-translate-y-1 transition-transform brutal-shadow"
+      className="flex items-baseline gap-2 cursor-pointer bg-white p-3 hover:-translate-y-1 transition-transform"
       onClick=${toggleExpand}
     >
       <span className="text-lg opacity-100 shrink-0 self-center leading-none">${subchapter.originalEmoji}</span>
@@ -70,7 +70,7 @@ const SubChapterItem = ({ subchapter }) => {
           href=${subchapter.link}
           target="_blank"
           rel="noopener noreferrer"
-          className="font-heading text-base md:text-lg font-bold text-black mr-2 break-words hover:underline decoration-4"
+          className="font-heading text-sm md:text-base font-bold text-black mr-2 break-words hover:underline decoration-4"
           onClick=${(e) => {
             e.stopPropagation();
             incrementInteraction();
@@ -78,17 +78,6 @@ const SubChapterItem = ({ subchapter }) => {
         >
           <${HighlightText} text=${subchapter.cleanTitle} highlight=${debouncedSearchQuery} />
         </a>
-
-        <span
-          className="inline-flex items-center justify-center w-5 h-5 border-2 border-black bg-yellow-200 text-[10px] align-middle"
-          title=${`Topic: ${subchapter.secondaryEmoji}`}
-          onClick=${(e) => {
-            e.stopPropagation();
-            incrementInteraction();
-          }}
-        >
-          ${subchapter.secondaryEmoji}
-        </span>
       </div>
 
       <button
@@ -159,7 +148,7 @@ const SubChapterItem = ({ subchapter }) => {
       isExpanded ? 'grid-rows-[1fr] opacity-100 mt-2 mb-4' : 'grid-rows-[0fr] opacity-0 mt-0 mb-0'
     }`}>
       <div className="overflow-hidden pl-0 md:pl-[2.5rem]">
-        <div className="prose prose-sm max-w-none text-black leading-relaxed font-medium break-words text-[13px] md:text-[14px]">
+        <div className="prose prose-sm max-w-none text-black leading-relaxed font-medium break-words text-[12px] md:text-[13px]">
           ${subchapter.content
             .split('\n')
             .map((paragraph, idx) => (paragraph.trim() ? html`<p key=${idx} className="mb-2 last:mb-0">


### PR DESCRIPTION
## Summary
- remove the topic emoji badges from subchapter entries and the navigation index
- lighten the subchapter presentation by dropping the box shadow and slightly reducing title/body font sizes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693658fc75b48320abcea59cf389ce31)