### PR TITLE
Refresh header background and archive filter placement

### DIFF
--- a/App.js
+++ b/App.js
@@ -15,21 +15,7 @@ const titleImageDataUri =
   'data:image/svg+xml;utf8,' +
   encodeURIComponent(`
     <svg width="740" height="160" viewBox="0 0 740 160" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Futuro Fortissimo">
-      <defs>
-        <linearGradient id="titleHue" x1="0%" x2="100%" y1="0%" y2="100%">
-          <stop offset="0%" stop-color="#4a90e2"/>
-          <stop offset="35%" stop-color="#f5a623"/>
-          <stop offset="70%" stop-color="#d0021b"/>
-          <stop offset="100%" stop-color="#2ecc71"/>
-        </linearGradient>
-        <pattern id="grid" width="24" height="24" patternUnits="userSpaceOnUse">
-          <path d="M24 0H0V24" fill="none" stroke="rgba(0,0,0,0.08)" stroke-width="1"/>
-        </pattern>
-      </defs>
-      <rect x="10" y="10" width="720" height="140" fill="white" stroke="#0a0a0a" stroke-width="10" rx="16" ry="16"/>
-      <rect x="22" y="22" width="696" height="116" fill="url(#grid)" rx="10" ry="10"/>
-      <rect x="22" y="22" width="696" height="116" fill="url(#titleHue)" opacity="0.18" rx="10" ry="10"/>
-      <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="'IBM Plex Mono','Inter',monospace" font-size="48" font-weight="700" letter-spacing="3" fill="#0a0a0a">
+      <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="'IBM Plex Mono','Inter',monospace" font-size="56" font-weight="700" letter-spacing="3.5" fill="#0a0a0a">
         Futuro Fortissimo
       </text>
     </svg>
@@ -40,17 +26,21 @@ const headerBackgroundDataUri =
   encodeURIComponent(`
     <svg width="1200" height="600" viewBox="0 0 1200 600" xmlns="http://www.w3.org/2000/svg">
       <defs>
-        <linearGradient id="backgroundHue" x1="0%" y1="0%" x2="100%" y2="0%">
-          <stop offset="0%" stop-color="#4a90e2" stop-opacity="0.14"/>
-          <stop offset="50%" stop-color="#f5a623" stop-opacity="0.18"/>
-          <stop offset="100%" stop-color="#2ecc71" stop-opacity="0.14"/>
+        <pattern id="headerGrid" width="26" height="26" patternUnits="userSpaceOnUse">
+          <rect width="26" height="26" fill="#ffffff"/>
+          <path d="M26 0H0V26" fill="none" stroke="rgba(0,0,0,0.08)" stroke-width="1"/>
+        </pattern>
+        <linearGradient id="bottomHue" x1="0%" y1="0%" x2="100%" y2="0%">
+          <stop offset="0%" stop-color="#c8e6ff" stop-opacity="0.7"/>
+          <stop offset="100%" stop-color="#ffd6ec" stop-opacity="0.7"/>
         </linearGradient>
       </defs>
-      <rect width="1200" height="600" fill="url(#backgroundHue)"/>
-      <circle cx="180" cy="160" r="90" fill="#4a90e2" fill-opacity="0.1"/>
-      <circle cx="620" cy="120" r="140" fill="#d0021b" fill-opacity="0.08"/>
-      <circle cx="980" cy="320" r="160" fill="#f5a623" fill-opacity="0.09"/>
-      <circle cx="420" cy="380" r="120" fill="#2ecc71" fill-opacity="0.08"/>
+      <rect width="1200" height="360" fill="url(#headerGrid)"/>
+      <rect y="360" width="1200" height="240" fill="url(#bottomHue)"/>
+      <circle cx="240" cy="220" r="110" fill="#c8e6ff" fill-opacity="0.35"/>
+      <circle cx="820" cy="160" r="140" fill="#ffd6ec" fill-opacity="0.3"/>
+      <circle cx="620" cy="440" r="170" fill="#c8e6ff" fill-opacity="0.25"/>
+      <circle cx="1040" cy="420" r="120" fill="#ffd6ec" fill-opacity="0.2"/>
     </svg>
   `);
 
@@ -275,7 +265,7 @@ const InnerApp = () => {
             src=${titleImageDataUri}
             alt="Futuro Fortissimo"
             loading="lazy"
-            className="w-full max-w-[580px] brutal-shadow border-3 border-black bg-white"
+            className="w-full max-w-[580px]"
           />
         </div>
         <div className="flex flex-wrap gap-3">
@@ -375,8 +365,19 @@ const InnerApp = () => {
 
           <div className="flex-1 space-y-6" onTouchStart=${handleTouchStart} onTouchEnd=${handleTouchEnd}>
             <div className="border-3 border-black p-3 bg-white flex flex-col gap-3 md:flex-row md:items-center md:justify-between sticky top-4 z-10">
-              <div className="flex items-center gap-3">
+              <div className="flex items-center gap-2 flex-wrap">
                 <div className="font-heading text-sm">Archivio</div>
+                <span aria-hidden="true" className="text-black/60">
+                  ·
+                </span>
+                ${selectedEmoji
+                  ? html`<button
+                      className="font-heading text-xs uppercase tracking-[0.2em] border-3 border-black px-3 py-2 bg-[var(--ff-yellow)] brutal-shadow"
+                      onClick=${() => handleTopicSelect(null)}
+                    >
+                      Clear ${selectedEmoji}
+                    </button>`
+                  : html`<span className="font-heading text-xs uppercase tracking-[0.2em]">Tutti i temi</span>`}
               </div>
 
               <div className="flex items-center gap-3 flex-wrap justify-end">
@@ -398,15 +399,6 @@ const InnerApp = () => {
                       </button>
                     </div>`
                   : null}
-
-                ${selectedEmoji
-                  ? html`<button
-                      className="font-heading text-xs uppercase tracking-[0.2em] border-3 border-black px-3 py-2 bg-[var(--ff-yellow)] brutal-shadow"
-                      onClick=${() => handleTopicSelect(null)}
-                    >
-                      Clear ${selectedEmoji}
-                    </button>`
-                  : html`<span className="font-heading text-xs uppercase tracking-[0.2em]">Tutti i temi</span>`}
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
- remove the boxed treatment on the title artwork and shift the color hue into the header background with a new split grid/gradient
- place the archive filter indicator beside the Archivio label with a dot separator for clearer context

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69366039fec883209e8a19ffb29b69a9)