### PR TITLE
Center homepage title and align heading sizes

### DIFF
--- a/App.js
+++ b/App.js
@@ -17,7 +17,7 @@ const headerBackgroundDataUri =
       <defs>
         <pattern id="headerGrid" width="26" height="26" patternUnits="userSpaceOnUse">
           <rect width="26" height="26" fill="#ffffff"/>
-          <path d="M26 0H0V26" fill="none" stroke="rgba(0,0,0,0.08)" stroke-width="1"/>
+          <path d="M26 0H0V26" fill="none" stroke="rgba(0,0,0,0.05)" stroke-width="1"/>
         </pattern>
         <linearGradient id="bottomHue" x1="0%" y1="0%" x2="100%" y2="0%">
           <stop offset="0%" stop-color="#c8e6ff" stop-opacity="0.7"/>
@@ -222,7 +222,7 @@ const InnerApp = () => {
 
     <div className="max-w-6xl mx-auto px-4 md:px-8 py-8 space-y-8">
       <header
-        className="brutal-card mobile-unboxed accent-bar accent-blue flex flex-col md:flex-row md:items-center justify-between gap-6 no-round"
+        className="brutal-card mobile-unboxed accent-bar accent-blue flex flex-col items-center justify-center gap-6 text-center no-round"
         style=${{
           backgroundImage: `url(${headerBackgroundDataUri})`,
           backgroundSize: 'cover',
@@ -230,10 +230,8 @@ const InnerApp = () => {
           backgroundRepeat: 'no-repeat'
         }}
       >
-        <div className="max-w-full w-full md:w-auto flex justify-center md:justify-start">
-          <div className="text-center">
-            <h1 className="pixel-title text-2xl md:text-3xl lg:text-4xl leading-tight">FUTURO FORTISSIMO</h1>
-          </div>
+        <div className="w-full">
+          <h1 className="pixel-title text-2xl md:text-3xl lg:text-4xl leading-tight text-center">FUTURO FORTISSIMO</h1>
         </div>
       </header>
 

--- a/components/IndexChapter.js
+++ b/components/IndexChapter.js
@@ -24,7 +24,7 @@ const IndexChapter = ({ chapter, highlight }) => {
     <div className="flex items-start gap-3">
       <span className="text-xl select-none leading-none">${chapter.primaryEmoji || chapter.originalEmoji}</span>
       <div className="flex-1">
-        <h2 className="font-heading text-xl md:text-2xl font-bold text-black leading-tight chapter-title">
+        <h2 className="font-heading text-lg md:text-xl font-bold text-black leading-tight chapter-title">
           <a href=${chapter.url} target="_blank" rel="noopener noreferrer" className="hover:underline decoration-4">
             <${HighlightText} text=${chapter.cleanTitle} highlight=${highlight} />
           </a>
@@ -56,7 +56,7 @@ const IndexChapter = ({ chapter, highlight }) => {
               href=${sub.link}
               target="_blank"
               rel="noopener noreferrer"
-              className="font-heading text-base md:text-lg font-bold text-black hover:underline decoration-2 break-words"
+              className="font-heading text-lg md:text-xl font-bold text-black hover:underline decoration-2 break-words"
             >
               <${HighlightText} text=${sub.cleanTitle} highlight=${highlight} />
             </a>

--- a/components/SubChapterItem.js
+++ b/components/SubChapterItem.js
@@ -49,7 +49,7 @@ const SubChapterItem = ({ subchapter, parentId }) => {
           href=${subchapter.link}
           target="_blank"
           rel="noopener noreferrer"
-          className="font-heading text-sm md:text-base font-bold text-black mr-2 break-words hover:underline decoration-4"
+          className="font-heading text-lg md:text-xl font-bold text-black mr-2 break-words hover:underline decoration-4"
           onClick=${(e) => {
             e.stopPropagation();
             incrementInteraction();

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
         --ff-yellow: #f5a623;
         --ff-green: #2ecc71;
         --ff-black: #0a0a0a;
-        --ff-grid: rgba(0, 0, 0, 0.06);
+        --ff-grid: rgba(0, 0, 0, 0.03);
       }
 
       body {


### PR DESCRIPTION
## Summary
- center the hero title and soften the header/background grid for better readability
- make chapter and subchapter headings share the same font size across index and detail views

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69427ff7482c8320bebc27276dda0357)