### PR TITLE
Refine Futuro Fortissimo layout and search UX

### DIFF
--- a/App.js
+++ b/App.js
@@ -10,19 +10,6 @@ import BooksPopup from './components/BooksPopup.js';
 import { NavigationProvider, useNavigation } from './NavigationContext.js';
 import IndexChapter from './components/IndexChapter.js';
 
-const titleImageDataUri =
-  'data:image/svg+xml;utf8,' +
-  encodeURIComponent(`
-    <svg width="740" height="130" viewBox="0 0 740 130" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="FUTURO FORTISSIMO">
-      <style>
-        @import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
-      </style>
-      <text x="50%" y="52%" dominant-baseline="middle" text-anchor="middle" font-family="'Press Start 2P','IBM Plex Mono',monospace" font-size="46" font-weight="700" letter-spacing="3.5" fill="#0a0a0a">
-        FUTURO FORTISSIMO
-      </text>
-    </svg>
-  `);
-
 const headerBackgroundDataUri =
   'data:image/svg+xml;utf8,' +
   encodeURIComponent(`
@@ -92,6 +79,7 @@ const InnerApp = () => {
   const [isBooksOpen, setIsBooksOpen] = React.useState(false);
   const [isSearchOverlayOpen, setIsSearchOverlayOpen] = React.useState(false);
   const [hasManuallyClosedSearch, setHasManuallyClosedSearch] = React.useState(false);
+  const [isFilterMenuOpen, setIsFilterMenuOpen] = React.useState(false);
   const { incrementInteraction, searchQuery, setSearchQuery, debouncedSearchQuery } = useNavigation();
 
   React.useEffect(() => {
@@ -170,13 +158,7 @@ const InnerApp = () => {
   const handleClearSearch = () => {
     setSearchQuery('');
     setHasManuallyClosedSearch(false);
-  };
-
-  const handleShowSearchOverlay = () => {
-    if (searchQuery.trim()) {
-      setHasManuallyClosedSearch(false);
-      setIsSearchOverlayOpen(true);
-    }
+    setIsSearchOverlayOpen(false);
   };
 
   const handleOpenMedia = () => {
@@ -249,12 +231,10 @@ const InnerApp = () => {
         }}
       >
         <div className="max-w-full w-full md:w-auto flex justify-center md:justify-start">
-          <img
-            src=${titleImageDataUri}
-            alt="Futuro Fortissimo"
-            loading="lazy"
-            className="w-full max-w-[620px]"
-          />
+          <div className="text-center">
+            <p className="text-[11px] font-heading uppercase tracking-[0.3em] text-black/70">Newsletter</p>
+            <h1 className="pixel-title text-2xl md:text-3xl lg:text-4xl leading-tight">FUTURO FORTISSIMO</h1>
+          </div>
         </div>
         <div className="flex flex-wrap gap-3 items-center justify-center md:justify-end w-full md:w-auto">
           <a
@@ -288,10 +268,29 @@ const InnerApp = () => {
                   value=${searchQuery}
                   onInput=${handleSearchChange}
                   placeholder="Cerca storie..."
-                  className="w-full px-4 py-3 pr-12 bg-white border-3 border-black font-heading uppercase tracking-[0.15em] placeholder:text-gray-400 focus:outline-none focus:ring-0"
+                  className="w-full px-4 py-3 pr-20 bg-white border-3 border-black font-heading uppercase tracking-[0.15em] placeholder:text-gray-400 focus:outline-none focus:ring-0"
                   aria-label="Cerca storie"
                 />
-                <span aria-hidden="true" className="absolute right-4 top-1/2 -translate-y-1/2 text-black">🔍</span>
+                <div className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-2">
+                  <button
+                    type="button"
+                    className="text-black text-lg"
+                    aria-label="Apri menu filtri"
+                    onClick=${() => setIsFilterMenuOpen(true)}
+                  >
+                    🔍
+                  </button>
+                  ${searchQuery
+                    ? html`<button
+                        type="button"
+                        className="text-black text-lg"
+                        aria-label="Pulisci ricerca"
+                        onClick=${handleClearSearch}
+                      >
+                        ✕
+                      </button>`
+                    : null}
+                </div>
               </div>
               <div className="flex flex-wrap gap-2 justify-start sm:justify-end">
                 <button
@@ -317,27 +316,6 @@ const InnerApp = () => {
                 </a>
               </div>
             </div>
-            ${searchQuery
-              ? html`<div className="flex flex-wrap gap-2 items-center">
-                  ${!isSearchOverlayOpen
-                    ? html`<button
-                        type="button"
-                        onClick=${handleShowSearchOverlay}
-                        className="px-3 py-2 border-3 border-black bg-white brutal-shadow font-heading text-[11px] uppercase tracking-[0.2em] hover:-translate-y-0.5 transition-transform"
-                      >
-                        Mostra risultati
-                      </button>`
-                    : null}
-                  <button
-                    type="button"
-                    onClick=${handleClearSearch}
-                    className="px-3 py-2 border-3 border-black bg-[var(--ff-yellow)] brutal-shadow font-heading text-[11px] uppercase tracking-[0.2em] hover:-translate-y-0.5 transition-transform"
-                  >
-                    Svuota ricerca
-                  </button>
-                </div>`
-              : null}
-
             <div className="flex justify-center lg:hidden">
               <${Sidebar} selectedEmoji=${selectedEmoji} onSelect=${handleTopicSelect} vertical=${false} />
             </div>
@@ -345,7 +323,7 @@ const InnerApp = () => {
         </div>
       </section>
 
-      <section id="indice" className="brutal-card mobile-unboxed no-round compact-index">
+      <section id="indice" className="compact-index space-y-6">
         <div className="flex flex-col gap-6">
           <div className="flex items-center gap-2 flex-wrap">
             <div className="font-heading text-sm">Indice</div>
@@ -396,6 +374,32 @@ const InnerApp = () => {
               </button>
             </div>
             <${MediaSlider} chapters=${processedData} />
+          </div>
+        </div>`
+      : null}
+
+    ${isFilterMenuOpen
+      ? html`<div className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm flex justify-end lg:hidden">
+          <div className="w-72 max-w-full bg-white border-l-4 border-black p-4 flex flex-col gap-4">
+            <div className="flex items-center justify-between">
+              <div className="font-heading text-xs uppercase tracking-[0.2em]">Filtri</div>
+              <button
+                type="button"
+                aria-label="Chiudi filtri"
+                className="text-lg font-bold"
+                onClick=${() => setIsFilterMenuOpen(false)}
+              >
+                ✕
+              </button>
+            </div>
+            <${Sidebar}
+              selectedEmoji=${selectedEmoji}
+              onSelect=${(emoji) => {
+                handleTopicSelect(emoji);
+                setIsFilterMenuOpen(false);
+              }}
+              vertical=${true}
+            />
           </div>
         </div>`
       : null}

--- a/components/IndexChapter.js
+++ b/components/IndexChapter.js
@@ -20,9 +20,9 @@ const IndexChapter = ({ chapter, highlight }) => {
   const citations = collectCitations(chapter.processedSubchapters);
   const [showCitations, setShowCitations] = React.useState(false);
 
-  return html`<article className="border-3 border-black bg-white brutal-shadow p-4 md:p-5 no-round chapter-card" id=${chapter.url}>
+  return html`<article className="chapter-card border-b border-black/10 pb-5 last:border-b-0" id=${chapter.url}>
     <div className="flex items-start gap-3">
-      <span className="text-2xl select-none leading-none">${chapter.primaryEmoji || chapter.originalEmoji}</span>
+      <span className="text-xl md:text-2xl select-none leading-none">${chapter.primaryEmoji || chapter.originalEmoji}</span>
       <div className="flex-1">
         <h2 className="font-heading text-lg md:text-xl font-bold text-black leading-tight chapter-title">
           <a href=${chapter.url} target="_blank" rel="noopener noreferrer" className="hover:underline decoration-4">
@@ -30,15 +30,16 @@ const IndexChapter = ({ chapter, highlight }) => {
           </a>
         </h2>
         ${chapter.subtitle
-          ? html`<p className="inline-block bg-[var(--ff-yellow)] px-2 py-1 text-[11px] text-black font-heading uppercase tracking-[0.18em] mt-2 sub-title">
+          ? html`<p className="inline-block px-0 py-1 text-[12px] md:text-sm text-black font-heading uppercase tracking-[0.18em] mt-2 sub-title">
               <${HighlightText} text=${chapter.subtitle} highlight=${highlight} />
             </p>`
           : null}
         ${chapter.keypoints.length
-          ? html`<ul className="mt-3 space-y-1 list-disc list-inside text-[13px] text-black font-medium">
+          ? html`<ul className="mt-2 space-y-1 text-sm md:text-[15px] text-black font-medium">
               ${chapter.keypoints.map((point, idx) =>
-                html`<li key=${idx} className="leading-snug">
-                  <${HighlightText} text=${point} highlight=${highlight} />
+                html`<li key=${idx} className="leading-snug flex gap-2 items-start">
+                  <span className="text-base leading-none mt-0.5">•</span>
+                  <span><${HighlightText} text=${point} highlight=${highlight} /></span>
                 </li>`
               )}
             </ul>`
@@ -49,18 +50,18 @@ const IndexChapter = ({ chapter, highlight }) => {
     <div className="mt-4 space-y-2">
       ${chapter.processedSubchapters.map((sub, idx) =>
         html`<div key=${idx} className="flex gap-2 items-start">
-          <span className="text-base leading-none mt-0.5">${sub.originalEmoji}</span>
+          <span className="text-xl leading-none mt-0.5">${sub.originalEmoji}</span>
           <div className="flex-1">
             <a
               href=${sub.link}
               target="_blank"
               rel="noopener noreferrer"
-              className="font-heading text-[13px] md:text-sm font-bold text-black hover:underline decoration-2 break-words"
+              className="font-heading text-sm md:text-base font-bold text-black hover:underline decoration-2 break-words"
             >
               <${HighlightText} text=${sub.cleanTitle} highlight=${highlight} />
             </a>
             ${sub.summary
-              ? html`<p className="text-[12px] text-gray-700 leading-snug mt-0.5">
+              ? html`<p className="text-[13px] text-gray-700 leading-snug mt-0.5">
                   <${HighlightText} text=${sub.summary} highlight=${highlight} />
                 </p>`
               : null}

--- a/components/SearchResultsModal.js
+++ b/components/SearchResultsModal.js
@@ -82,27 +82,31 @@ const SearchResultsModal = ({ chapters, isOpen, onHide, onClear, onNavigate }) =
     }
   };
 
+  const handleClose = () => {
+    if (typeof onClear === 'function') {
+      onClear();
+    }
+    if (typeof onHide === 'function') {
+      onHide();
+    }
+  };
+
   return html`<div className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm overflow-y-auto p-4 sm:p-6">
-    <div className="max-w-4xl mx-auto bg-white border-4 border-black brutal-shadow no-round"> 
+    <div className="max-w-4xl mx-auto bg-white border-4 border-black brutal-shadow no-round">
       <div className="p-4 sm:p-6 flex flex-col gap-4">
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-          <div>
-            <div className="text-[11px] font-heading uppercase tracking-[0.3em] text-black">Ricerca</div>
-            <h3 className="text-2xl font-heading font-black leading-tight">Risultati per “${searchQuery}”</h3>
-            <p className="text-sm text-black/70 max-w-2xl">Apri il risultato per scorrere alla card corrispondente. I testi coincidono con l’evidenziazione già visibile nelle schede.</p>
-          </div>
-          <div className="flex flex-wrap gap-2">
+        <div className="flex flex-col gap-3">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <div className="text-[11px] font-heading uppercase tracking-[0.3em] text-black">Ricerca</div>
+              <h3 className="text-2xl font-heading font-black leading-tight">Risultati per “${searchQuery}”</h3>
+              <p className="text-sm text-black/70 max-w-2xl">Apri il risultato per scorrere alla card corrispondente. I testi coincidono con l’evidenziazione già visibile nelle schede.</p>
+            </div>
             <button
-              onClick=${onHide}
+              onClick=${handleClose}
               className="px-3 py-2 border-3 border-black bg-white font-heading text-[11px] uppercase tracking-[0.2em] brutal-shadow hover:-translate-y-0.5 transition-transform"
+              aria-label="Chiudi e cancella ricerca"
             >
-              Nascondi
-            </button>
-            <button
-              onClick=${onClear}
-              className="px-3 py-2 border-3 border-black bg-[var(--ff-yellow)] font-heading text-[11px] uppercase tracking-[0.2em] brutal-shadow hover:-translate-y-0.5 transition-transform"
-            >
-              Azzera ricerca
+              ✕
             </button>
           </div>
         </div>

--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -13,7 +13,7 @@ const Sidebar = ({ selectedEmoji, onSelect, vertical = true }) => {
 
   const containerClasses = vertical
     ? 'flex-col items-center gap-3'
-    : 'flex-row flex-wrap items-center gap-3 px-2 justify-center';
+    : 'flex-row items-center gap-3 px-2 justify-start overflow-x-auto whitespace-nowrap no-scrollbar';
 
   const itemClasses =
     'w-12 h-12 flex-shrink-0 flex items-center justify-center border-3 border-black text-black font-heading text-lg transition-all duration-150 shadow-[6px_6px_0_#000] hover:-translate-y-0.5';

--- a/index.html
+++ b/index.html
@@ -77,34 +77,6 @@
         box-shadow: 4px 4px 0 var(--ff-black);
       }
 
-      .compact-index {
-        position: relative;
-      }
-
-      .compact-index::before {
-        content: '';
-        position: absolute;
-        left: -16px;
-        top: 24px;
-        bottom: 24px;
-        width: 5px;
-        background: var(--ff-black);
-      }
-
-      .compact-index .chapter-card {
-        position: relative;
-      }
-
-      .compact-index .chapter-card::before {
-        content: '';
-        position: absolute;
-        left: -12px;
-        top: 12px;
-        bottom: 12px;
-        width: 3px;
-        background: linear-gradient(180deg, var(--ff-blue), var(--ff-yellow));
-      }
-
       .compact-index .chapter-title {
         font-size: 15px;
       }


### PR DESCRIPTION
## Summary
- replace header image with pixel-font title and lighten index/chapter presentation
- streamline search controls with inline clear button, updated overlay close, and mobile filter drawer
- adjust emoji/filter sizing and typography for consistent, uncluttered layout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69410f2190088320856f808a6b65b7d3)