### PR TITLE
Refine chapter navigation and styling

### DIFF
--- a/App.js
+++ b/App.js
@@ -419,13 +419,13 @@ const InnerApp = () => {
           </div>
 
           <div id="indice" className="hidden lg:block border-3 border-black bg-white p-4 sticky top-6">
-            <${RightSidebar} chapters=${filteredData} onOpenMedia=${handleOpenMedia} />
+            <${RightSidebar} chapters=${filteredData} />
           </div>
         </div>
       </section>
 
       <div className="lg:hidden brutal-card mobile-unboxed no-round">
-        <${RightSidebar} chapters=${filteredData} isMobileMode=${true} onOpenMedia=${handleOpenMedia} />
+        <${RightSidebar} chapters=${filteredData} isMobileMode=${true} />
       </div>
     </div>
 

--- a/components/ChapterItem.js
+++ b/components/ChapterItem.js
@@ -11,7 +11,7 @@ const ChapterItem = ({ chapter }) => {
             ${chapter.cleanTitle}
           </a>
         </h2>
-        <p className="inline-block bg-[var(--ff-yellow)] px-2 py-1 text-xs md:text-sm text-black font-semibold mt-2">
+        <p className="inline-block bg-[var(--ff-yellow)] px-2 py-1 text-[11px] md:text-sm text-black font-heading uppercase tracking-[0.18em] mt-2">
           ${chapter.subtitle}
         </p>
       </div>
@@ -32,7 +32,7 @@ const ChapterItem = ({ chapter }) => {
 
     <div className="space-y-2">
       ${chapter.processedSubchapters.map(
-        (sub, idx) => html`<${SubChapterItem} key=${idx} subchapter=${sub} />`
+        (sub, idx) => html`<${SubChapterItem} key=${idx} subchapter=${sub} parentId=${chapter.url} />`
       )}
     </div>
   </article>`;

--- a/components/RightSidebar.js
+++ b/components/RightSidebar.js
@@ -2,7 +2,7 @@ import { React, html } from '../runtime.js';
 import { slugify } from '../utils.js';
 import { useNavigation } from '../NavigationContext.js';
 
-const RightSidebar = ({ chapters, isMobileMode = false, onOpenMedia }) => {
+const RightSidebar = ({ chapters, isMobileMode = false }) => {
   const { searchQuery, debouncedSearchQuery, setActiveId, incrementInteraction, setIsMobileMenuOpen } = useNavigation();
 
   const handleItemClick = (id) => {
@@ -37,20 +37,8 @@ const RightSidebar = ({ chapters, isMobileMode = false, onOpenMedia }) => {
   }).filter(Boolean);
 
   return html`<div className="space-y-4">
-    <div className="flex items-center justify-between gap-2">
-      <div className="font-heading text-[11px] uppercase tracking-[0.18em] text-black">
-        ${searchQuery ? `Risultati per “${searchQuery}”` : 'Naviga tra i capitoli'}
-      </div>
-      ${onOpenMedia
-        ? html`<button
-            type="button"
-            onClick=${() => onOpenMedia()}
-            className="px-3 py-1 border-2 border-black bg-white font-heading text-[11px] uppercase tracking-[0.18em] hover:-translate-y-0.5 transition-transform"
-            aria-label="Apri media"
-          >
-            Media
-          </button>`
-        : null}
+    <div className="font-heading text-[11px] uppercase tracking-[0.18em] text-black">
+      ${searchQuery ? `Risultati per “${searchQuery}”` : 'Naviga tra i capitoli'}
     </div>
 
     <div className="max-h-[70vh] overflow-y-auto pr-1 space-y-6 no-scrollbar">

--- a/components/SubChapterItem.js
+++ b/components/SubChapterItem.js
@@ -26,7 +26,7 @@ const isValidLink = (text, url) => {
 const isCrossReference = (text) => text.toLowerCase().includes('ff.');
 const capitalizeFirstLetter = (string) => string.charAt(0).toUpperCase() + string.slice(1);
 
-const SubChapterItem = ({ subchapter }) => {
+const SubChapterItem = ({ subchapter, parentId }) => {
   const [isExpanded, setIsExpanded] = React.useState(false);
   const { debouncedSearchQuery, activeId, incrementInteraction } = useNavigation();
   const id = slugify(subchapter.cleanTitle);
@@ -38,10 +38,10 @@ const SubChapterItem = ({ subchapter }) => {
   };
 
   React.useEffect(() => {
-    if (activeId === id) {
+    if (activeId === id || activeId === parentId) {
       setIsExpanded(true);
     }
-  }, [activeId, id]);
+  }, [activeId, id, parentId]);
 
   React.useEffect(() => {
     if (debouncedSearchQuery) {
@@ -100,14 +100,18 @@ const SubChapterItem = ({ subchapter }) => {
       </button>
     </div>
 
-    ${validLinks.length > 0
-      ? html`<div className="pl-0 md:pl-[2.5rem] mt-2 mb-3">
-          <div className="flex flex-wrap gap-2">
-            ${validLinks.map((ref, idx) => {
-              const isCross = isCrossReference(ref.text);
-              const displayText = isCross ? ref.text : capitalizeFirstLetter(ref.text);
+    <div className=${`grid transition-all duration-500 ease-in-out ${
+      isExpanded ? 'grid-rows-[1fr] opacity-100 mt-2 mb-4' : 'grid-rows-[0fr] opacity-0 mt-0 mb-0'
+    }`}>
+      <div className="overflow-hidden pl-0 md:pl-[2.5rem]">
+        ${validLinks.length > 0 && isExpanded
+          ? html`<div className="mb-3 flex flex-col gap-2">
+              ${validLinks.map((ref, idx) => {
+                const isCross = isCrossReference(ref.text);
+                const displayText = isCross ? ref.text : capitalizeFirstLetter(ref.text);
+                const linkClasses =
+                  'inline-flex items-center gap-1 bg-[var(--ff-yellow)] text-[11px] font-heading uppercase tracking-[0.18em] px-2 py-1 text-black w-fit hover:underline decoration-2';
 
-              if (isCross) {
                 return html`<a
                   key=${idx}
                   href=${ref.url}
@@ -117,37 +121,14 @@ const SubChapterItem = ({ subchapter }) => {
                     e.stopPropagation();
                     incrementInteraction();
                   }}
-                  className="text-sm md:text-base font-heading underline decoration-2 text-black"
+                  className=${linkClasses}
                 >
-                  ${displayText}
+                  <span className="break-words">${displayText}</span>
+                  ${isCross ? null : html`<span aria-hidden="true" className="text-[10px]">↗</span>`}
                 </a>`;
-              }
-
-              return html`<a
-                key=${idx}
-                href=${ref.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick=${(e) => {
-                  e.stopPropagation();
-                  incrementInteraction();
-                }}
-                className="inline-flex items-center gap-1.5 px-3 py-1 border-2 border-black bg-white text-black hover:-translate-y-0.5 transition-transform bg-gray-50"
-              >
-                <span className="text-xs md:text-sm font-bold font-heading break-all">
-                  ${displayText}
-                </span>
-                <span className="text-black text-xs">↗</span>
-              </a>`;
-            })}
-          </div>
-        </div>`
-      : null}
-
-    <div className=${`grid transition-all duration-500 ease-in-out ${
-      isExpanded ? 'grid-rows-[1fr] opacity-100 mt-2 mb-4' : 'grid-rows-[0fr] opacity-0 mt-0 mb-0'
-    }`}>
-      <div className="overflow-hidden pl-0 md:pl-[2.5rem]">
+              })}
+            </div>`
+          : null}
         <div className="prose prose-sm max-w-none text-black leading-relaxed font-medium break-words text-[12px] md:text-[13px]">
           ${subchapter.content
             .split('\n')


### PR DESCRIPTION
## Summary
- unify heading styling on chapter subtitles
- hide subchapter references until expanded and restyle them as highlighted subtitles
- update index navigation to open chapters when clicked and remove the media action

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936bd259a3c8320a6fe6e59c9276210)