### PR TITLE
Refocus homepage on index-only navigation with direct links

### DIFF
--- a/components/IndexChapter.js
+++ b/components/IndexChapter.js
@@ -1,0 +1,92 @@
+import { html } from '../runtime.js';
+import { HighlightText, isLinkValid } from '../utils.js';
+
+const collectCitations = (subchapters = []) => {
+  const seen = new Set();
+
+  return subchapters.reduce((acc, sub) => {
+    [...(sub.references || []), ...(sub.connections || [])].forEach((ref) => {
+      if (!isLinkValid(ref.text, ref.url)) return;
+      const key = ref.url || ref.text;
+      if (seen.has(key)) return;
+      seen.add(key);
+      acc.push(ref);
+    });
+    return acc;
+  }, []);
+};
+
+const IndexChapter = ({ chapter, highlight }) => {
+  const citations = collectCitations(chapter.processedSubchapters);
+
+  return html`<article className="border-3 border-black bg-white brutal-shadow p-4 md:p-5 no-round" id=${chapter.url}>
+    <div className="flex items-start gap-3">
+      <span className="text-2xl select-none leading-none">${chapter.primaryEmoji || chapter.originalEmoji}</span>
+      <div className="flex-1">
+        <h2 className="font-heading text-lg md:text-xl font-bold text-black leading-tight">
+          <a href=${chapter.url} target="_blank" rel="noopener noreferrer" className="hover:underline decoration-4">
+            <${HighlightText} text=${chapter.cleanTitle} highlight=${highlight} />
+          </a>
+        </h2>
+        ${chapter.subtitle
+          ? html`<p className="inline-block bg-[var(--ff-yellow)] px-2 py-1 text-[11px] text-black font-heading uppercase tracking-[0.18em] mt-2">
+              <${HighlightText} text=${chapter.subtitle} highlight=${highlight} />
+            </p>`
+          : null}
+        ${chapter.keypoints.length
+          ? html`<ul className="mt-3 space-y-1 list-disc list-inside text-[13px] text-black font-medium">
+              ${chapter.keypoints.map((point, idx) =>
+                html`<li key=${idx} className="leading-snug">
+                  <${HighlightText} text=${point} highlight=${highlight} />
+                </li>`
+              )}
+            </ul>`
+          : null}
+      </div>
+    </div>
+
+    <div className="mt-4 space-y-2">
+      ${chapter.processedSubchapters.map((sub, idx) =>
+        html`<div key=${idx} className="flex gap-2 items-start">
+          <span className="text-base leading-none mt-0.5">${sub.originalEmoji}</span>
+          <div className="flex-1">
+            <a
+              href=${sub.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-heading text-[13px] md:text-sm font-bold text-black hover:underline decoration-2 break-words"
+            >
+              <${HighlightText} text=${sub.cleanTitle} highlight=${highlight} />
+            </a>
+            ${sub.summary
+              ? html`<p className="text-[12px] text-gray-700 leading-snug mt-0.5">
+                  <${HighlightText} text=${sub.summary} highlight=${highlight} />
+                </p>`
+              : null}
+          </div>
+        </div>`
+      )}
+    </div>
+
+    ${citations.length
+      ? html`<div className="mt-4">
+          <div className="text-[11px] font-heading uppercase tracking-[0.18em] text-black mb-2">Link citati</div>
+          <div className="space-y-1">
+            ${citations.map((ref, idx) =>
+              html`<a
+                key=${idx}
+                href=${ref.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block bg-[var(--ff-yellow)] text-[11px] font-heading uppercase tracking-[0.18em] px-2 py-1 text-black hover:underline decoration-2"
+              >
+                <${HighlightText} text=${ref.text} highlight=${highlight} />
+              </a>`
+            )}
+          </div>
+        </div>`
+      : null}
+  </article>`;
+};
+
+export default IndexChapter;

--- a/components/SubChapterItem.js
+++ b/components/SubChapterItem.js
@@ -1,27 +1,6 @@
 import { React, html } from '../runtime.js';
-import { slugify, HighlightText } from '../utils.js';
+import { slugify, HighlightText, isLinkValid } from '../utils.js';
 import { useNavigation } from '../NavigationContext.js';
-
-const isValidLink = (text, url) => {
-  if (!text) return false;
-  const lowerText = text.toLowerCase();
-  const lowerUrl = url.toLowerCase();
-
-  if (lowerText.includes('whatsapp')) return false;
-  if (lowerText.includes('offrimi')) return false;
-  if (lowerText.includes('caffè') || lowerText.includes('caffe')) return false;
-  if (lowerText.includes('micmer')) return false;
-  if (lowerText.includes('iscriviti')) return false;
-  if (lowerText.includes('supportare questo progetto')) return false;
-  if (lowerText.trim() === '☕') return false;
-  if (lowerText.trim() === '❤️') return false;
-  if (lowerText.trim() === '.') return false;
-
-  if (lowerUrl.includes('paypal')) return false;
-  if (lowerUrl.includes('whatsapp')) return false;
-
-  return true;
-};
 
 const isCrossReference = (text) => text.toLowerCase().includes('ff.');
 const capitalizeFirstLetter = (string) => string.charAt(0).toUpperCase() + string.slice(1);
@@ -56,7 +35,7 @@ const SubChapterItem = ({ subchapter, parentId }) => {
   }, [debouncedSearchQuery, subchapter]);
 
   const allLinks = [...subchapter.references, ...subchapter.connections];
-  const validLinks = allLinks.filter((ref) => isValidLink(ref.text, ref.url));
+  const validLinks = allLinks.filter((ref) => isLinkValid(ref.text, ref.url));
 
   return html`<div id=${id} className="relative pl-0 group scroll-mt-32 transition-all duration-300">
     <div

--- a/utils.js
+++ b/utils.js
@@ -44,6 +44,27 @@ export const HighlightText = ({ text, highlight }) => {
   }
 };
 
+export const isLinkValid = (text = '', url = '') => {
+  const lowerText = text.toLowerCase();
+  const lowerUrl = url.toLowerCase();
+
+  if (!text) return false;
+  if (lowerText.includes('whatsapp')) return false;
+  if (lowerText.includes('offrimi')) return false;
+  if (lowerText.includes('caffè') || lowerText.includes('caffe')) return false;
+  if (lowerText.includes('micmer')) return false;
+  if (lowerText.includes('iscriviti')) return false;
+  if (lowerText.includes('supportare questo progetto')) return false;
+  if (lowerText.trim() === '☕') return false;
+  if (lowerText.trim() === '❤️') return false;
+  if (lowerText.trim() === '.') return false;
+
+  if (lowerUrl.includes('paypal')) return false;
+  if (lowerUrl.includes('whatsapp')) return false;
+
+  return true;
+};
+
 const buildLinkLabel = (url, title) => {
   try {
     const { hostname } = new URL(url);


### PR DESCRIPTION
## Summary
- replace the chapter preview layout with an index-focused view filtered by search and topic
- add an index card component that links chapters and subchapters directly to their Substack pages with highlighted subtitles and citations
- centralize link validation logic for reuse across components

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940e478e78c8320a1f27200a466a644)