### PR TITLE
Refine compact index design

### DIFF
--- a/App.js
+++ b/App.js
@@ -14,7 +14,10 @@ const titleImageDataUri =
   'data:image/svg+xml;utf8,' +
   encodeURIComponent(`
     <svg width="740" height="130" viewBox="0 0 740 130" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="FUTURO FORTISSIMO">
-      <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="'IBM Plex Mono','Inter',monospace" font-size="54" font-weight="700" letter-spacing="3.5" fill="#0a0a0a">
+      <style>
+        @import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
+      </style>
+      <text x="50%" y="52%" dominant-baseline="middle" text-anchor="middle" font-family="'Press Start 2P','IBM Plex Mono',monospace" font-size="46" font-weight="700" letter-spacing="3.5" fill="#0a0a0a">
         FUTURO FORTISSIMO
       </text>
     </svg>
@@ -342,7 +345,7 @@ const InnerApp = () => {
         </div>
       </section>
 
-      <section id="indice" className="brutal-card mobile-unboxed no-round">
+      <section id="indice" className="brutal-card mobile-unboxed no-round compact-index">
         <div className="flex flex-col gap-6">
           <div className="flex items-center gap-2 flex-wrap">
             <div className="font-heading text-sm">Indice</div>

--- a/components/IndexChapter.js
+++ b/components/IndexChapter.js
@@ -1,4 +1,4 @@
-import { html } from '../runtime.js';
+import { React, html } from '../runtime.js';
 import { HighlightText, isLinkValid } from '../utils.js';
 
 const collectCitations = (subchapters = []) => {
@@ -18,18 +18,19 @@ const collectCitations = (subchapters = []) => {
 
 const IndexChapter = ({ chapter, highlight }) => {
   const citations = collectCitations(chapter.processedSubchapters);
+  const [showCitations, setShowCitations] = React.useState(false);
 
-  return html`<article className="border-3 border-black bg-white brutal-shadow p-4 md:p-5 no-round" id=${chapter.url}>
+  return html`<article className="border-3 border-black bg-white brutal-shadow p-4 md:p-5 no-round chapter-card" id=${chapter.url}>
     <div className="flex items-start gap-3">
       <span className="text-2xl select-none leading-none">${chapter.primaryEmoji || chapter.originalEmoji}</span>
       <div className="flex-1">
-        <h2 className="font-heading text-lg md:text-xl font-bold text-black leading-tight">
+        <h2 className="font-heading text-lg md:text-xl font-bold text-black leading-tight chapter-title">
           <a href=${chapter.url} target="_blank" rel="noopener noreferrer" className="hover:underline decoration-4">
             <${HighlightText} text=${chapter.cleanTitle} highlight=${highlight} />
           </a>
         </h2>
         ${chapter.subtitle
-          ? html`<p className="inline-block bg-[var(--ff-yellow)] px-2 py-1 text-[11px] text-black font-heading uppercase tracking-[0.18em] mt-2">
+          ? html`<p className="inline-block bg-[var(--ff-yellow)] px-2 py-1 text-[11px] text-black font-heading uppercase tracking-[0.18em] mt-2 sub-title">
               <${HighlightText} text=${chapter.subtitle} highlight=${highlight} />
             </p>`
           : null}
@@ -69,21 +70,31 @@ const IndexChapter = ({ chapter, highlight }) => {
     </div>
 
     ${citations.length
-      ? html`<div className="mt-4">
-          <div className="text-[11px] font-heading uppercase tracking-[0.18em] text-black mb-2">Link citati</div>
-          <div className="space-y-1">
-            ${citations.map((ref, idx) =>
-              html`<a
-                key=${idx}
-                href=${ref.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block bg-[var(--ff-yellow)] text-[11px] font-heading uppercase tracking-[0.18em] px-2 py-1 text-black hover:underline decoration-2"
-              >
-                <${HighlightText} text=${ref.text} highlight=${highlight} />
-              </a>`
-            )}
-          </div>
+      ? html`<div className="mt-4 border-t border-black/10 pt-3">
+          <button
+            type="button"
+            className="links-toggle inline-flex items-center gap-2 border-3 border-black bg-white brutal-shadow font-heading uppercase tracking-[0.18em] px-3 py-2"
+            onClick=${() => setShowCitations((prev) => !prev)}
+            aria-expanded=${showCitations}
+          >
+            ${showCitations ? 'Nascondi link' : `Link citati (${citations.length})`}
+            <span aria-hidden="true">${showCitations ? '▲' : '▼'}</span>
+          </button>
+          ${showCitations
+            ? html`<div className="space-y-1 mt-2">
+                ${citations.map((ref, idx) =>
+                  html`<a
+                    key=${idx}
+                    href=${ref.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="block bg-[var(--ff-yellow)] text-[11px] font-heading uppercase tracking-[0.18em] px-2 py-1 text-black hover:underline decoration-2"
+                  >
+                    <${HighlightText} text=${ref.text} highlight=${highlight} />
+                  </a>`
+                )}
+              </div>`
+            : null}
         </div>`
       : null}
   </article>`;

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@600;700&family=Press+Start+2P&display=swap" rel="stylesheet">
 
     <style>
       :root {
@@ -49,6 +49,11 @@
         text-transform: uppercase;
       }
 
+      .pixel-title {
+        font-family: 'Press Start 2P', 'IBM Plex Mono', monospace;
+        letter-spacing: 0.05em;
+      }
+
       .brutal-card {
         border: 4px solid var(--ff-black);
         background: #ffffff;
@@ -70,6 +75,43 @@
 
       .brutal-shadow {
         box-shadow: 4px 4px 0 var(--ff-black);
+      }
+
+      .compact-index {
+        position: relative;
+      }
+
+      .compact-index::before {
+        content: '';
+        position: absolute;
+        left: -16px;
+        top: 24px;
+        bottom: 24px;
+        width: 5px;
+        background: var(--ff-black);
+      }
+
+      .compact-index .chapter-card {
+        position: relative;
+      }
+
+      .compact-index .chapter-card::before {
+        content: '';
+        position: absolute;
+        left: -12px;
+        top: 12px;
+        bottom: 12px;
+        width: 3px;
+        background: linear-gradient(180deg, var(--ff-blue), var(--ff-yellow));
+      }
+
+      .compact-index .chapter-title {
+        font-size: 15px;
+      }
+
+      .compact-index .sub-title,
+      .compact-index .links-toggle {
+        font-size: 12px;
       }
 
       .accent-bar { position: relative; }


### PR DESCRIPTION
## Summary
- update the title artwork to use a pixel-inspired font
- add compact index styling with side accent lines
- make cited links collapsible to keep the index tidy

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694109574e0083209fa9aa2eb681a984)