### PR TITLE
Improve subchapter summaries and header spacing

### DIFF
--- a/App.js
+++ b/App.js
@@ -14,9 +14,9 @@ import { NavigationProvider, useNavigation } from './NavigationContext.js';
 const titleImageDataUri =
   'data:image/svg+xml;utf8,' +
   encodeURIComponent(`
-    <svg width="740" height="160" viewBox="0 0 740 160" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Futuro Fortissimo">
-      <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="'IBM Plex Mono','Inter',monospace" font-size="56" font-weight="700" letter-spacing="3.5" fill="#0a0a0a">
-        Futuro Fortissimo
+    <svg width="740" height="130" viewBox="0 0 740 130" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="FUTURO FORTISSIMO">
+      <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="'IBM Plex Mono','Inter',monospace" font-size="54" font-weight="700" letter-spacing="3.5" fill="#0a0a0a">
+        FUTURO FORTISSIMO
       </text>
     </svg>
   `);
@@ -250,7 +250,7 @@ const InnerApp = () => {
     />
     <${BooksPopup} isOpen=${isBooksOpen} onClose=${handleCloseBooks} books=${bookSuggestions} />
 
-    <div className="max-w-6xl mx-auto px-4 md:px-8 py-10 space-y-10">
+    <div className="max-w-6xl mx-auto px-4 md:px-8 py-8 space-y-8">
       <header
         className="brutal-card mobile-unboxed accent-bar accent-blue flex flex-col md:flex-row md:items-center justify-between gap-6 no-round"
         style=${{

--- a/components/SubChapterItem.js
+++ b/components/SubChapterItem.js
@@ -58,9 +58,9 @@ const SubChapterItem = ({ subchapter, parentId }) => {
   const allLinks = [...subchapter.references, ...subchapter.connections];
   const validLinks = allLinks.filter((ref) => isValidLink(ref.text, ref.url));
 
-  return html`<div id=${id} className="relative pl-0 group mb-6 scroll-mt-32 transition-all duration-300">
+  return html`<div id=${id} className="relative pl-0 group scroll-mt-32 transition-all duration-300">
     <div
-      className="flex items-baseline gap-2 cursor-pointer bg-white p-3 hover:-translate-y-1 transition-transform"
+      className="flex items-start gap-3 cursor-pointer bg-white p-3 hover:-translate-y-1 transition-transform"
       onClick=${toggleExpand}
     >
       <span className="text-lg opacity-100 shrink-0 self-center leading-none">${subchapter.originalEmoji}</span>
@@ -78,6 +78,11 @@ const SubChapterItem = ({ subchapter, parentId }) => {
         >
           <${HighlightText} text=${subchapter.cleanTitle} highlight=${debouncedSearchQuery} />
         </a>
+        ${subchapter.summary
+          ? html`<p className="mt-1 text-[12px] md:text-[13px] text-gray-700 font-medium leading-snug pr-8">
+              ${subchapter.summary}
+            </p>`
+          : null}
       </div>
 
       <button
@@ -101,7 +106,7 @@ const SubChapterItem = ({ subchapter, parentId }) => {
     </div>
 
     <div className=${`grid transition-all duration-500 ease-in-out ${
-      isExpanded ? 'grid-rows-[1fr] opacity-100 mt-2 mb-4' : 'grid-rows-[0fr] opacity-0 mt-0 mb-0'
+      isExpanded ? 'grid-rows-[1fr] opacity-100 mt-1.5 mb-3' : 'grid-rows-[0fr] opacity-0 mt-0 mb-0'
     }`}>
       <div className="overflow-hidden pl-0 md:pl-[2.5rem]">
         ${validLinks.length > 0 && isExpanded


### PR DESCRIPTION
## Summary
- update the hero title graphic to use uppercase text and tighter surrounding spacing
- add automatic summaries and meaningful default labels for subchapter links
- show the new summaries under each subchapter toggle while reducing excess spacing between items

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936c1343aa0832095af2ed3d8a39eb3)