### PR TITLE
Add publications 139-89 to data.js

### DIFF
--- a/data.js
+++ b/data.js
@@ -1,5 +1,5932 @@
 export const rawData = [
     {
+        "url": "https://fortissimo.substack.com/p/ff139-e-stato-lai",
+        "title": "🎼 ff.139 E' Stato l'AI?",
+        "subtitle": "Se NVIDIA vale più della Svizzera",
+        "keypoints": [
+            "Tutta la Svizzera vale come NVIDIA?",
+            "Fotocamera : influencers = Gemini : ?",
+            "… non perdetevi il furetto nutrizionista alla fine!"
+        ],
+        "subchapters": [
+            {
+                "title": "🍫ff.139.1 Svizzero? No, NVIDIA",
+                "link": "https://fortissimo.substack.com/i/179548983/ff-svizzero-no-nvidia",
+                "content": "In 3 mesi, NVIDIA ha incassato 57 miliardi di dollari (guadagnandone 36, con un margine del 75%). Numeri incomprensibili. Proviamo a capirli.\nC’è chi confronta il suo valore di mercato con il prodotto interno lordo di interi stati. E’ sbagliato.\nValuation ≠ GDP.Il primo è valoreteoricopercepito, il secondo rappresenta quantofisicamente prodotto(da uno stato) in un anno.\nPiù corretto parlare di fantacalcio. Se voleste NVIDIA, dovreste vendere un bel po’ di “giocatori”:\ntuttele aziende svizzere quotate a Zurigo (Rolex, Nestlé, ABB, Novartis…)le 20 aziende più importanti in Europa (ASML, LVMH, SAP…)\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!LQuA!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F0c64355e-a736-4cfd-b5c0-cab97f758377_850x519.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!7UEK!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F3f11228e-0c7c-4253-ae4c-6865f5d73f63_640x775.png",
+                        "caption": "NVIDIA vale più delle 20 aziende europee più grandi (messe insieme) (via futuro fortissimo)."
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "le aziende svizzere quotate a Zurigo (Rolex, Nestlé, ABB, Novartis…)",
+                        "url": "https://www.verbolsa.com/market-country-Switzerland-1"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🧃ff.139.2 Combini e paperclips",
+                "link": "https://fortissimo.substack.com/i/179548983/ff-combini-e-paperclips",
+                "content": "Perché questohype? Perché l’AI si sta mostrando economicamente fruttifera.\nDave Blundin nel sempre stimolante podcast MOONSHOTfa notare che il mercato delle pubblicità online (600 miliardi) è già interamente gestito da algoritmi.\nAgenti con capacità più spinte (e-commerce, contrattazione materie prime…) possono creare un mercato di almeno 1T$ (~1% del GPD mondiale).\nA riconferma (e dato che gli ultimi modelli stanno saturando i benchmark più difficili:Gemini 3 risolve 1/3 delle domande dell’Humanity Last Exam), le nuove “classifiche” di AI sono economiche:\nperformance in finanza (Alpha Arena)abilità di vendita, contrattazione e pianificazione a lungo termine (Vending-Bench 2; anche qui Gemini 3 vince “portando a casa 5000$”).\nAngolo nerd.Variazione dei guadagni suddivisi per modelli AI e strategie di contrattazione (amichevole, negoziatore, doppiogiochista).\nOttimizzazione economica,long term planning... Mi torna in mente ilminigioco per massimizzare la produzione di graffette, citato da Bolstrom come esempio di superefficienza che porta all’estinzione (🦉 ff.36.2 Il super-librozzo sulla singolarità).\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!pCwF!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F291740ec-a1ed-46b9-8fe9-f02787e8a7e0_1559x738.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!qvEL!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fb914f638-c0a1-4dd4-bf49-11527923c4af_1101x519.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!DcyR!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F0c21eb3a-6fce-4a07-93d8-92a1e033e2be_359x512.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Dave Blundin nel sempre stimolante podcast MOONSHOT",
+                        "url": "https://www.youtube.com/watch?v=r8RGYw1n-5k&t=1771s"
+                    },
+                    {
+                        "text": "Gemini 3 risolve 1/3 delle domande dell’Humanity Last Exam",
+                        "url": "https://scale.com/leaderboard/humanitys_last_exam"
+                    },
+                    {
+                        "text": "Alpha Arena",
+                        "url": "https://nof1.ai/"
+                    },
+                    {
+                        "text": "Vending-Bench 2",
+                        "url": "https://andonlabs.com/evals/vending-bench-2"
+                    },
+                    {
+                        "text": "minigioco per massimizzare la produzione di graffette",
+                        "url": "https://www.decisionproblem.com/paperclips/index2.html"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🦉 ff.36.2 Il super-librozzo sulla singolarità",
+                        "url": "https://fortissimo.substack.com/i/74061252/ff-il-super-librozzo-sulla-singolarita"
+                    }
+                ]
+            },
+            {
+                "title": "🍫ff.139.3 Dov’è la mia macchina volante (in GTA 6?)",
+                "link": "https://fortissimo.substack.com/i/179548983/ff-dove-la-mia-macchina-volante-in-gta",
+                "content": "Tutte queste riflessioni tornano in auge per via dell’ennesimo, silente ma sbalorditivo modello.\nGemini 3è più di un semplice update di numero: è il primo vero modello multimodale.\nGenera app che integrano riconoscimento di videocamera, creazione immagini, search e text-to-speech. App contool-calling, insomma.\nUn paio di esempi (creati con una descrizione lunga meno di un tweet):\nFuretto nutrizionista. Scattando foto al cibo, la analizza e restituisce un report dettagliato (a colpo di squit!) del piatto che “ha annusato”.\nPodcast converter. Copiando la puntata di oggi, ottengo post LinkedIn personalizzato, immagini sui temi più importanti e un podcast di 5 minuti.\n140 caratteri.Storrs Hall lamentava che abbiamo Twitter, ma non le auto volanti (😭 ff.46.3 Anni buttati).\nMa ora con Gemini e 140 caratteri abbiamo unasimulazionedi auto volante. In un futuro robotico, lo stesso input potrebbeconcrettizzarla.\nNon è un caso chePolymarket sia sempre più sicuro che Google avrà il migliore modello a fine 2025.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!rsMo!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F44a11cf6-618d-4faf-a5f6-3207a152d744_404x726.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!7QG2!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F5da638cb-590a-4657-9759-5e1a37766ec9_640x711.jpeg",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Gemini 3",
+                        "url": "https://blog.google/products/gemini/gemini-3/#gemini-3"
+                    },
+                    {
+                        "text": "Furetto nutrizionista",
+                        "url": "https://ai.studio/apps/drive/1hpe_F_V6mm3LM1UiGrHzesT7-uxZjV0-"
+                    },
+                    {
+                        "text": "",
+                        "url": "https://substackcdn.com/image/fetch/$s_!0lmk!,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fc1782e21-615a-40ea-a78f-93c7ab99f8f8_1188x750.png"
+                    },
+                    {
+                        "text": "Polymarket sia sempre più sicuro che Google avrà il migliore modello a fine 2025",
+                        "url": "https://www.reddit.com/r/aicuriosity/comments/1ofy33f/google_dominates_polymarket_77_odds_for_best_ai/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "😭 ff.46.3 Anni buttati",
+                        "url": "https://fortissimo.substack.com/i/90882152/ff-anni-buttati"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff138-biofilia-portami-via",
+        "title": "🎼 ff.138 Biofilia portami via",
+        "subtitle": "Bagni nel bosco e i benefici dell'autunno",
+        "keypoints": [
+            "Meglio una scuola con vista sul verde?",
+            "Bagno nel bosco come la cannabis?",
+            "Piante vs Roomba: i pericoli di una casa pulita?"
+        ],
+        "subchapters": [
+            {
+                "title": "🏎️ff.138.1 La strada più veloce",
+                "link": "https://fortissimo.substack.com/i/178186942/ff-la-strada-piu-veloce",
+                "content": "Brachistocrona. Oggi vi perdo con una parola.\nE’ il percorso più veloce (ma non il più breve!) tra due punti: la curva rossa, la più efficace nel convertire energia potenziale in cinetica.\nGli algoritmi che sempre più regolano la società fanno di tutto per ottimizzare tempi. Per esempio, mio fratello Luca mi ha segnalatoOpenroute: tempi di percorrenza in città, con vari mezzi di trasporto.Almeno vince la bici.\nPoi, si corre a ottimizzare i consumi:Google Maps e i tragitti meno inquinanti.\nMa in tutte queste ottimizzazioni, qualcuno considera il lato umano, psico-fisico delle cose? La nostra salute mentale?\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!8Egh!,w_1456,c_limit,f_auto,q_auto:good,fl_lossy/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F980df9cd-d533-47dd-9d2b-397fd8e09b27_488x203.gif",
+                        "caption": "Andare più veloci con un tragitto più lungo: la brachistocrona."
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!SYm4!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F80794a3c-4477-4365-8bac-324b66f388bd_1124x635.png",
+                        "caption": "Mappe di tempi di percorrenza per ogni città: Openroute"
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!W9L2!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F725341b9-9a20-4565-ad73-fdcf3d5cf602_1114x733.png",
+                        "caption": "Da qualche anno, Google include il consumo di benzina nel calcolare il tragitto ottimale."
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Openroute: tempi di percorrenza in città, con vari mezzi di trasporto.",
+                        "url": "https://mapsplatform.google.com/resources/blog/navigate-more-sustainably-and-optimize-fuel-savings-eco-friendly-routing/"
+                    },
+                    {
+                        "text": "Google Maps e i tragitti meno inquinanti",
+                        "url": "https://mapsplatform.google.com/resources/blog/navigate-more-sustainably-and-optimize-fuel-savings-eco-friendly-routing/"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "😊ff.138.2 La strada più felice",
+                "link": "https://fortissimo.substack.com/i/178186942/ff-la-strada-piu-felice",
+                "content": "Se ci chiedessimo invece quale percorso massimizza la felicità?\nSecondoKathy Willis (La natura che cura), si trovaallungandoil tragitto verso il lavoro, includendo parchi e verde (o, ancora meglio, un florilegio di colori autunnali).\nTorna con nuovi dettagli il “bagno nei boschi” (💚 ff.51.1 L’affabulazione per il verde):\nOrizzonti naturali hanno una “dimensione frattale” (la complessità di uno skyline) calmante: i nostri sensi prediligono spazi ampi con qualche albero qua e là (come nella savana, da dove proveniamo evoluzionisticamente).\nScuole immerse nel verde hanno effetti benefici sullo sviluppo cognitivo dei bambini.\nPS. ChatGPT ha coniato un termine per la “brachistocrona di felicità”:euthymìcrona(εὔθυμος+χρόνος), il tempo del buon animo.εὔθυμος = “di buon cuore, sereno” +  χρόνος  = “tempo”.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!AZFm!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F50647001-c033-4db3-8d84-1e6350e9e174_1000x1491.jpeg",
+                        "caption": "La natura che curaKathy Willis"
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!lsFX!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F80cd8a62-cf41-455c-a333-06f6e50acfa5_717x801.png",
+                        "caption": "L’effetto di orizzonti con differente dimensionalità frattale sullo stato mentale."
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Kathy Willis (",
+                        "url": "https://amzn.to/4ouHFKs"
+                    },
+                    {
+                        "text": "La natura che cura",
+                        "url": "https://amzn.to/4ouHFKs"
+                    },
+                    {
+                        "text": ")",
+                        "url": "https://amzn.to/4ouHFKs"
+                    },
+                    {
+                        "text": "Scuole immerse nel verde hanno effetti benefici sullo sviluppo cognitivo dei bambini",
+                        "url": "https://www.pnas.org/doi/10.1073/pnas.1503402112"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "💚 ff.51.1 L’affabulazione per il verde",
+                        "url": "https://fortissimo.substack.com/i/88408587/ff-laffabulazione-per-il-verde"
+                    }
+                ]
+            },
+            {
+                "title": "🪵ff.138.3 Toccare legno o ferro?",
+                "link": "https://fortissimo.substack.com/i/178186942/ff-toccare-legno-o-ferro",
+                "content": "Sviste.Kathy Willies lamenta però l’eccessivo e platonico peso dato alla vista (a fronte di 1500 paper sugli effetti psicologici del “vedere la natura”, solo 40 si chiedono se abbia senso “toccarla”).\nCome ci influenza, quindi, la natura attraverso gli altri sensi?\nToccare una quercia, rispetto a marmo e metallo, ha effetti calmanti.\nLo stesso gruppo, giapponese ovviamente, ha confrontato anche il contatto con foglie stampate e vere(notare il calzino).\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!pSGb!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fc5400356-43ac-4455-8eb4-964e9722b85f_220x161.jpeg",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!8WLR!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fb552c082-68d8-475d-b3fd-844a7fea767a_725x547.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!dQLo!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fb776766f-e8c8-4ef7-86a7-d5fe3c69d53d_685x913.jpeg",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Toccare una quercia, rispetto a marmo e metallo, ha effetti calmanti",
+                        "url": "https://pubmed.ncbi.nlm.nih.gov/28718814/"
+                    },
+                    {
+                        "text": "Lo stesso gruppo, giapponese ovviamente, ha confrontato anche il contatto con foglie stampate e vere",
+                        "url": "https://jphysiolanthropol.biomedcentral.com/articles/10.1186/1880-6805-32-7"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🥌ff.138.4 Roomba o piante ornamentali?",
+                "link": "https://fortissimo.substack.com/i/178186942/ff-roomba-o-piante-ornamentali",
+                "content": "Non è solo una questione di percezione: la natura cambia il microbioma (e, quindi, la regolamentazione fisiologica e psicologica,🥽 ff.90.3 Micro-bi di stress):\nSostituire ghiaia con foreste in asili nidoaumenta in soli 28 giorni la biodiversità nei bambini svedesi, riducendo biomarker di infiammazione e malattie auto-immuni.Una sola piantapuò ripopolare le nostre case, sterili, di microbi benefici (RoombaI see you).\nBonus.Gli ambienti indoor possono essere più inquinati dell’esterno, specie per composti volatili (Volatile Organic Compounds, VOCs) rilasciati da oggetti di plastica o detergenti.Una pianta può ridurli.\n",
+                "images": [],
+                "references": [
+                    {
+                        "text": "Sostituire ghiaia con foreste in asili nido",
+                        "url": "https://www.science.org/doi/10.1126/sciadv.aba2578"
+                    },
+                    {
+                        "text": "Una sola pianta",
+                        "url": "https://www.frontiersin.org/journals/microbiology/articles/10.3389/fmicb.2015.00887/full"
+                    },
+                    {
+                        "text": "Gli ambienti indoor possono essere più inquinati dell’esterno",
+                        "url": "https://www.mann-hummel.com/en/insights/indoor-air-quality-vs-outdoor-air-pollution.html"
+                    },
+                    {
+                        "text": "Una pianta può ridurli",
+                        "url": "https://www.sciencedirect.com/science/article/abs/pii/S0048969723048945?via%3Dihub"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🥽 ff.90.3 Micro-bi di stress",
+                        "url": "https://fortissimo.substack.com/i/141914401/ff-micro-bi-di-stress"
+                    }
+                ]
+            },
+            {
+                "title": "🚬ff.138.5 Sto lontano dallo stress…",
+                "link": "https://fortissimo.substack.com/i/178186942/ff-sto-lontano-dallo-stress",
+                "content": "Dulcis in fundo, il respiro, un altro cavallo di battaglia di futuro fortissimo (‍💨ff.87.1 Breve storia del respiro).\nIl bagno nel bosco rilassa anche per l’α-pinene, sostanza rilasciata dalle conifere (e presente nella cannabis).\nE bastanotre notti in un hotel che rilascia fragranze di cipresso per aumentare segnali di rilassatezza(misurati con la componente “high-frequency” (HF) dell’HRV,heart rate variability.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!G0Ud!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F94e96e72-da99-4348-8303-3e9ff13f00f5_472x205.jpeg",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!6-K7!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F5bee51a3-e3d4-4ce4-b9a5-66cccbd63565_2119x1400.jpeg",
+                        "caption": "Formafantasma, Cambio (Serpentine Gallery, 2020)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Il bagno nel bosco rilassa anche per l’α-pinene",
+                        "url": "https://jwoodscience.springeropen.com/articles/10.1007/s10086-016-1576-1"
+                    },
+                    {
+                        "text": "tre notti in un hotel che rilascia fragranze di cipresso per aumentare segnali di rilassatezza",
+                        "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC4687359/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "ff.87.1 Breve storia del respiro",
+                        "url": "https://fortissimo.substack.com/i/141422894/ff-breve-storia-del-respiro"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff137-decrescita-felice",
+        "title": "🎼 ff.137 Decrescita felice?",
+        "subtitle": "Guida per accettare un futuro peggiore",
+        "keypoints": [
+            "Cosa fare se la crescita si arresta?",
+            "Bach o Darwin: chi era più depresso?",
+            "Sapere fluido o cristallizzato?"
+        ],
+        "subchapters": [
+            {
+                "title": "⛰️ ff.137.1 Orografia di una discesa",
+                "link": "https://fortissimo.substack.com/i/177574524/ff-orografia-di-una-discesa",
+                "content": "Spesso, si paragona un progetto al salire una montagna. La cima - obiettivo ultimo - deve essere sempre ben visibile, ma l’attenzione va rivolta a panorami e pensieri raccolti salendo.\nProcessi (ogni passo), più che obiettivi (la cima), insomma, come per il mio primo IRONMAN (🎼 ff.133 Sono un Ironman?).\nMa se il processo non basta?Una volta in cima, abbandonare la vista mozzafiato e discendere è dura. Durissima. Come sopravvivere a questa “depressione”, senza buttarsi dal primo precipizio?\nSeth Godin e le discese della vita,per capire se valga la pena continuare il percorso:\nThe Dip,depressione momentanea.I più mollano, i migliori emergono superando ildowne rimanendo fedeli al processo.Cul-de-Sac, illusoria risaliza.Gli sforzi crescenti al più mantengono quanto raggiunto.The Cliff, un vero precipizio.Ulteriori sforzi non fanno che peggiorare la situazione.\nMa, come vedremo, a volte abbandonare non è possibile. La vita, la sopravvivenza è entropicamente stasi o decadenza verso il “peggio”.\nOppure, come vedremo, il segreto sta nel controllare quello che mettiamo sull’asse y. Come definiamo ilreward.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!JB4p!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fe3dc302c-84e6-466a-a740-23a8165ba440_1099x437.png",
+                        "caption": "Le tre curve della vita, tra cui il The Dip (dal libro di Seth Godin/futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Seth Godin e le discese della vita,",
+                        "url": "https://readingraphics.com/book-summary-the-dip-seth-godin/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🎼 ff.133 Sono un Ironman?",
+                        "url": "https://fortissimo.substack.com/p/ff133-sono-un-ironman"
+                    }
+                ]
+            },
+            {
+                "title": "🏆 ff.137.2 Picchi entropici",
+                "link": "https://fortissimo.substack.com/i/177574524/ff-picchi-entropici",
+                "content": "Torniamo al picco.Arthur Brooks in un famoso articolo sul The Atlantic (2019)spiega la crescente depressione dei “grandi”:principle of psychoprofessional gravitation. Più si arriva in alto, più è dura andarsene.\nSto parlando di atleti olimpici in straordinaria forma, attori che guadagnano 1 milione per episodio prodotto o ex Youtuber dimenticati (mi ci metto, con 50.000 iscritti nel 2013).\nAnzi, sto parlando di tutti noi, aldilà dell’altezza raggiunta.\nBrooks porta il suo personale (e musicale) esempio: un giorno “ti svegli e non suoni più il corno con la stessa fluidità”.\nNon solo: rimanere al livello raggiunto è sempre più difficile. Insomma, si invecchia, vince l’entropia. Come accettarlo?\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!dQx_!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F019f951a-8e19-484e-9a04-6f1e93beeb44_482x601.png",
+                        "caption": "Kipchoge in lacrime dopo quella che - a 40 anni - potrebbe essere l’ultima maratona da professionista (con tanto di medaglia per le 6 majors)."
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Arthur Brooks in un famoso articolo sul The Atlantic (2019)",
+                        "url": "https://www.removepaywall.com/search?url=https://www.theatlantic.com/magazine/archive/2019/07/work-peak-professional-decline/590650/#google_vignette"
+                    },
+                    {
+                        "text": "mi ci metto, con 50.000 iscritti nel 2013",
+                        "url": "https://www.youtube.com/@VeI2ax/videos"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "💎 ff.137.3 Cristalli e Bach",
+                "link": "https://fortissimo.substack.com/i/177574524/ff-cristalli-e-bach",
+                "content": "Una cura è la psicologia diRaymond Cattell e le sue due forme di intelligenza:\nfluida: quella che risolve problemi inediti con creatività (i giovani che fondano più startup).cristallizzata: quella che distilla e insegna alle future generazioni (gli storici con il picco a 60 anni).\nDarwin evolve in Bach? Sempre Brooks racconta come Darwin, dopo l’innovativa gioventù, sia finito in una depressa inattività. Bach, invece, pure rivestito di successo da giovane, è riuscito a superarla, insegnando.\nServe quindi, invecchiando, cristallizzare esperienze di vita. Dar loro valore con il ricordo(📈 ff.111.4 Esperienze = investimenti), la condivisione, l’insegnamento.\n",
+                "images": [],
+                "references": [
+                    {
+                        "text": "Raymond Cattell e le sue due forme di intelligenza",
+                        "url": "https://it.wikipedia.org/wiki/Intelligenza_fluida_e_cristallizzata"
+                    },
+                    {
+                        "text": "i giovani che fondano più startup",
+                        "url": "https://hbr.org/2014/04/how-old-are-silicon-valleys-top-founders-heres-the-data"
+                    },
+                    {
+                        "text": "gli storici con il picco a 60 anni",
+                        "url": "https://www.researchgate.net/publication/232593631_Creative_life_cycles_in_literature_Poets_versus_novelists_or_conceptualists_versus_experimentalists"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "📈 ff.111.4 Esperienze = investimenti",
+                        "url": "https://fortissimo.substack.com/i/152438665/ff-esperienze-investimenti"
+                    }
+                ]
+            },
+            {
+                "title": "📈 ff.137.4 Filosofia dell’accumulo",
+                "link": "https://fortissimo.substack.com/i/177574524/ff-filosofia-dellaccumulo",
+                "content": "I cristalli (non meth) salvano contro la fluidità moderna.\nProprio loro, che a livello chimico-fisico sono esempio di stabilità al caos entropico.\nCristalli tanto più preziosi anche a seguito di una piccola crescita o rimanendo stabili nel tempo.\nCristalli che accumulano “storia”, nelcompound, tangibilissimo in finanza, come nel conto in banca di Warren Buffett:\nSoldi a parte, in ogni ambito serve essere “storici della propria vita”: accumulare per anni buone abitudini - attività sportiva, una dieta sana - deve essere percepito come una continua crescita.\nPer ricordarmelo, ho creato League of Strava, una dashboard che trasformi kcal e anni di sport in qualcosa di tangibile.\nCome il conto di Buffet, ma in buffet di pizze mangiate e salute “guadagnata”.\nIl cortoHagdiAnna Ginsburg: rivalutare l’estetica del post-picco nelle donne, oltre la “befana”.\nhagiverseA post shared by@hagiverse\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!PevR!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fb64e6bc1-0764-4bc7-93e2-a7e5dab86a78_1151x677.jpeg",
+                        "caption": "Il 95% del patrimonio di Warren Buffet si è accumulato dopo i suoi 65 anni."
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!Uvpu!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fa4095927-54e1-4c21-8454-94d80832dcca_1515x731.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Il corto",
+                        "url": "https://www.itsnicethat.com/articles/anna-ginsburg-strange-beast-hag-animation-film-project-281015?utm_source=dailyemail&utm_medium=email&utm_campaign=intemail"
+                    },
+                    {
+                        "text": "Hag",
+                        "url": "https://www.itsnicethat.com/articles/anna-ginsburg-strange-beast-hag-animation-film-project-281015?utm_source=dailyemail&utm_medium=email&utm_campaign=intemail"
+                    },
+                    {
+                        "text": "di",
+                        "url": "https://www.itsnicethat.com/articles/anna-ginsburg-strange-beast-hag-animation-film-project-281015?utm_source=dailyemail&utm_medium=email&utm_campaign=intemail"
+                    },
+                    {
+                        "text": "",
+                        "url": "https://www.itsnicethat.com/articles/anna-ginsburg-strange-beast-hag-animation-film-project-281015?utm_source=dailyemail&utm_medium=email&utm_campaign=intemail"
+                    },
+                    {
+                        "text": "Anna Ginsburg",
+                        "url": "https://www.itsnicethat.com/articles/anna-ginsburg-strange-beast-hag-animation-film-project-281015?utm_source=dailyemail&utm_medium=email&utm_campaign=intemail"
+                    },
+                    {
+                        "text": "hagiverse",
+                        "url": "https://instagram.com/hagiverse"
+                    },
+                    {
+                        "text": "",
+                        "url": "https://instagram.com/p/DQUVl6VjIwL"
+                    },
+                    {
+                        "text": "@hagiverse",
+                        "url": "https://instagram.com/hagiverse"
+                    }
+                ],
+                "connections": []
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff136-on-da-e-ner-ge-ti-caaa",
+        "title": "🎼 ff.136 On-da e-ner-ge-ti-caaa!",
+        "subtitle": "Contro il consumo astronomico dell'AI, Goku?",
+        "keypoints": [
+            "Bollette aumentate da ChatGPT?",
+            "1/3 del PIL americano: costo dell’energia previsto da OpenAI nel 2033",
+            "Cina: quale connessione tra sanzioni e caffè(111!?!)?"
+        ],
+        "subchapters": [
+            {
+                "title": "💲 ff.135.1 I costi dell’Intelligenza Artificiale",
+                "link": "https://fortissimo.substack.com/i/176809376/ff-i-costi-dellintelligenza-artificiale",
+                "content": "Secondo alcuni,ChatGPT sta facendo salire le bollette elettriche: dati Federal Reserve riportano un aumento da 0.17 a 0.19 $/kWh(in Europa eclissato dagli effetti ben più tangibili della guerra in Ucraina).\nPerò, però, però.Non è un problema di AI, ma di miopia energetica:Germania e Regno Unito producono meno energia elettrica di 40 anni fa…\nAngolo nerd.I consumi dell’AI (Nature 2025):\n0.5 Wh = energia per un’immagine1000 Wh/20(h)/60(min) = 0.83 Wh energia per un minuto di laptop\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!8pnL!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F9996796c-d5ab-48e2-b549-40e8de6862ad_1309x521.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!lzxG!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F408fd7d4-a7b1-449f-aeaa-175d2aefe10d_864x1049.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!XQhl!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fbff2adb7-cb01-48dd-a417-c8b9fbc3f18c_751x628.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "ChatGPT sta facendo salire le bollette elettriche: dati Federal Reserve riportano un aumento da 0.17 a 0.19 $/kWh",
+                        "url": "https://fred.stlouisfed.org/series/APU000072610"
+                    },
+                    {
+                        "text": "Germania e Regno Unito producono meno energia elettrica di 40 anni fa…",
+                        "url": "https://x.com/scaling01/status/1981642142050136104"
+                    },
+                    {
+                        "text": "I consumi dell’AI (Nature 2025)",
+                        "url": "https://www.nature.com/articles/d41586-025-00616-z"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🌊 ff.135.2 Onda (anomala) energetica",
+                "link": "https://fortissimo.substack.com/i/176809376/ff-onda-anomala-energetica",
+                "content": "Tutto ciò non è nulla rispetto ai piani per il futuro:\nMusk vuole comprare50 milioni di H100 nei prossimi 5 anni (assorbendo 35 GW, il 2% del consumo globale di elettricità oggi).\nAltman vuole rimuovere i limiti imposti dalla produzione energetica:\nCon 10 GW di calcolo, l’AI può curare il cancro. Oppure diventare un tutor privato per tutti gli studenti del mondo. Ma non può fare entrambi.Se siamo limitati dall’energia, dobbiamo scegliere a cosa dare priorità.La nostra visione è semplice: vogliamo produrre una centrale energetica per generare 1 GW di calcolo a settimana.Sam Altman,Abundant Intelligence\nFortunatamente, una soluzione è il solare:in soli 10 anni da 0 a 2073 TWh (237 GW potenza istantanea, totale energia prodotta diviso ore in un anno).\nSapevatelo.Gli investimenti nel solare ($500B) hanno superato quelli per l’aviazione durante la seconda guerra mondiale($400B, corretto per inflazione).\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!LMb5!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fcb3f80b7-aa5c-4f79-ae97-3faf86712ab9_586x228.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!cpW_!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fb2fcbfba-94b8-441c-9b93-d2ad9d98abb8_1920x1519.jpeg",
+                        "caption": "I costi energetici di OpenAI nel 2033: come 1/3 del GDP attuale US"
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!sGeK!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Ff7ec363e-ec42-4f52-b9c9-f9ee02ace9f2_1600x1194.jpeg",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "50 milioni di H100 nei prossimi 5 anni (assorbendo 35 GW, il 2% del consumo globale di elettricità oggi)",
+                        "url": "https://x.com/EthanHe_42/status/1947711720665059595?s=33"
+                    },
+                    {
+                        "text": "Abundant Intelligence",
+                        "url": "https://blog.samaltman.com/abundant-intelligence"
+                    },
+                    {
+                        "text": "in soli 10 anni da 0 a 2073 TWh (237 GW potenza istantanea, totale energia prodotta diviso ore in un anno)",
+                        "url": "https://x.com/AssaadRazzouk/status/1965923547869790614/photo/1"
+                    },
+                    {
+                        "text": "Gli investimenti nel solare ($500B) hanno superato quelli per l’aviazione durante la seconda guerra mondiale",
+                        "url": "https://x.com/patrickc/status/1698496805162353029?t=MfWXDBXWA0o8XMVm_0logQ&s=33"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "♾️ ff.135.3 Siamo nella singolarità?",
+                "link": "https://fortissimo.substack.com/i/176809376/ff-siamo-nella-singolarita",
+                "content": "Tutta questa energia, comunque, serve (ed è già servita) a qualcosa.\nAd esempio, a “risolvere” la matematica.\nGPT-5 Pro dà risposte a problemi “FrontierMath Livello 4” (talmente difficili che, posto che vengano risolti, richiedono a esperti matematici settimane di lavoro).\nQuesta svolta è importantissima: dalla matematica dipendono, a cascata, fisica, chimica e - infine - biologia.\nE’ tanto sbalorditivo cheAlex Wissner, un vero geniettodice che siamonellasingolarità, descrivendola come un’illusione ottica che da lontano appare come un “asintoto verticale”, ma che “quando ci sei in mezzo... sembra abbastanza continuo”.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!cxdR!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fd30fc62b-8b26-4e8e-90a0-8380526a998c_1312x771.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!EXPy!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F3eb79ab9-93e2-49e7-be73-542b9f900bdb_1234x483.png",
+                        "caption": "Un esempio di problema di difficoltà 4 in FrontierMath"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Alex Wissner, un vero genietto",
+                        "url": "https://www.alexwg.org/"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "☕ ff.135.4 L’AGI avanza: il “caffè” cinese",
+                "link": "https://fortissimo.substack.com/i/176809376/ff-lagi-avanza-il-caffe-cinese",
+                "content": "AGI e singolarità sono unplus: Dave Blundin, sempre nello stesso podcast, fa notare chese anche lo sviluppo dell’AI si fermasse oggi, servirebbero anni per digerire, esplorare e implementare le sue potenziali applicazioni.\nI modelli attuali sono già abbastanza intelligenti, ma bisogna distribuirli in robot, fabbriche e logistica; abbassandone i consumi.\nTorna così - rampante - la Cina: per l’embargo sulle GPU più potenti (🎼 ff.82 Guerra a colpi di chip) è stata costretta a spremere i “granelli di caffè” (= bits) con “macchine del caffè” (= GPU) meno performanti (analogia diRyan Cunningham).\nNon a caso, durante la recente AI Conference di Shanghai, il professore Wang Yu ha coniato il“watt-to-bit”, parametro per classificare l’efficienza dei modelli-AI (Energy-Compute Theory).\nSempre non a caso, laleaderboard dell’ARC Prize include il costo per task(che traccia un limite di Pareto al momento occupato dai modelli o3 di OpenAI).\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!iZ67!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F6cc7004b-dc72-4393-809b-e4defbee5067_1206x703.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!u7Cq!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fdb703308-86b9-4763-ac6c-94a4030531a6_930x397.png",
+                        "caption": "Cartography of generative AI(futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "se anche lo sviluppo dell’AI si fermasse oggi, servirebbero anni per digerire, esplorare e implementare le sue potenziali applicazioni",
+                        "url": "https://youtu.be/VfwNK9OVsrM?si=bVnXhAK-f4JqRizG&t=1503"
+                    },
+                    {
+                        "text": "Ryan Cunningham",
+                        "url": "https://open.substack.com/users/2295132-ryan-cunningham?utm_source=mentions"
+                    },
+                    {
+                        "text": "“watt-to-bit”, parametro per classificare l’efficienza dei modelli-AI (Energy-Compute Theory)",
+                        "url": "https://substack.com/home/post/p-170203312?utm_source=substack&utm_medium=email"
+                    },
+                    {
+                        "text": "leaderboard dell’ARC Prize include il costo per task",
+                        "url": "https://arcprize.org/leaderboard"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🎼 ff.82 Guerra a colpi di chip",
+                        "url": "https://fortissimo.substack.com/p/ff81-guerra-a-colpi-di-chip?utm_source=publication-search"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff135-casino-royale",
+        "title": "🎼 ff.135 Casino Royale",
+        "subtitle": "La politica è una slot machine?",
+        "keypoints": [
+            "Prevedere un premio Nobel con i mercati?",
+            "Albania: il primo ministro-AI",
+            "Controllare il figlio di Trump con le criptovalute?"
+        ],
+        "subchapters": [
+            {
+                "title": "🎭 ff.135.1 E’ tutto un casino: manipolazioni",
+                "link": "https://fortissimo.substack.com/i/173499753/ff-e-tutto-un-casino-manipolazioni",
+                "content": "Abbiamo un problema: Trump. O meglio, la possibilità che il mondo cambi con un tweet; per una guerra, un incremento di dazi, un blocco alle migrazioni.\nCinguetti di “singoli nodi” che creano onde anomale nel mare iperconnesso che ci circonda. Tanto che una nuova minaccia di tariffe può valere80 milioni in 30 minuti (almeno per qualcuno con accesso a informazioni confidenziali😉Barron Trump).\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!ch7c!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F98ef8bb4-3cfe-4853-b670-ede23b14bbd5_1356x2088.jpeg",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "80 milioni in 30 minuti (almeno per qualcuno con accesso a informazioni confidenziali😉Barron Trump).",
+                        "url": "https://www.binance.com/en/square/post/30920097507386"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "⚜ ff.135.2 Ritorno ai Comuni medievali?",
+                "link": "https://fortissimo.substack.com/i/173499753/ff-ritorno-ai-comuni-medievali",
+                "content": "Non possiamo più permetterci di centralizzare (male) informazioni e scelte:l’incendio degli archivi in Sud Corea che ha bruciato 8 anni di lavoro pubblico.\nEcco allora che nasce l’idea di🎼 ff.52 Fondare una Nazione in garage; un’Età dei Comuni 2.0, accelerati dalla tecnologia.\n",
+                "images": [],
+                "references": [
+                    {
+                        "text": "l’incendio degli archivi in Sud Corea che ha bruciato 8 anni di lavoro pubblico",
+                        "url": "https://www.macitynet.it/incendio-in-corea-del-sud-ha-distrutto-858-terabyte-di-dati-governativi/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🎼 ff.52 Fondare una Nazione in garage",
+                        "url": "https://fortissimo.substack.com/p/ff52-fondare-una-nazione-in-garage?utm_source=publication-search"
+                    }
+                ]
+            },
+            {
+                "title": "🎲 ff.135.3 Scommesse da Nobel",
+                "link": "https://fortissimo.substack.com/i/173499753/ff-scommesse-da-nobel",
+                "content": "La sfiducia nei “nodi singoli” (e nell’America) sta tutta in questo grafico, che mostra come per la prima volta dal 1996 le banche comprano più oro che debito pubblico americano:\nAccelerato dall’AI, il futuro è di una nuova superpotenza tra:\nCina, con la suacentralizzazione di datiche un tempo avrebbero sommerso ogni burocrazia, ma che oggi vengono gestiti da AI e LLMs.Internet, con la suade-centralizzazione e libertà di mercato, esemplificata da prediction market cheprevedono il Nobel per la Pace 11 ore prima dell’annuncio.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!UQ3F!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Faefc8c09-003a-4922-b6bc-c8650f180531_881x592.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!g-3Z!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fb39fb10e-cd9c-451f-b3ba-e227c2b3dda2_570x839.png",
+                        "caption": "Polymarket prevede il Nobel per la Pace 2025 con 11 ore di anticipo"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "prevedono il Nobel per la Pace 11 ore prima dell’annuncio",
+                        "url": "https://x.com/CarOnPolymarket/status/1976580469492715841?t=nWreL6M7j-5hoeqMiYcDLQ&s=33"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "💳 ff.135.4 America, Nigeria e criptovalute",
+                "link": "https://fortissimo.substack.com/i/173499753/ff-america-nigeria-e-criptovalute",
+                "content": "Torniamo al debito degli Stati Uniti d’America. E alle criptovalute.\nDiamo i numeri.Nel 2011, Cina e Giappone detenevano il 23% del debito USA. Oggi poco più del 6%. Chi li ha sostituiti? Probabilmente, Nigeria e Argentina.\nAlla ricerca di indipendenza finanziaria (e una moneta stabile contro l’inflazione,👍 ff.73.3 Una VPN finanziaria), i paesi in via di sviluppo stanno comprando USDT, “dollari digitali” in blockchain.\nCosì, ildebito americano è digitalizzato e decentralizzato (report di ARK Invest).\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!LWyH!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Ffcd15414-3a93-4ec0-a40d-5fbcc26a0256_705x611.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!gxIx!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F96b32817-d867-457f-9bc3-5324ab774886_3968x2136.jpeg",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "debito americano è digitalizzato e decentralizzato (report di ARK Invest)",
+                        "url": "https://www.ark-invest.com/articles/analyst-research/stablecoins-as-a-us-financial-ally"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "👍 ff.73.3 Una VPN finanziaria",
+                        "url": "https://fortissimo.substack.com/i/115631636/ff-una-vpn-finanziaria"
+                    }
+                ]
+            },
+            {
+                "title": "🏛️ ff.135.5 Politica tecnologica",
+                "link": "https://fortissimo.substack.com/i/173499753/ff-politica-tecnologica",
+                "content": "Altri esempi di digitalizzazione in politica:\nIl Nepal ha eletto il primo ministro tramite Discord(👾 ff.3.5 Discord).\nL’Albania ha proposto un ministro creato con l’Intelligenza Artificiale. In un paese in cui 1/3 dei soldi pubblici viene bruciato in corruzione, sarebbe un dipendente imparziale e senza “nepotismi”.\n🎶archivio note fortissime\n👋 A presto, damicmer\n©futuro fortissimo|michele merelli\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!IYdF!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F64e3d289-612c-4ecc-ad77-21a5c96e9ea8_592x130.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!IiTs!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fd6c47fc2-67e7-4ba2-a446-06506fd97e20_625x571.jpeg",
+                        "caption": "Il trailer di Casino Royale(2006) via futuro fortissimo"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Il Nepal ha eletto il primo ministro tramite Discord",
+                        "url": "https://x.com/Polymarket/status/1966398992922690046?t=kLwszKIBHHmtvoB8L4EA9Q&s=19"
+                    },
+                    {
+                        "text": "L’Albania ha proposto un ministro creato con l’Intelligenza Artificiale",
+                        "url": "https://www.politico.eu/article/albania-apppoints-worlds-first-virtual-minister-edi-rama-diella/"
+                    },
+                    {
+                        "text": "archivio note fortissime",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    },
+                    {
+                        "text": "futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/"
+                    },
+                    {
+                        "text": "michele merelli",
+                        "url": "https://www.linkedin.com/in/michelemerelli/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "👾 ff.3.5 Discord",
+                        "url": "https://fortissimo.substack.com/i/43912374/ff-discord"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff134-nomi-alle-cose",
+        "title": "🎼 ff.134 Nomi alle cose",
+        "subtitle": "Il valore delle parole tra umanità e ChatGPT",
+        "keypoints": [
+            "Perché dare un nome alle emozioni?",
+            "La bellezza sta negli occhi: le 72 stagioni giapponesi",
+            "Lingue e parole aliene?"
+        ],
+        "subchapters": [
+            {
+                "title": "🗣️ ff.134.1 Parole, parole, parole…",
+                "link": "https://fortissimo.substack.com/i/171281710/ff-parole-parole-parole",
+                "content": "Il rapporto tra pensiero, parole e costruzione del mondo mi affascina, specie da quando i modelli di linguaggio come ChatGPT hanno reso questa connessione ancor più stretta (🧠 ff.83.3 Linguaggio e pensiero).\n1.1 Il Mondo è la totalità dei Fatti, non delle Cose.2.1 Noi ci facciamo immagini dei Fatti.3. L’immagine logica dei Fatti è il Pensiero.Ludving Witgenstein,Tractatus Logico-Philosophicus\nIl Pensiero (e il Linguaggio) sono quindi un’immagine del Mondo. Tanto che alcune parole esistono solo in alcune lingue, in alcuni Mondi: solo nelle uggiose e fredde serate olandesi si può davverosentirelagezelligheid.\nAltre parole uniche e intraducibili: 別腹betsubara, lo “stomaco per i dolci” giapponese.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!bP5Z!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F7e92ca05-194c-4bb5-aae3-10c8450ef581_1080x1080.jpeg",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!it_7!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F6f988a48-a4b7-49ac-8698-bfb408a2c69b_1080x1440.jpeg",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Tractatus Logico-Philosophicus",
+                        "url": "https://www.filosofico.net/Antologia_file/wittggggggeee32.htm"
+                    },
+                    {
+                        "text": "gezelligheid",
+                        "url": "https://it.wikipedia.org/wiki/Gezelligheid"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🧠 ff.83.3 Linguaggio e pensiero",
+                        "url": "https://fortissimo.substack.com/i/140010460/ff-linguaggio-e-pensiero"
+                    }
+                ]
+            },
+            {
+                "title": "😭 ff.134.2 Dare un nome alle emozioni",
+                "link": "https://fortissimo.substack.com/i/171281710/ff-dare-un-nome-alle-emozioni",
+                "content": "Le parole servono anche a identificare un altro mondo: quello che ognuno di noi ha dentro, condensato nelle emozioni.\nQueste, secondo la neuroscienziata Lisa Feldman Barrett,sono simulazioni create dal cervelloper integrare vari segnali subconsci, viscerali: battito cardiaco, temperatura e altri segnali interocettivi (🥇 ff.128.1 Giochi (olimpici) mentali).\nDare un nome alle emozioni è fondamentale per superare i blocchi che ci auto-imponiamo: prima di una gara o di un esame sale l’ansia, ma spesso è solo una sfumatura dell’eccitazione, fomento dell’adrenalina dell’attesa di un grande evento.\nMarc Brackett (fondatore del Centro per l’Intelligenza Emotiva a Yale) segue proprio questa linea, con una guida per capire e fare leva sulle emozioni:Dealing with Feeling: Harness Your Emotions to Create the Life You Want.\nMentre il fondatore di Pinterest ha creato un’app,How We Feel, un vero e proprio “Pokédex per le emozioni”.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!baIy!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Ffa8deb42-f221-409d-b892-b700e6596873_1400x870.jpeg",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "sono simulazioni create dal cervello",
+                        "url": "https://pubmed.ncbi.nlm.nih.gov/27798257/"
+                    },
+                    {
+                        "text": "Dealing with Feeling: Harness Your Emotions to Create the Life You Want",
+                        "url": "https://amzn.to/4o4L7ej"
+                    },
+                    {
+                        "text": "How We Feel, un vero e proprio “Pokédex per le emozioni”",
+                        "url": "https://howwefeel.org/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🥇 ff.128.1 Giochi (olimpici) mentali",
+                        "url": "https://fortissimo.substack.com/i/161443015/ff-giochi-olimpici-mentali"
+                    }
+                ]
+            },
+            {
+                "title": "❄️ ff.134.3 Le 72 stagioni giapponesi",
+                "link": "https://fortissimo.substack.com/i/171281710/ff-le-stagioni-giapponesi",
+                "content": "Qualche tempo fa, parlavamo di come fermare il tempo: notando la novità che ogni giorno offre (🎼 ff.65 Come fermare il tempo).\nIn un raggio di sole che filtra tra alberi o in una particolare giustapposizione di colori può celarsi ilPerfect Day(👶 ff.108.2 Con gli occhi del fanciullino).\nProprio questi“occhi da fanciullo”possono portarci dal qualunquista “non esistono più le mezze stagioni” avederne settantadue, come in Giappone:\n白露 (Hakuro): la rugiada “bianca” brilla08 – 12 Settembre土潤溽暑 (Tsuchi uruōte mushi atsushi): terra umida, caldo soffocante29 Luglio – 2 Agosto魚上氷 (Uo kōri o izuru): i pesci fanno capolino dal ghiaccio14 – 18 Febbraio\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!kmOx!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fcb6d3a93-54b8-4c3e-b405-e25719f6f4d7_1000x667.jpeg",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "vederne settantadue, come in Giappone",
+                        "url": "https://www.ohayo.it/category/cultura/72-stagioni-giapponesi/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🎼 ff.65 Come fermare il tempo",
+                        "url": "https://fortissimo.substack.com/p/ff65-come-fermare-il-tempo?utm_source=publication-search"
+                    },
+                    {
+                        "text": "👶 ff.108.2 Con gli occhi del fanciullino",
+                        "url": "https://fortissimo.substack.com/i/148256057/ff-con-gli-occhi-del-fanciullino"
+                    }
+                ]
+            },
+            {
+                "title": "🦴 ff.134.4 Umanità all’osso",
+                "link": "https://fortissimo.substack.com/i/171281710/ff-umanita-allosso",
+                "content": "Questo sentire-definire è quello che ci resta, in un Mondo di “pensiero allocato a GPT”:\nUn’emozione puramente disincarnata è un non-ente.William James,Che cos’è un’emozione?(1884)\nE se il mondo digitale sta già cambiando il significato di certe parole: “to scale a startup”, “scaliamo” startup invece che montagne; per resistere alla disincarnazione dobbiamo ri-attaccarci alle parole, legame tra Pensiero e Mondo.\nBonus.Un caso che ilvideo di Michaell McAfeeper Max CooperI Am in a Church in Gravesend, Listening to Old Vinyl and Drinking Coffeesia un fiume di paroleche scaturisce da questa particolarissima esperienza?\n🎶archivio note fortissime\n👋 A presto, damicmer\n©futuro fortissimo|michele merelli\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!l6vU!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F1bb255f5-7aa5-4b50-8ebb-08c441be59ab_680x525.jpeg",
+                        "caption": "Le proto-emoji di Wilhelm von Humboldt(via futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "William James,",
+                        "url": "https://www.romolocapuano.com/wp-content/uploads/2019/08/CheCosaEmozione.pdf"
+                    },
+                    {
+                        "text": "Che cos’è un’emozione?",
+                        "url": "https://www.romolocapuano.com/wp-content/uploads/2019/08/CheCosaEmozione.pdf"
+                    },
+                    {
+                        "text": "(1884)",
+                        "url": "https://www.romolocapuano.com/wp-content/uploads/2019/08/CheCosaEmozione.pdf"
+                    },
+                    {
+                        "text": "video di Michaell McAfee",
+                        "url": "https://www.instagram.com/mcafee.design/?hl=en"
+                    },
+                    {
+                        "text": "I Am in a Church in Gravesend, Listening to Old Vinyl and Drinking Coffee",
+                        "url": "https://maxcooper.net/i-am-in-a-church-in-gravesend-listening-to-old-vinyl-and-drinking-coffee"
+                    },
+                    {
+                        "text": "archivio note fortissime",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    },
+                    {
+                        "text": "futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/"
+                    },
+                    {
+                        "text": "michele merelli",
+                        "url": "https://www.linkedin.com/in/michelemerelli/"
+                    }
+                ],
+                "connections": []
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff133-sono-un-ironman",
+        "title": "🎼 ff.133 Sono un Ironman?",
+        "subtitle": "Quello che ho capito preparando il triathlon più lungo al mondo",
+        "keypoints": [
+            "La follia di una maratona dopo 180km di bici e 3.8km di nuoto",
+            "Lo sport per spremere la vita (la mia filosofia-scienza del bikepacking)",
+            "Più mente che fisico? La fatica di mesi di preparazione"
+        ],
+        "subchapters": []
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff132-inno-ai-videogiochi",
+        "title": "🎼 ff.132 Inno ai videogiochi",
+        "subtitle": "Perché i gamers hanno una vita in più?",
+        "keypoints": [
+            "Costruire mondi è più divertente che giocarli?",
+            "Musk e Hassabis si sfideranno a Tekken?",
+            "I videogiochi causano una crisi dell’attenzione?"
+        ],
+        "subchapters": [
+            {
+                "title": "🎯 ff.132.1 Crisi dell’attenzione?",
+                "link": "https://fortissimo.substack.com/i/170166035/ff-crisi-dellattenzione",
+                "content": "Da gamer e (ex) youtuber con 50.000 iscritti, i videogiochi mi stanno a cuore.\nSpesso demonizzati insieme ai TikTok da 15 secondi, sono accusati di distruggere l’attenzione.\nPerò, però, però.Siamo sicuri che non sappiamo più concentrarci? Secondo lo storico Daniel Immerwahr, non è così.\nUn paio di riflessioni che ha portato in un recente podcast con Adam Grant:\nNell’Ottocento si diceva che i libri distraessero. Oggi sono simbolo di concentrazione.I videogiochi, come i social feed,generano flow, non distrazione. E ci fanno perdere ore, nella loro immersività.\nLa vera domanda non è “quanto” ci concentriamo, ma su cosa.\n",
+                "images": [],
+                "references": [],
+                "connections": []
+            },
+            {
+                "title": "🕹️ ff.132.2 I benefici dei videogiochi",
+                "link": "https://fortissimo.substack.com/i/170166035/ff-i-benefici-dei-videogiochi",
+                "content": "Ma poi, il tempo “giocando alla Play” è davvero sprecato?\nSparare in GTA aiuta a non farlo nella vita reale (🎮 ff.8.5 Ammazzare la noia (e non esseri umani)). Larelazione violenza-videogiochi? Forse fuffa.\nI videogiochi favoriscono ildecision-makingsotto stress, la coordinazione occhio-mano nonché la collaborazione in team. Non a caso, molti founder hanno un passato da gamer:Kennan Davison, Top 200 in League of Legends ora CEO di Skio (YC S20).\nAsh Brandin (The Gamer Educator su Instagram)fa inoltre notare che alcuni videogiochi, comeBraid,Edith FincheUntitled Goose Gamefavoriscono apprendimento emotivo.\n",
+                "images": [],
+                "references": [
+                    {
+                        "text": "relazione violenza-videogiochi? Forse fuffa",
+                        "url": "https://www.psichi.org/page/173EyeSprSum13cCan2"
+                    },
+                    {
+                        "text": "Kennan Davison, Top 200 in League of Legends ora CEO di Skio (YC S20)",
+                        "url": "https://www.linkedin.com/in/kennandavison/"
+                    },
+                    {
+                        "text": "Ash Brandin (The Gamer Educator su Instagram)",
+                        "url": "https://www.instagram.com/thegamereducator"
+                    },
+                    {
+                        "text": "Braid",
+                        "url": "https://www.ted.com/pages/surprising-effects-of-video-games--transcripthttps://www.ted.com/pages/surprising-effects-of-video-games--transcript"
+                    },
+                    {
+                        "text": ",",
+                        "url": "https://www.ted.com/pages/surprising-effects-of-video-games--transcripthttps://www.ted.com/pages/surprising-effects-of-video-games--transcript"
+                    },
+                    {
+                        "text": "Edith Finch",
+                        "url": "https://www.ted.com/pages/surprising-effects-of-video-games--transcripthttps://www.ted.com/pages/surprising-effects-of-video-games--transcript"
+                    },
+                    {
+                        "text": "e",
+                        "url": "https://www.ted.com/pages/surprising-effects-of-video-games--transcripthttps://www.ted.com/pages/surprising-effects-of-video-games--transcript"
+                    },
+                    {
+                        "text": "Untitled Goose Game",
+                        "url": "https://www.ted.com/pages/surprising-effects-of-video-games--transcripthttps://www.ted.com/pages/surprising-effects-of-video-games--transcript"
+                    },
+                    {
+                        "text": "favoriscono apprendimento emotivo",
+                        "url": "https://www.ted.com/pages/surprising-effects-of-video-games--transcripthttps://www.ted.com/pages/surprising-effects-of-video-games--transcript"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🎮 ff.8.5 Ammazzare la noia (e non esseri umani)",
+                        "url": "https://fortissimo.substack.com/i/43943640/ff-ammazzare-la-noia-e-non-esseri-umani"
+                    }
+                ]
+            },
+            {
+                "title": "📐 ff.132.3 Misurare e modellare il mondo",
+                "link": "https://fortissimo.substack.com/i/170166035/ff-misurare-e-modellare-il-mondo",
+                "content": "Per “illudere” (in-ludere, parola legata alluduslatino, al gioco), un videogioco deve simulare, modellare il mondo in modo coerente (🎼 ff.98 Giochi e simulazioni).\nCostruire mondi virtuali serve anche a capire quello reale.\nNon a caso, Demis Hassabis (DeepMind) - pure ex videogiocatore - oggi “gioca” a modellare cellule (dopo il Nobel ricevuto per la modellazione con AI delle proteine).\nE l’analogia è ancora più stretta:Genie 3 crea in tempo reale, anche da un’immagine, videogiochi interattivi e consistenti nel tempo.\nCVD.SimCityè nato quandoWill Wright si accorse che creare il mondo del suo sparatutto arcade era più divertente che giocarlo.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!oKj7!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F8d5ee1ef-a169-48cf-be35-cf8e9b6d4826_864x1306.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!1P0p!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fc9c74ee3-a275-4ca5-aaff-28ab7986a20c_1536x1024.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Genie 3 crea in tempo reale, anche da un’immagine, videogiochi interattivi e consistenti nel tempo",
+                        "url": "https://deepmind.google/discover/blog/genie-3-a-new-frontier-for-world-models/"
+                    },
+                    {
+                        "text": "Will Wright si accorse che creare il mondo del suo sparatutto arcade era più divertente che giocarlo.",
+                        "url": "https://it.wikipedia.org/wiki/Will_Wright_(informatico)"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🎼 ff.98 Giochi e simulazioni",
+                        "url": "https://fortissimo.substack.com/p/ff98-giochi-e-simulazioni?utm_source=publication-search"
+                    }
+                ]
+            },
+            {
+                "title": "🛶 ff.132.4 “Tutto scorre” anche Skyrim",
+                "link": "https://fortissimo.substack.com/i/170166035/ff-tutto-scorre-anche-skyrim",
+                "content": "Per chiudere il cerchio della verosimilitudine dei videogiochi, c’è chi si chiede se l’idrogeologia diSkyrimsia corretta, cercando la sorgente dell’acqua dei suoi fiumi.\n🎶archivio note fortissime\n👋 A presto, damicmer\n©futuro fortissimo|michele merelli\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!Tonj!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fbc11123c-5aef-4109-b0ab-336ca7a50807_1440x1047.bin",
+                        "caption": "Luca Bjørnsten ci riporta con nostalgia a quando giocavamo a WWE usando Hulk Hogan (via futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "archivio note fortissime",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    },
+                    {
+                        "text": "futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/"
+                    },
+                    {
+                        "text": "michele merelli",
+                        "url": "https://www.linkedin.com/in/michelemerelli/"
+                    }
+                ],
+                "connections": []
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff131-lestate-sta-iniziando",
+        "title": "🎼 ff.131 L'estate sta iniziando",
+        "subtitle": "Come passare agosto pensando a un futuro fortissimo",
+        "keypoints": [],
+        "subchapters": [
+            {
+                "title": "📚 ff.131.1 Una lettura",
+                "link": "https://fortissimo.substack.com/i/168408634/ff-una-lettura",
+                "content": "Pensando al libro più significativo di quest’anno, non posso che tornare suLa saggezza del Tao(☯️ ff.108.3 Essere acqua).\nRaccoglie e interpreta gli81 messaggi di Lao Tzuapplicandoli ai tormentati, digitali, iper-connessi e ottimizzatori giorni nostri.\nHo riletto per esempio parte del verso 23. Interessante.\nParlare poco è naturale:i venti impetuosi non soffiano tutta la mattina;una pioggia torrenziale non dura tutto il giorno.Chi li crea? Il cielo e la terra.Ma questi sono fenomeni atmosferici violenti,ecco perché non possono durare a lungo.Se il cielo e la terranon possono sostenere a lungo un’azione violenta,come potrebbero riuscire gli uomini?Lao Tzu,Tao Te Ching\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!YXut!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F7a0a05df-6ebe-44b1-bc6d-414b185fbb40_500x748.jpeg",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "La saggezza del Tao",
+                        "url": "https://www.amazon.it/saggezza-cambiare-pensare-vivere-meglio/dp/8867008870?_encoding=UTF8&qid=&sr=&linkCode=sl1&tag=micmeramazon-21&linkId=5b1a1caff0c808c56c81174a8af0d976&language=it_IT&ref_=as_li_ss_tl"
+                    },
+                    {
+                        "text": "81 messaggi di Lao Tzu",
+                        "url": "https://www.fabriziotocci.it/formazione-e-crescita-personale/lao-tsu-gli-81-versi-del-tao-te-ching/"
+                    },
+                    {
+                        "text": "Tao Te Ching",
+                        "url": "https://amzn.to/4lHE7mQ"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "☯️ ff.108.3 Essere acqua",
+                        "url": "https://fortissimo.substack.com/p/ff108-inno-alla-routine?utm_source=publication-search"
+                    }
+                ]
+            },
+            {
+                "title": "📜 ff.131.2 Due articoli",
+                "link": "https://fortissimo.substack.com/i/168408634/ff-due-articoli",
+                "content": "Per letture più rapide, invece, un paio di articoli.\nDue uscite di futuro fortissimo a cui tengo particolarmente: riflessioni illuminanti del viaggio tra Hong Kong e Shenzhen, che ho fatto a inizio anno.\n🎼 ff.117 Viviamo in una simulazioneL'ho capito in viaggio tra Hong Kong e Shenzhen\n🎼 ff.118 Paprika e massaggiSpezie tra internet e Il Mondo Nuovo\nE’ un intreccio tra passato coloniale, “segni” asiatici, futuri incerti di geopolitica e riflessioni sul libero arbitrio, in un mondo di telecamere/algoritmi/social media.\n",
+                "images": [],
+                "references": [],
+                "connections": [
+                    {
+                        "text": "🎼 ff.117 Viviamo in una simulazioneL'ho capito in viaggio tra Hong Kong e Shenzhen",
+                        "url": "https://fortissimo.substack.com/p/ff117-viviamo-in-una-simulazione"
+                    },
+                    {
+                        "text": "🎼 ff.118 Paprika e massaggiSpezie tra internet e Il Mondo Nuovo",
+                        "url": "https://fortissimo.substack.com/p/ff118-paprika-e-massaggi?utm_source=publication-search"
+                    }
+                ]
+            },
+            {
+                "title": "🎧 ff.131.3 Tre ascolti",
+                "link": "https://fortissimo.substack.com/i/168408634/ff-tre-ascolti",
+                "content": "Se preferite il formato audio, ecco cosa ascoltare.\nUn revival del podcast di Lex Fridman con Joscha Bach, filosofo esperto di neuroscienze e AI.\nSe poi anche quest'anno l’onirico Salar de Uyuni in Bolivia rimane - appunto - solo un sogno, tranquilli: tuffatevi in questa live di FKJ.\nInfine, una delle mie scoperte preferite dell’ultimo periodo:faccianuvola, 2002 di Sondrio che - dopo un breveexcursusa Milano per studiare Fisica - è tornato tra le sue montagne.Per fare musica elettronica che parla di passato (o undomani?).\nSai che un po' mi mancano tutti quei posti straniDove si viveva soli senza pensare al domanifaccianuvola,undomani\n",
+                "images": [],
+                "references": [
+                    {
+                        "text": "faccianuvola, 2002 di Sondrio che - dopo un breve",
+                        "url": "https://radioairplay.fm/artista/217842/faccianuvola/biografia/"
+                    },
+                    {
+                        "text": "excursus",
+                        "url": "https://radioairplay.fm/artista/217842/faccianuvola/biografia/"
+                    },
+                    {
+                        "text": "a Milano per studiare Fisica - è tornato tra le sue montagne.",
+                        "url": "https://radioairplay.fm/artista/217842/faccianuvola/biografia/"
+                    },
+                    {
+                        "text": "undomani",
+                        "url": "https://www.youtube.com/watch?v=5SvAHlkS_IA"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "✒️ ff.131.4 Quattro riflessioni",
+                "link": "https://fortissimo.substack.com/i/168408634/ff-quattro-riflessioni",
+                "content": "Spunti e citazioni su cui riflettere in riva al mare, aspettando la grande onda di Piotta.\nA differenza dei beni materiali, che inizialmente sembrano eccitanti ma perdono di valore velocemente, le esperienze guadagnano valore nel tempo: pagano ciò che chiamo “dividendi di memoria”.Bill Perkins,Die with zero(🎼 ff.111 Morire con zero)\nSul tema dell’io e dell’eccessiva auto-consapevolezza, ottimizzazione, individualismo (🎁 ff.68.4 Meno ego e controllo, più flow e presente: la cura di Naval) ho trovato un’altra perla:\nL'ego, il falso sé, [è] la radice di tutto il male che penetra nella terra e distrugge la vita umana, e con esso, naturalmente, la realtà del tempo, la realtà della presenza vissuta.L'ego vive solo nel futuro e nel passato; non ha un momento presente; è sempre di fretta o sogna.La radice del nostro moderno problema con il tempo non è né tecnologica, né sociologica, né economica, né psicologica. È metafisica. È una questione del significato stesso della vita umana.Jacob Needleman,Time and Soul\nLa ciclicità dei momenti. Belli, brutti, sfuggevoli, sempre effimeri; nel genio del professore-sballone Cosmo.\nVorrei fermare subito 'sto treno Vorrei saperlo fareVorrei saperlo fareVorrei che fosse tutto un po' più lento Vorrei saperlo fareDilatare il tempoVorrei bruciarmi e nascere di nuovo Vorrei proteggerti da questo ventoE mi godrò ogni singolo momentoPer poi lasciarlo andareE poi ricominciareCosmo,Momenti\nDiventare grandi vuol dire preferire la verdura ai biscotti.\nLa felicità è come un biscotto. Quando sei bambino, pensi che i biscotti siano molto importanti e vuoi avere tutti i biscotti del mondo.Aspetti con impazienza di diventare adulto, perché allora potrai avere quanti biscotti vuoi, giusto? Sì, ma da adulto capisci che il biscotto è uno strumento.Uno strumento per farti mangiare le verdure.E una volta che lo capisci, mangi comunque le verdure e smetti per lo più di mangiare biscotti, perché altrimenti rischi di avere il diabete e non essere presente per i tuoi figli.Joscha Bach,Lex Fridman Podcast #101\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!_np2!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Ffe2a6112-5ed6-4d84-ad59-9582869748f1_595x565.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Die with zero",
+                        "url": "https://www.amazon.it/Die-Zero-Getting-Your-Money/dp/0358567092?_encoding=UTF8&dib_tag=se&dib=eyJ2IjoiMSJ9.DjBH__-HfyPd_gR26LmhmRWXddAw2TVFU9zpYMfYi1AHT2rISaxCbSlJpPlylMYO52jLWrBltQ2VHkG57gopfBdmHIN3b7WWqKm-dhkesnwbCsnLnqX06AREkNH2jIrV.bJK4hsc0o2XITqirn0rgM2L-PDD1VXuVNyDZn62FwM8&qid=1733415990&sr=1-1&linkCode=sl1&tag=micmeramazon-21&linkId=198d932ae64fdf40461cf7580fab4375&language=it_IT&ref_=as_li_ss_tl"
+                    },
+                    {
+                        "text": "Time and Soul",
+                        "url": "https://amzn.to/459DBId"
+                    },
+                    {
+                        "text": "Momenti",
+                        "url": "https://www.youtube.com/watch?v=jx1Umh-2AE0"
+                    },
+                    {
+                        "text": "Lex Fridman Podcast #101",
+                        "url": "https://www.youtube.com/watch?v=P-2P3MSZrBM"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🎼 ff.111 Morire con zero",
+                        "url": "https://fortissimo.substack.com/p/ff111-morire-con-zero?utm_source=publication-search"
+                    },
+                    {
+                        "text": "🎁 ff.68.4 Meno ego e controllo, più flow e presente: la cura di Naval",
+                        "url": "https://fortissimo.substack.com/p/ff68-che-ansia-pt-2?open=false#%C2%A7ff-meno-ego-e-controllo-piu-flow-e-presente-la-cura-di-naval"
+                    }
+                ]
+            },
+            {
+                "title": "🖐️ ff.131.5 Cinque pezzi facili",
+                "link": "https://fortissimo.substack.com/i/168408634/ff-cinque-pezzi-facili",
+                "content": "Considera disupportare 🎼 ff con un cafféoppure usa il tasto qui sotto per invitare un amico e guadagnarti un libro.Refer a friendDedica 15 minuti alla lettura, 20 minuti a una qualsiasi attività sportiva, 30 minuti a una chiacchierata senza cellulare nelle tue vicinanze.Mangia almeno 20g di fibre.Abbronzati un po’.Mandami per email un articolo, una citazione o unmemeleggero (michelemerelli.8@gmail.com).\nVuoi supportare questo progetto?→ Condividilo con un amico suWhatsApp→Offrimi un caffè😏→Ricordati di mettere un cuoricino qua sotto.\n☕❤️\n👋 Buona estate! damicmer\n©futuro fortissimo|michele merelli\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!WwBa!,w_1456,c_limit,f_auto,q_auto:good,fl_lossy/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F415b956a-913f-4d08-a257-ae7eb34e4cd1_700x438.gif",
+                        "caption": "Thomas Merceron"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "supportare 🎼 ff con un caffé",
+                        "url": "https://www.paypal.com/paypalme/MicheleMerelli"
+                    },
+                    {
+                        "text": "",
+                        "url": "https://substackcdn.com/image/fetch/$s_!61-w!,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fd3d2be84-c520-48cb-9bb7-5841c777b5a1_478x205.png"
+                    },
+                    {
+                        "text": "Offrimi un caffè",
+                        "url": "https://www.paypal.com/paypalme/MicheleMerelli"
+                    },
+                    {
+                        "text": "☕",
+                        "url": "https://www.paypal.com/paypalme/MicheleMerelli"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    },
+                    {
+                        "text": "futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/"
+                    },
+                    {
+                        "text": "michele merelli",
+                        "url": "https://www.linkedin.com/in/michelemerelli/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "Refer a friend",
+                        "url": "https://fortissimo.substack.com/leaderboard??utm_source=post"
+                    },
+                    {
+                        "text": "WhatsApp",
+                        "url": "https://api.whatsapp.com/send?text=https%3A%2F%2Ffortissimo.substack.com%2F"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff130-microplastiche",
+        "title": "🎼 ff.130 Microplastiche",
+        "subtitle": "tra diamanti, arte, sperma e carotide",
+        "keypoints": [
+            "Quali cibi sono più contaminati?",
+            "Trasformare bottiglie in diamanti?",
+            "Gli effetti delle microplastiche sulla salute umana (e la fecondità)"
+        ],
+        "subchapters": [
+            {
+                "title": "🥤 ff.130.1 Plastic is fantastic",
+                "link": "https://fortissimo.substack.com/i/158354893/ff-plastic-is-fantastic",
+                "content": "Non demonizziamola plastica: fa anche del bene, specie per conservare il cibo(Bressanini sempre sul pezzo).\ndario.bressaniniA post shared by@dario.bressanini\nDa italiani, poi, dobbiamo esserne anche un po’ fieri. Vedi Nobel per la Chimica di Natta nel 1963.\nPerò, però, però.I suoi vantaggi, come flessibilità e durabilità chimica, sono anche ciò che ne complicano separazione e riciclo. Lavorando con DOW, Google X proponeun’AI per categorizzare scarti in base al tipo di plastica.\nSappiate comunque che potenzialmente possiamo trasformarele bottiglie di plastica in diamanti(Science 2022).\nNell’attesa che sia economicamente fattibile, cosa fare?\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!sxD0!,w_1456,c_limit,f_auto,q_auto:good,fl_lossy/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F82ad579d-03c3-444f-b95e-24bd6c54448e_712x503.gif",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "la plastica: fa anche del bene, specie per conservare il cibo",
+                        "url": "https://bressanini-lescienze.blogautore.espresso.repubblica.it/2019/07/10/benedetta-plastica/comment-page-1/index.html"
+                    },
+                    {
+                        "text": "dario.bressanini",
+                        "url": "https://instagram.com/dario.bressanini"
+                    },
+                    {
+                        "text": "",
+                        "url": "https://instagram.com/p/BzufIREIJPd"
+                    },
+                    {
+                        "text": "@dario.bressanini",
+                        "url": "https://instagram.com/dario.bressanini"
+                    },
+                    {
+                        "text": "un’AI per categorizzare scarti in base al tipo di plastica",
+                        "url": "https://x.company/blog/posts/circularity-dow/"
+                    },
+                    {
+                        "text": "le bottiglie di plastica in diamanti",
+                        "url": "https://www.science.org/doi/10.1126/sciadv.abo0617"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🎨 ff.130.2 Arte riciclabile?",
+                "link": "https://fortissimo.substack.com/i/158354893/ff-arte-riciclabile",
+                "content": "Possiamo trasformala in arte.\nMandy Baker cataloga mutande e altri indumenti finiti in mare come fossero alghe(🏭 ff.39.1 L’impatto del fast fashion sul clima).\nMatthew Miller crea invece grafiche su temi socio-economici, trattando anche le microplastiche.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!0gLe!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F7c24eca0-64a3-4c15-a56c-6ab17eed096a_1440x1009.bin",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!-2Qk!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fe5ee1d06-d958-436f-b280-7aba56cf8015_1440x951.bin",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!G5bC!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F690febb1-a27f-481b-98cf-07058eda2c73_1417x1772.bin",
+                        "caption": "Matthew Millerusa il graphic design per tematiche ecologiche (via futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Mandy Baker cataloga mutande e altri indumenti finiti in mare come fossero alghe",
+                        "url": "https://www.itsnicethat.com/articles/mandy-barker-photographs-of-british-algae-cyanotype-imperfections-photography-publication-project-270325"
+                    },
+                    {
+                        "text": "Matthew Miller crea invece grafiche su temi socio-economici",
+                        "url": "https://www.bymatthewmiller.com/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🏭 ff.39.1 L’impatto del fast fashion sul clima",
+                        "url": "https://fortissimo.substack.com/i/49833709/ff-limpatto-del-fast-fashion-sul-clima"
+                    }
+                ]
+            },
+            {
+                "title": "🗑️ ff.130.3 Microplastiche: da dove provengono?",
+                "link": "https://fortissimo.substack.com/i/158354893/ff-microplastiche-da-dove-provengono",
+                "content": "Come si vede, la plastica è ovunque. Anche nell’aria.\nAmore mio, non sai quante volte ho sognatoChe lei stesse distante da noiMa poi si è intromessa ed ha rovinato tuttoTu vivi nell'aria, tu vivi dentro al mio cuoreMiani,Tu vivi nell'aria(feat. Goodzilla)\nSì, e vive anche dentro il vostro cuore. Ma ci arriviamo.\nIniziamo col dire chemicroplastiche disperse in aria possono essere assorbite dalle piante, entrando nella catena alimentare (Nature, 2024).\nUn’altra sorpresa amara, come la birra, arriva da un nuovo studio francese:\nAngolo nerd:se volete un Pokédex delle microplastiche,plasticlist.com elenca le microplastiche in quasi tutto(dal Vanilla Shake del Burger King al latte Oatly).\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!FLRN!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F9c175a52-d9a2-4e63-82ae-7a46ec4ffe11_786x423.png",
+                        "caption": "Le microplastiche nelle bevande vendute in Francia(Journal of Food Composition and Analysis, 2025, via futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "microplastiche disperse in aria possono essere assorbite dalle piante",
+                        "url": "https://www.nature.com/articles/d41586-025-00909-3"
+                    },
+                    {
+                        "text": "plasticlist.com elenca le microplastiche in quasi tutto",
+                        "url": "https://www.plasticlist.org/"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "💀 ff.130.4 La danza macabra",
+                "link": "https://fortissimo.substack.com/i/158354893/ff-la-danza-macabra",
+                "content": "Le microplastiche sono talmente diffuse che neanche il superuomo-wannabeBryan Johnson può sfuggirne (💊 ff.49.4 Il superuomo che prende 100 pillole al giorno).\nConsauna, trasfusione di plasma e rimozione di oggetti di plastica ha però ridotto del 90% le particelle nel suo sangue.\nIn omnia pericula, tasta testicula.Nonostante il mantra DON’T DIE di Bryan, il suo sperma rimane contaminato. Meglio “toccarsi” una volta in più, come suggeriscono i latini.\nNascerà un bebè di plastica, come in questo corto demenzialegenerato con Veo3?\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!YsfB!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F423c537a-079c-4f6f-9c82-25279ce379ca_591x159.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "sauna, trasfusione di plasma e rimozione di oggetti di plastica ha però ridotto del 90% le particelle nel suo sangue",
+                        "url": "https://x.com/bryan_johnson/status/1935395096054349899"
+                    },
+                    {
+                        "text": "Nascerà un bebè di plastica, come in questo corto demenziale",
+                        "url": "https://x.com/MetaPuppet/status/1926659557914268155?t=UB8XAb_78R-DWwo7PPJ1mw&s=19"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "💊 ff.49.4 Il superuomo che prende 100 pillole al giorno",
+                        "url": "https://fortissimo.substack.com/i/95768941/ff-il-superuomo-che-prende-pillole-al-giorno"
+                    }
+                ]
+            },
+            {
+                "title": "🩸 ff.130.5 Microplastiche induriscono arterie",
+                "link": "https://fortissimo.substack.com/i/158354893/ff-microplastiche-induriscono-arterie",
+                "content": "Ma quali effetti hanno le microplastiche sulla salute?\nUno èindurire le arterie, aumentando infiammazione ed eventi cardiaci, come fa notare il sempre puntuale Eric Topol.\nIn particolare,il DEHP (uno ftalato presente nel PVC) si stima abbia causato 356.000 morti in più per malattie cardiovascolari, ossia il 13.5% delle morti totali globali (picco del 16.8% in Asia Meridionale dove il DEHP è più diffuso).\nInsomma, è bene che sia stata esposta a Bangkokl’operaMega Matcon 500 tappetini di plastica riciclata.\nartribuneA post shared by@artribune\n👋 E con questo è tutto.Ricordatevi di mettere un❤️cuoricino qui sotto❤️\n©futuro fortissimo|michele merelli\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!U10U!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F27e2268c-e805-42d9-a53a-f46817c74930_5746x2220.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "indurire le arterie, aumentando infiammazione ed eventi cardiaci",
+                        "url": "https://erictopol.substack.com/p/theres-plastic-in-my-plaque?utm_campaign=posts-open-in-app&triedRedirect=true"
+                    },
+                    {
+                        "text": "il DEHP (uno ftalato presente nel PVC) si stima abbia causato 356.000 morti in più per malattie cardiovascolari",
+                        "url": "https://www.thelancet.com/journals/ebiom/article/PIIS2352-3964(25)00174-4/fulltext"
+                    },
+                    {
+                        "text": "l’opera",
+                        "url": "http://nella piazza Lan Khon Mueang Town, fuori dal Bangkok Metropolitan Authority City Hall, “Mega Mat” è un’opera modulare, composta da oltre 500 tappetini di plastica riciclata, un’installazione che mostra le possibilità di utilizzo della plastica riciclata negli oggetti di uso quotidiano."
+                    },
+                    {
+                        "text": "Mega Mat",
+                        "url": "http://nella piazza Lan Khon Mueang Town, fuori dal Bangkok Metropolitan Authority City Hall, “Mega Mat” è un’opera modulare, composta da oltre 500 tappetini di plastica riciclata, un’installazione che mostra le possibilità di utilizzo della plastica riciclata negli oggetti di uso quotidiano."
+                    },
+                    {
+                        "text": "con 500 tappetini di plastica riciclata",
+                        "url": "http://nella piazza Lan Khon Mueang Town, fuori dal Bangkok Metropolitan Authority City Hall, “Mega Mat” è un’opera modulare, composta da oltre 500 tappetini di plastica riciclata, un’installazione che mostra le possibilità di utilizzo della plastica riciclata negli oggetti di uso quotidiano."
+                    },
+                    {
+                        "text": "artribune",
+                        "url": "https://instagram.com/artribune"
+                    },
+                    {
+                        "text": "",
+                        "url": "https://instagram.com/p/DG0jxKrPz5A"
+                    },
+                    {
+                        "text": "@artribune",
+                        "url": "https://instagram.com/artribune"
+                    },
+                    {
+                        "text": "futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/"
+                    },
+                    {
+                        "text": "michele merelli",
+                        "url": "https://www.linkedin.com/in/michelemerelli/"
+                    }
+                ],
+                "connections": []
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff129-il-valzer-di-tesla",
+        "title": "🎼 ff.129 Il valzer di Tesla",
+        "subtitle": "Altro che ChatGPT: l'intelligenza artificiale fisica",
+        "keypoints": [
+            "Sam Altman: il 2027 sarà l’anno dei robot",
+            "Perché la robotica sta rinascendo?",
+            "Marte sarà colonizzata da umanoidi?"
+        ],
+        "subchapters": [
+            {
+                "title": "🕳️ff.129.1 La singolarità “gentile” di Altman",
+                "link": "https://fortissimo.substack.com/i/162404080/ff-la-singolarita-gentile-di-altman",
+                "content": "QuandoSam Altmanpubblica qualcosa sul suo blog, è bene dargli una letta.\nInThe Gentle Singularitysostiene che abbiamo superato l’orizzonte degli eventi dell’intelligenza artificiale. Ma in modo tanto “gentile” da non essercene nemmeno accorti.\nViviamo già con una intelligenza digitale incredibile ma, dopo lo shock iniziale, ci siamo velocemente abituati.Siamo passati da essere meravigliati per la scrittura di un paragrafo a chiederci quando l’AI scriverà interi libri; sorpresi da diagnosi mediche fino a chiederci quando svilupperà la prossima medicina.\nUn agricoltore di sussistenza dell’anno 1000 direbbe che abbiamo dei lavori finti, e che il capitalismo è solo un gioco per intrattenerci, dato che abbiamo cibo e lussi a volontà.\nChaGTP (150 volte più economico ed ecologico in un solo anno) è un esempio di questa accelerazione. Ma il prossimo salto tecnologico sarà nel mondo reale.\n",
+                "images": [],
+                "references": [
+                    {
+                        "text": "Sam Altman",
+                        "url": "https://blog.samaltman.com/the-gentle-singularity"
+                    },
+                    {
+                        "text": "The Gentle Singularity",
+                        "url": "https://blog.samaltman.com/the-gentle-singularity"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🥧ff.129.2 Pi-greco, FigureAI e 1 ora “logistica”?",
+                "link": "https://fortissimo.substack.com/i/162404080/ff-pi-greco-figureai-e-ora-logistica",
+                "content": "Gli LLMs non stanno solo democratizzando il software. Sono l’interfaccia più semplice che abbiamo mai avuto per il mondo fisico per “parlare ai robot”.\nCosì, programmarli è oggi meno costoso e più generalizzabile. Ecco il motivo della diffusione di vari “robot foundation models”:\nπ0, di Physical Intelligencegestisce 8 architetture e svariate azioni, come preparare il caffè o aprire i pop-corn.\nHelix, di FigureAIcombina un cervello “lento e semantico” (System 2) che comprende frasi complesse e scene nuove, e uno “rapido e motorio” (System 1) che agisce.\nSAS Prompt di Googletraduce coordinate x, y, z del robot in movimenti descritti a parole.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!g78b!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F576977e6-c2c3-4fc8-bec0-8cf5eedb0919_1072x155.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!JEqJ!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fd8465ad4-7790-4127-82f3-e51e5501b3ad_1393x517.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!d5UW!,w_1456,c_limit,f_auto,q_auto:good,fl_lossy/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F0736195d-76c9-43f7-bbb5-b9714fdd40a6_800x450.gif",
+                        "caption": "Google insegna ai robot a giocare a ping pong(via futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "π0, di Physical Intelligence",
+                        "url": "https://www.physicalintelligence.company/blog/pi0"
+                    },
+                    {
+                        "text": "Helix, di FigureAI",
+                        "url": "https://www.figure.ai/news/helix"
+                    },
+                    {
+                        "text": "SAS Prompt di Google",
+                        "url": "https://x.com/asurobot/status/1917618945617715392?t=bKQw7P9FJnKqRzSaiRSMMw&s=19"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "💃🏻ff.129.3 Il valzer di Tesla (con la Cina)",
+                "link": "https://fortissimo.substack.com/i/162404080/ff-il-valzer-di-tesla-con-la-cina",
+                "content": "Ricerca di base a parte, vi lascio alcuni esempi concreti.\nOptimus di Tesla che balla un walzer:\nRobot cinesi per spruzzare pesticidi:\nHelix di FigureAI che smista pacchetti per un’ora (migliora in pochi mesi: da 5 a 4s per pacchetto).\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!sEG_!,w_1456,c_limit,f_auto,q_auto:good,fl_lossy/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F759de3d3-19f9-4b2b-b5c0-f65764362fef_260x461.gif",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!sMkS!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F680524bb-6ba8-4196-a099-02763e875e0f_590x639.png",
+                        "caption": "Il robot cinese che spruzza pesticidi (Peter Diamandis via futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Optimus di Tesla che balla un walzer",
+                        "url": "https://x.com/Tesla_Optimus/status/1922456791549427867"
+                    },
+                    {
+                        "text": "Robot cinesi per spruzzare pesticidi",
+                        "url": "https://x.com/PeterDiamandis/status/1922502553071140882?t=Dc5PPLsPnzJ2YhFNptZtOA&s=19"
+                    },
+                    {
+                        "text": "migliora in pochi mesi: da 5 a 4s per pacchetto",
+                        "url": "https://www.figure.ai/news/scaling-helix-logistics"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🪐ff.129.4 Colonizzare Marte",
+                "link": "https://fortissimo.substack.com/i/162404080/ff-colonizzare-marte",
+                "content": "Facendo leva suknow-howe capacità produttiva di Tesla (la guida autonoma tra le strade di Roma?), Musk vuole usare proprio i robot per colonizzare Marte (non soffrono raggi cosmici e a noiosi viaggi interplanetari lunghi mesi).\nSecondo alcune interpretazioni, quindi, può essere che avesse ragione Guzzanti.\ninfine,\nprima di andare ricordati di mettere un cuoricino qua sotto❤️\n👋 A presto, damicmer\n©futuro fortissimo|michele merelli\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!EhcX!,w_1456,c_limit,f_auto,q_auto:good,fl_lossy/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F3d37c623-05a8-45aa-b7c4-56595bceeb1e_480x270.gif",
+                        "caption": "Il radar di Tesla superumano: vede oltre il bus e pre-vede la presenza di un pedone."
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!jNWs!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F4ec168a1-70da-4994-8dc3-bf1c87ae20e1_620x323.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!RQPs!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F03663aa4-673f-455f-9429-fd2a90320286_1570x811.png",
+                        "caption": "AATB, Andrea Anner e Thibault Brevet: robot industriali in esplorazioni artistiche"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "la guida autonoma tra le strade di Roma?",
+                        "url": "https://www.linkedin.com/posts/brgndr_tesla-ha-rilasciato-un-footage-di-fsd-che-ugcPost-7329854505930375170-txYt?utm_source=share&utm_medium=member_android&rcm=ACoAABIxLMUBRUppy-bOKJj9naMo0QXZnkUNfBE"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    },
+                    {
+                        "text": "futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/"
+                    },
+                    {
+                        "text": "michele merelli",
+                        "url": "https://www.linkedin.com/in/michelemerelli/"
+                    }
+                ],
+                "connections": []
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff128-la-mente-ci-limita",
+        "title": "🎼 ff.128 La mente ci limita?",
+        "error": "HTTP 404"
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff127-jazz-con-chatgpt",
+        "title": "🎼 ff.127 Jazz con ChatGPT",
+        "subtitle": "Perché umanesimo e scienza devono tornare a parlarsi?",
+        "keypoints": [
+            "Rick Rubin: da Adele a Anthropic",
+            "Ma cos’è ilvibe coding?",
+            "Leopardi riscrive l’equazione di Schrödinger"
+        ],
+        "subchapters": [
+            {
+                "title": "🛣️ ff.127.1 La terza vIA?",
+                "link": "https://fortissimo.substack.com/i/165079348/ff-la-terza-via",
+                "content": "Sin dal liceo, sono stato affascinato dall’intersezione tra umanesimo e sapere scientifico. Penso l’avrete capito anche da futuro fortissimo (🖼️ ff.18.3 L’arte, tra intelligenza artificiale e l’uomo,📜 ff.101.4 Web Poetico).\nSinteticità.Questa la mia tesi da sbarbino maturando, sulla capacità di condensare concetti con pochi segni: daSoldatidi Ungaretti all’equazione di Eulero.\nSinteticità come punto di contatto tra umanesimo e scienza.\nLe due culture,così distinte nell’omonimo saggio da Snow (1959), sono però sempre più distanti, anche per la crescente specializzazione.\n[…] ho chiesto ai presenti quanti di loro sapessero descrivere il Secondo Principio della Termodinamica. La risposta è stata negativa. Eppure stavo chiedendo l'equivalente scientifico di: “hai letto un'opera di Shakespeare?”C. P. Snow,Le due culture\nL’Intelligenza Artificiale può abbattere questo “muro di Berlino”?\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!UuiF!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F4594102c-46ac-47b2-b15a-bd97eaf3355f_880x324.png",
+                        "caption": "Varie interpretazioni e iterazioni “creative” della sinteticità tra poesia ed equazioni (micmer x o3)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Le due culture",
+                        "url": "https://amzn.to/3SBldB7"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🖼️ ff.18.3 L’arte, tra intelligenza artificiale e l’uomo",
+                        "url": "https://fortissimo.substack.com/i/49403403/ff-larte-tra-intelligenza-artificiale-e-luomo"
+                    },
+                    {
+                        "text": "📜 ff.101.4 Web Poetico",
+                        "url": "https://fortissimo.substack.com/i/147431787/ff-web-poetico"
+                    }
+                ]
+            },
+            {
+                "title": "🤘 ff.127.2 Rock ‘n’ roll e vibe coding",
+                "link": "https://fortissimo.substack.com/i/165079348/ff-rock-n-roll-e-vibe-coding",
+                "content": "Secondo il mitico Rick Rubin (🎤 ff.101.1 Il manager di Adele), sì.\nEntersvibe coding.Per dimostrarlo, Rick ha lavorato con Anthropic per creareThe Way of Code, un software-libro interattivo che “remixa” messaggi del Tao di 3000 anni fa (☯️ ff.108.3 Essere acqua)con concetti contemporanei.\nRick paragona ChatGPT alla rivoluzione del jazz: permette di rimescolare elementi, non solo sonori, ma culturali (🐆 ff.127.3 Leopardi e l’equazione di Schrödinger).\nPerò, però, però.L’AI non deve essere un semplice copia e incolla: la prima risposta, per la natura statistica degli LLMs, è  “comune”, banale, poco creativa.\nRick spiega come usa l’AI: lo fa in modo iterativo, con domande e commenti, allineando sempre più le risposte col suo gusto artistico. Lo stesso metodo che utilizzava nei primi lavori con Johnny Cash.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!5hJh!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fcb6904cf-d041-48f1-9ecc-5e5831cf9dbb_878x445.png",
+                        "caption": "Il podcast di A16Z con Rick Rubin e il suo nuovo libro The Way of Code(futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "The Way of Code",
+                        "url": "https://www.thewayofcode.com/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🎤 ff.101.1 Il manager di Adele",
+                        "url": "https://fortissimo.substack.com/i/147431787/ff-il-manager-di-adele"
+                    },
+                    {
+                        "text": "☯️ ff.108.3 Essere acqua",
+                        "url": "https://fortissimo.substack.com/i/148256057/ff-essere-acqua"
+                    }
+                ]
+            },
+            {
+                "title": "🐆 ff.127.3 Leopardi e l’equazione di Schrödinger",
+                "link": "https://fortissimo.substack.com/i/165079348/ff-leopardi-e-lequazione-di-schrodinger",
+                "content": "Perché ora? Due anni fa, l’arte generativa dava scarsi risultati (🌳 ff.35.5 L'infinito di Leopardi secondo l’AI). Oggi è tutta un’altra musica (remixata).\nEcco una poesia in stile Leopardi dell’Equazione di Schrödinger:\nOnda ch’ignota dimori —ψ, tenuesospir dell’essere, in spazi ove il nullaparla con voce d’Hilbert —, ascolta:ché l’algebra del cosmo entro il tuo grembod’ombra risuona.Là, fra silenzidove il gran vuoto ricama la tramadel tempo, il segno∂/∂tt’accarezzae, con costante di Planck —ħ, lievecencio stellare —, t’invola. Il quadratodel modulo tuo — mistica densitàdi probabil verità — si fafugace patria d’ogni particella,che mai possiede stanza o confine,ma vaga, spera, decade.Cosìl’operatore Laplaciano, arcanoscalpello dell’infinito, t’incidesu potenziale campo,V(x),mentre la massa, timida ancella,in ogni punto rifrange l’equilibriotra impulso e destino.Eternosi libra allora l’equazione, severa:iħ ∂ψ/∂t = [−ħ²∇²/2m + V]ψ,lido d’incertezza dove il realeoscilla e tace, quasi sperassecon poesia d’elettrone nascosto scorgere fine al cieco divenire.Oh dolce illusïon! Che ancor m’affannia porre misura al moto del cuore,se pur la luna nel cielo profondonon sa se stessa, e noi, larve d’atomi,in un sol verso di Schrödinger, erriamo.micmer x o3 x Leopardi,Onde\n“l’operatore Laplaciano, arcano scalpello dell’infinito”“noi, larve d’atomi”“ħ, lieve cencio stellare”\nSe non è poetico questo…\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!YnaO!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F4de83c8a-71aa-4002-8b44-fb4f936ea7d6_181x44.svg",
+                        "caption": "L’Equazione di Schrödinger spiegata a un bambino di 5 anni con ChatGPT"
+                    }
+                ],
+                "references": [],
+                "connections": [
+                    {
+                        "text": "🌳 ff.35.5 L'infinito di Leopardi secondo l’AI",
+                        "url": "https://fortissimo.substack.com/i/147431787/ff-web-poetico"
+                    }
+                ]
+            },
+            {
+                "title": "🚁 ff.127.4 E Palantir che c’entra?",
+                "link": "https://fortissimo.substack.com/i/165079348/ff-e-palantir-che-centra",
+                "content": "L’umanesimo è anche cura per venti di guerra.\nNel suo recente libro, il co-fondatore di Palantir Alex Karp denuncia una Silicon Valley senza senso nazionale e militare.\nGli ingegneri della Silicon Valley si rifiutano di lavorare con l’esercito americano, ma non esitano a raccogliere fondi per costruire il prossimo social network alienante.Il numero di laureati in materie umanisticheè passato dal 14 al 7% (179k) dal 1966 ad oggi, mentre il numero di iscritti aingegneria informatica è arrivato a 90k nel 2020.Abbiamo bisogno di ingegneri curiosi del mondo, della sua storia, delle sue contraddizioni; non solo capaci di programmare.Alex Karp,The Technological Republic\nIn passato, ho sostenuto che🎼 ff.14 La guerra non è futuro. Però, Mariana Mazzucato ci ricorda nel suo libro,Lo Stato innovatore, che internet e GPS sono frutto del Dipartimento della Difesa americano. Poi, sono arrivati Instagram e Uber.\nInsomma, se l’AI permette a Rick Rubin di diventare un programmatore, così la Silicon Valley deve riscoprire arte, storia e filosofia.\nPer una terza via pacifista, ma consapevole dei rischi che il software, nuovo “nucleare”, pone rispetto al futuro dell’umanità.\n🎶archivio note fortissime\n👋 A presto, damicmer\n©futuro fortissimo|michele merelli\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!TXy7!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F396d2ac9-8074-4acb-8a49-a482ccc4a4bd_864x458.png",
+                        "caption": "Il monito di 10 anni fa di naval sui droni come prossime bombe nucleari(futuro fortissimo)"
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!9aQF!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F7988faa4-53e7-4847-aa17-efdb321655c4_975x1500.jpeg",
+                        "caption": "Il libro del fondatore di Palantir, Alex Karp,The Technological Republic(futuro fortissimo)"
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!YBN5!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F9c773f73-70ef-431c-b15c-eb1365552df0_309x482.png",
+                        "caption": "Tra bellezza e guerra:Diaries of WarUcraina-Russia di Nora Krug(futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "è passato dal 14 al 7% (179k) dal 1966 ad oggi",
+                        "url": "https://www.amacad.org/humanities-indicators/higher-education/bachelors-degrees-humanities#31600"
+                    },
+                    {
+                        "text": "ingegneria informatica è arrivato a 90k nel 2020",
+                        "url": "https://www.reddit.com/r/dataisbeautiful/comments/ocpf0g/oc_us_computer_science_bachelors_degrees_awarded/"
+                    },
+                    {
+                        "text": "Lo Stato innovatore",
+                        "url": "https://amzn.to/4l5Sqks"
+                    },
+                    {
+                        "text": "archivio note fortissime",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    },
+                    {
+                        "text": "futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/"
+                    },
+                    {
+                        "text": "michele merelli",
+                        "url": "https://www.linkedin.com/in/michelemerelli/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🎼 ff.14 La guerra non è futuro",
+                        "url": "https://fortissimo.substack.com/p/-ff14-la-guerra-non-e-futuro?utm_source=publication-search"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff126-google-fine-o-rinascita",
+        "title": "🎼 ff.126 Google: fine o rinascita?",
+        "subtitle": "L'importanza di reinventarsi, anche quando tutto va bene",
+        "keypoints": [
+            "Dai campi di sterminio a Intel: paranoia",
+            "Veo 3: la fine di Hollywood?",
+            "Google e premi Nobel?"
+        ],
+        "subchapters": [
+            {
+                "title": "🔯 ff.126.1 Da campi di sterminio a Intel",
+                "link": "https://fortissimo.substack.com/i/164288050/ff-da-campi-di-sterminio-a-intel",
+                "content": "Andy Grove è sopravvissuto all’Olocausto. Poi, emigrato in America dall’Ungheria, ha guidato sin dalla sua nascita, Intel (co-fondata con Moore, quello della legge).\nNonostante la sua formazione tecnica, si è reinventato manager operativo, raccogliendo successi tanto da essere nominatoTime Man of The Year 1997.\nParanormal activity.La stessa paranoia fomentata dalla gioventù tra guerra e nazismo, ha salvato Intel dalla competizione giapponese: Andy spostò nel 1985 il focus aziendale dalla memoria (DRAM) ai chip.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!EXsz!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F5f7167e9-bd71-40e4-9818-ec52a648ee2d_971x1500.jpeg",
+                        "caption": "Only the paranoid survive(via futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Andy Grove è sopravvissuto all’Olocausto",
+                        "url": "https://en.wikipedia.org/wiki/Andrew_Grove"
+                    },
+                    {
+                        "text": "Time Man of The Year 1997",
+                        "url": "https://time.com/4267150/andrew-grove-intel-survivor-biography-budapest/"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🐦 ff.126.2 Non è la fine di Google",
+                "link": "https://fortissimo.substack.com/i/164288050/ff-non-e-la-fine-di-google",
+                "content": "Sterminio ChatGPT e Perplexity?Google oggi è in una situazione simile. Il 50% del suo business, Google Search ($200 miliardi l’anno) è sotto attacco. In più, Apple pensa di sostituirlo come default su Safari (nonostante Google paghi $20 miliardi per questo privilegio).\nDurante l’annuale conferenza Google I/O, il gigante ha mostrato tutte le sue carte:\nVeo 3, modellotext-to-videocon qualità alla Hollywood, consistenza di personaggi e integrazione audio e dialoghi.Un caso cheveo, in spagnolo, voglia dire vedere?Veo veo.¿Qué ves?Una cosita.¿Qué cosa es?Empieza por \"C\".¿Qué será qué será qué será?\nTraduzioni audio simultanee in Google Meet(mantenendo voce ed espressività).Smart-glasses potenziati dall’AI (Android XR Glasses) e televisori in grado di creare avatar 3D (Google Beam).\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!dWlP!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F6a9509b3-f088-4081-8e33-765b672f034d_2160x2700.webp",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Traduzioni audio simultanee in Google Meet",
+                        "url": "https://www.youtube.com/watch?v=hyXqcsWOONo"
+                    },
+                    {
+                        "text": "Android XR Glasses",
+                        "url": "https://blog.google/products/android/android-xr-gemini-glasses-headsets/"
+                    },
+                    {
+                        "text": "Google Beam",
+                        "url": "https://blog.google/technology/research/project-starline-google-beam-update/"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "❎ ff.126.3 La luna di Google: X",
+                "link": "https://fortissimo.substack.com/i/164288050/ff-la-luna-di-google-x",
+                "content": "Ecco i vantaggi secondo Sundar Pichai, CEO di Google, rispetto a OpenAI, Antrophic, Meta e Perplexity:\nProdotti diffusi nella popolazione.Gmail, YouTube, Cloud.Chip personalizzati.Sviluppo interno delle Tensor Processing Units (TPUs) ora alla 7° generazione, con Ironwood, 40+ exaflops.X, Alphabeth’s Moonshoot Factory. Fucina di ricerche su guida autonoma (Waymo), computer quantistici e biologia (🎼 ff.28 Google ricerca il futuro).Nobel.Riconoscimento raramente assegnato ad aziende private, vinto daDemis Hassabis per la Chimica 2024(🧬 ff.4.1 La struttura delle proteine).\nInsomma, Google non è solo search.\n",
+                "images": [],
+                "references": [
+                    {
+                        "text": "Demis Hassabis per la Chimica 2024",
+                        "url": "https://en.wikipedia.org/wiki/Demis_Hassabis"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🎼 ff.28 Google ricerca il futuro",
+                        "url": "https://fortissimo.substack.com/p/-ff24-google-ricerca-il-nostro-benessere?utm_source=publication-search"
+                    },
+                    {
+                        "text": "🧬 ff.4.1 La struttura delle proteine",
+                        "url": "https://fortissimo.substack.com/i/44077581/ff-la-struttura-delle-proteine"
+                    }
+                ]
+            },
+            {
+                "title": "🅰️ ff.126.4 AlphaEvolve",
+                "link": "https://fortissimo.substack.com/i/164288050/ff-alphaevolve",
+                "content": "Chicca finale.Dopo AlphaGo e AlphaStar, Google/DeepMind ha recentemente presentatoAlphaEvolve. Non per vincere ai videogiochi, ma per rivoluzionare la matematica.\nMentre espande le frontiere della matematica (nuovo record di 593 sfere nel“problema dei baci” in 11 dimensioni), riduce dell’1% il consumo dei data center (miglioral’algoritmo di Strassen imbattuto dal 1969).\n🎶archivio note fortissime\n👋 A presto, damicmer\n©futuro fortissimo|michele merelli\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!jcqn!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F5408e125-ab17-469e-989d-9664f362797c_1229x754.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!5Wab!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fbba776bb-3a49-4440-b198-54f4de01d8f8_1440x808.bin",
+                        "caption": "Isle of Any: la pubblicità di Coinbase per i playoff NBA 2025(It’s Nice That, futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "AlphaEvolve",
+                        "url": "https://storage.googleapis.com/deepmind-media/DeepMind.com/Blog/alphaevolve-a-gemini-powered-coding-agent-for-designing-advanced-algorithms/AlphaEvolve.pdf"
+                    },
+                    {
+                        "text": "“problema dei baci” in 11 dimensioni",
+                        "url": "http://en.wikipedia.org/wiki/Kissing_number"
+                    },
+                    {
+                        "text": "l’algoritmo di Strassen imbattuto dal 1969",
+                        "url": "https://it.wikipedia.org/wiki/Algoritmo_di_Strassen"
+                    },
+                    {
+                        "text": "archivio note fortissime",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    },
+                    {
+                        "text": "futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/"
+                    },
+                    {
+                        "text": "michele merelli",
+                        "url": "https://www.linkedin.com/in/michelemerelli/"
+                    }
+                ],
+                "connections": []
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff125-usa-crollo-di-un-impero",
+        "title": "🎼 ff.125 USA: crollo di un impero",
+        "subtitle": "Chi sostituirà l'America? Cina o Internet?",
+        "keypoints": [
+            "Criptovalute e debito USA: segnali allarmanti",
+            "Cosa si è detto alla conferenza Token 2049 di Dubai?",
+            "Cina o Internet: chi guiderà il mondo?"
+        ],
+        "subchapters": [
+            {
+                "title": "🏯 ff.125.1 Cicli imperiali",
+                "link": "https://fortissimo.substack.com/i/163689154/ff-cicli-imperiali",
+                "content": "Tre anni fa, parlavamo della visione di Ray Dalio, fondatore di Bridgewater e 88esima persona più ricca al mondo, sul possibile arrivo di un nuovo ordine mondiale (📈 ff.14.2 Nostradamus: Ray Dalio e l’ordine mondiale).\nQualunque grande potenza che spenda più per debito che per la difesa rischia di cessare di essere una grande potenza.Niall Ferguson,Debt Has Always Been the Ruin of Great Powers. Is US the Next?\nDurante questo periodo di malattia e guarigione, ho esplorato meandri nascosti di YouTube. Tra le scoperte, le registrazioni della conferenzaTOKEN 2049 di Dubai.\nIn uno dei talk, Lily Liu (Solana Foundation, SOL = quarta criptovaluta per capitalizzazione di mercato) ha mostrato questo grafico.\nAnche se probabilmente sbagliato nei numeri (8000% è 80x, non 800x), il messaggio è chiaro: dal 1970 il PIL USA è cresciuto 20volte. Il debito pubblico? 83 volte.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!mDeI!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fe33ec731-07a8-4c03-8956-77775cb4b917_1407x791.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Debt Has Always Been the Ruin of Great Powers. Is US the Next?",
+                        "url": "https://www.wsj.com/politics/policy/debt-has-always-been-the-ruinof-great-powers-is-the-u-s-next-02f16402?utm_source=nomercynomalice.beehiiv.com&utm_medium=newsletter&utm_campaign=the-fix&_bhlid=87e4cf109ad453a93745f94e0fd0f5a938245164"
+                    },
+                    {
+                        "text": "TOKEN 2049 di Dubai",
+                        "url": "https://www.dubai.token2049.com/speakers"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "📈 ff.14.2 Nostradamus: Ray Dalio e l’ordine mondiale",
+                        "url": "https://fortissimo.substack.com/i/49335079/ff-nostradamus-ray-dalio-e-lordine-mondiale"
+                    }
+                ]
+            },
+            {
+                "title": "💵 ff.125.2 Stabilizzare il dollaro",
+                "link": "https://fortissimo.substack.com/i/163689154/ff-stabilizzare-il-dollaro",
+                "content": "Ilmoney-printing, insomma, e la ben nota inflazione. Per un’azione di S&P500 in quegli anni bastavano 25 ore di lavoro, oggi servono 24giornidi lavoro.\nUna delle risposte? Le stablecoin: valute digitali il cui valore è stabilizzato algoritmicamente.\nSempre più diffuse, specialmente nei BRICS e in Arabia Saudita, in 5 anni hanno superato VISA e Mastercard per quantità di transazioni (15T$ nel 2024).\nNon a caso, Stripe ha annunciatol’integrazione di pagamenti con Stablecoins.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!bzJ-!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F70c565ec-5001-40f1-9f4e-022b43d6d9d7_1199x657.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!SGFk!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fcc681581-5b5d-4178-9399-afd1675a053b_1204x798.jpeg",
+                        "caption": "Valore monetario di transizioni annuali per Visa, Mastercard, American Express e Stablecoins, ARK Invest Big Ideas 2025(via futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "l’integrazione di pagamenti con Stablecoins",
+                        "url": "https://docs.stripe.com/crypto/stablecoin-financial-accounts"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🏮 ff.125.3 Cina: il prossimo impero mondiale?",
+                "link": "https://fortissimo.substack.com/i/163689154/ff-cina-il-prossimo-impero-mondiale",
+                "content": "Se l’impero americano sta cedendo, chi raccoglierà il testimone? Nel mondo fisico,laCina sembra la candidata più credibile.\nAvendo visitato Shenzhen (città costruita in 40 anni, ora la terza per popolazione,🏆 ff.117.1 Giornate da Oscar), mi ha stupito quanto la Cina odierna sia lontana anni luce da quella di 25 anni fa, immersa in nubi tossiche di smog:\nConsumo energetico: da 2.5k a 10k TWh (USA fermi a 4k), di cui l’8% da energia solare.\nNucleare: leader in impianti pianificati, seconda l’India.\nAlta velocità: 45.000 km partendo da zero. Altro che TAV…Alta velocità cinese: 45.000 km in meno di 20 anni(brilliantmaps x futuro fortissimo)\nStagnazione che?Storrs Hall, nell’omonimo libro provocatorio, si chiedeva dove fosse la sua auto volante (😭 ff.46.3 Anni buttati). La risposta è: proprio a Shenzhen.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!dvYm!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F028e8478-d588-4424-90a0-279eaf4ff8cf_1454x1679.jpeg",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!v_JA!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fe30994a4-a5e5-4b15-8a55-7bbb1b6e7998_1165x646.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "",
+                        "url": "https://substackcdn.com/image/fetch/$s_!ge72!,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F4ba9dead-9af9-4284-8e4a-b3a481bcd85f_1788x768.png"
+                    },
+                    {
+                        "text": "Alta velocità cinese: 45.000 km in meno di 20 anni",
+                        "url": "https://brilliantmaps.com/high-speed-rail-china/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🏆 ff.117.1 Giornate da Oscar",
+                        "url": "https://fortissimo.substack.com/i/157086176/ff-giornate-da-oscar"
+                    },
+                    {
+                        "text": "😭 ff.46.3 Anni buttati",
+                        "url": "https://fortissimo.substack.com/i/90882152/ff-anni-buttati"
+                    }
+                ]
+            },
+            {
+                "title": "🌐 ff.125.4 L’alternativa alla Cina: Internet",
+                "link": "https://fortissimo.substack.com/i/163689154/ff-lalternativa-alla-cina-internet",
+                "content": "Cosa fate appena svegli? Guardate il telefono o ammirate la bandiera nazionale?\nCon questa provocazione, Balaji Srinivasan (ex CTO di Coinbase e general partner diA16Z,🌐 ff.52.3 Fondare la propria nazione) propone un’alternativa al dominio cinese:Internet come nuova nazione.\nLo Stato tradizionale è sempre più inefficiente (🎼 ff.110 Uno Stato da mantenere), il cittadino è sempre più online ed è stanco di vedere la sua vita influenzata da sbalzi emotivi/geopolitici di leader con la smania di potenza.\nLa stabilità di Bitcoin, “moneta di Internet”, durante il recente crollo finanziario per i dazi di Trump, è indicativa.\nCVD.Coinbase entra nell’SP500.\n🎶archivio note fortissime\n👋 A presto, damicmer\n©futuro fortissimo|michele merelli\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!FR3p!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F54171608-7605-4d5b-8d02-bbfb04ebb6d8_1920x1080.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!qsgZ!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Ff2e5f6b7-f12e-473d-bc22-bbb194eaf42f_584x315.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!5Wab!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fbba776bb-3a49-4440-b198-54f4de01d8f8_1440x808.bin",
+                        "caption": "Isle of Any: la pubblicità di Coinbase per i playoff NBA 2025(It’s Nice That, futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "A16Z",
+                        "url": "https://a16z.com/"
+                    },
+                    {
+                        "text": "Internet come nuova nazione",
+                        "url": "https://www.youtube.com/watch?v=cTacROXRbwQ&t=377s"
+                    },
+                    {
+                        "text": "Coinbase entra nell’SP500",
+                        "url": "https://www.ilsole24ore.com/art/coinbase-entra-nell-indice-sp-500-AHL3IPj"
+                    },
+                    {
+                        "text": "archivio note fortissime",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    },
+                    {
+                        "text": "futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/"
+                    },
+                    {
+                        "text": "michele merelli",
+                        "url": "https://www.linkedin.com/in/michelemerelli/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🌐 ff.52.3 Fondare la propria nazione",
+                        "url": "https://fortissimo.substack.com/i/83498036/ff-fondare-la-propria-nazione"
+                    },
+                    {
+                        "text": "🎼 ff.110 Uno Stato da mantenere",
+                        "url": "https://fortissimo.substack.com/p/ff110-uno-stato-da-mantenere?utm_source=publication-search"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff124-ah-ia",
+        "title": "🎼 ff.124 Ah-IA!",
+        "subtitle": "Cadere in bici ai tempi di ChatGPT",
+        "keypoints": [
+            "Dalì e radiologi a portata di smartphone",
+            "ChatGPT meglio del tuo medico?",
+            "Emicrania sconfitta dopo anni di tentativi falliti"
+        ],
+        "subchapters": [
+            {
+                "title": "🦴 ff.124.1 Dalì sciogli clavicole",
+                "link": "https://fortissimo.substack.com/i/162941285/ff-dali-sciogli-clavicole",
+                "content": "Sono caduto in bici. O meglio, mi han fatto cadere. Risultato: 30 giorni di divano forzato e un'immersione nell'AI che non avevo previsto.\nIn🎼 ff.109 Medico in famigl-IAparlavamo di come ChatGPT non sia solo per immagini buffe o email automatiche, ma possa impattare la vita quotidiana.\nCon questo infortunio, ne ho avuto conferma.\nInnanzitutto, mi ha aiutato a sdrammatizzare. Clavicole che si sciolgono come orologi di Dalì, selfie post-trauma trasformato in emoji e sketch cubista.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!T11l!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F0b6556b9-09d7-4a72-92e6-6ce22630a4d3_758x411.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [],
+                "connections": [
+                    {
+                        "text": "🎼 ff.109 Medico in famigl-IA",
+                        "url": "https://fortissimo.substack.com/p/ff109-medico-in-famigl-ia"
+                    }
+                ]
+            },
+            {
+                "title": "✍️ ff.124.2 Longa manus",
+                "link": "https://fortissimo.substack.com/i/162941285/ff-longa-manus",
+                "content": "Abbiamo anche visto che l’AI è una “longa manus”, autonoma e in grado di fare lavoro per noi (🎼 ff.119 Mani ovunque).\nDato che digitare a tastiera mi è al momento impossibile, mi ha aiutato a dare forma a questa newsletter, trascrivendo le mie note vocali e fornendo revisioni stilistiche.\nPer ilterzo paziente di Neuralink (paralizzato dalla SLA) questo è l’unico modo per postare su X.\nBonus.Neuroprotesi convertono in tempo reale pensieri in dialoghi, fino a 90 parole al minuto.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!rxNG!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F1047d8f4-72a4-43ef-a821-0f1652fe7785_593x659.png",
+                        "caption": "Bradford Smith: il terzo paziente Neuralink affetto da SLA(via futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "terzo paziente di Neuralink (paralizzato dalla SLA) questo è l’unico modo per postare su X.",
+                        "url": "https://x.com/ALScyborg/status/1916630186382291242?t=BDPESOX_wwbnrQsESArUDQ&s=33"
+                    },
+                    {
+                        "text": "Neuroprotesi convertono in tempo reale pensieri in dialoghi, fino a 90 parole al minuto",
+                        "url": "https://www.nature.com/articles/s41593-025-01905-6"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🎼 ff.119 Mani ovunque",
+                        "url": "https://fortissimo.substack.com/p/ff119-mani-ovunque"
+                    }
+                ]
+            },
+            {
+                "title": "🩺 ff.124.3 Medico in famiglia (e in tasca)",
+                "link": "https://fortissimo.substack.com/i/162941285/ff-medico-in-famiglia-e-in-tasca",
+                "content": "Online altri esempi di come l’intelligenza artificiale risolva problemi di salute, fisici e reali. Tanto che Reid Hoffman, co-founder di LinkedIn, parla disuperagency:\nIn Italia possiamo ancora contare su una sanità pubblica solida, anche se sempre più sotto pressione. Ma immaginate di vivere in Nigeria o Argentina, con pochi soldi e nessun accesso a medici esperti.\nOppure, pur avendo risorse, non trovare nessuno che capisca davvero cosa vi affligge (comel’imprenditrice di Y Combinator che ha sconfitto l’emicrania dopo anni).\nL’AI sta democratizzando e facilitando l’accesso a tutto ciò.\nCosì, durante questa convalescenza,ChatGPT (o3) è diventato il mio radiologo personale(e dopo 10 giorni dalla caduta ha analizzato il video di un movimento che facevo e suggerito di non ripeterlo, essendo troppo prematuro!).\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!hPRd!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fcdabfc22-a8de-4066-a19d-91c8c688a896_590x552.png",
+                        "caption": "Reid Hoffman, fondatore di LinkedIn, sostenitore dell’AI(via futuro fortissimo)"
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!PsvX!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F05dcdb24-c1c7-4098-a51e-d70e8f62466a_734x791.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "l’imprenditrice di Y Combinator che ha sconfitto l’emicrania dopo anni",
+                        "url": "https://x.com/yanatweets/status/1916160569293394251"
+                    },
+                    {
+                        "text": "ChatGPT (o3) è diventato il mio radiologo personale",
+                        "url": "https://micmer.notion.site/Analisi-frattura-clavicola-o3-1eb41b31f60e80d19f19f19e05f1d485?pvs=4"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🤹 ff.124.4 ChatGPT tuttofare",
+                "link": "https://fortissimo.substack.com/i/162941285/ff-chatgpt-tuttofare",
+                "content": "Mi ha anche guidato in esercizi di fisioterapia, ha costruito un piano di recupero per il mio Ironman di settembre (finger crossed) e fornito una review stile PhD sull’uso dicollagene + vitamina C per favorire ricrescita ossea.\nInsomma, ChatGPT non sarà il miglior medico del mondo, ma spesso è meglio di quello disponibile: stressato, di fretta, con 5 minuti per noi dopo un turno di 12 ore.\nE voi come state usando questasuperagency? Scrivetemelo nei commenti!\nE forse non finisci gambe all'aria, ahTi prego fatti dire, amore mioChe eri davvero bellaQuando cadevi e dicevi, \"Ahia!\"Pinguini Tattici Nucleari,Ahia!\n🎶archivio note fortissime\n👋 A presto, damicmer\n©futuro fortissimo|michele merelli\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!xPK6!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F193b6de6-8816-4615-867b-1d3dc11db9f3_729x516.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!sZsy!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F932f35cb-31bd-4f45-8f11-6fca3e9dd987_500x500.jpeg",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "collagene + vitamina C per favorire ricrescita ossea",
+                        "url": "https://chatgpt.com/share/681a4e45-541c-8000-b8dd-62dafdf1990f"
+                    },
+                    {
+                        "text": "archivio note fortissime",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    },
+                    {
+                        "text": "futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/"
+                    },
+                    {
+                        "text": "michele merelli",
+                        "url": "https://www.linkedin.com/in/michelemerelli/"
+                    }
+                ],
+                "connections": []
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff123-a-caccia-di-diamanti",
+        "title": "🎼 ff.123 A caccia di diamanti",
+        "subtitle": "OpenAI o3 con coltellino svizzero è AGI?",
+        "keypoints": [
+            "L’AI che trova diamanti su Minecraft (da sola)",
+            "Il team di DeepMind: cos’è l’Era dell’Esperienza?",
+            "Pokémon-filosofi e Harry Potter al rave: non solo Ghibli"
+        ],
+        "subchapters": [
+            {
+                "title": "🛠️ ff.123.1 L’AI con il coltellino svizzero",
+                "link": "https://fortissimo.substack.com/i/161516506/ff-lai-con-il-coltellino-svizzero",
+                "content": "Se Tayler Coen (teorico della “grande stagnazione”,🤔 ff.50.1 La stranezza degli ultimi 50 anni),dice che il 16 aprile 2025 ha visto l’AGI (o un porno), bisogna fermarsi.\nIn quel giorno, OpenAI ha reso pubblico il tanto atteso o3.\nIn passato, sono stati contestati a ChatGPT errori matematici banali (⚠️ ff.48.4 I limiti (matematici) di ChatGPT). La soluzione? Dargli accesso a una calcolatrice, per esempio.\no3 combina nei suoi pensieri (chain of thought) vari “strumenti” (screenshots, navigazione web, lancio codici python), raggiungendo unIQ di 136 (1% popolazione umana, l’anno scorso il record era 94).\nPer darvi un’idea,risolve un labirinto mostrando il percorso.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!X5co!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fbc4995fd-8041-440a-9eba-d4cce2ef7463_672x415.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!71Cy!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F788b6354-831f-4498-b6c7-b039a362e914_378x375.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "IQ di 136 (1% popolazione umana, l’anno scorso il record era 94)",
+                        "url": "https://www.maximumtruth.org/p/skyrocketing-ai-intelligence-chatgpts"
+                    },
+                    {
+                        "text": "risolve un labirinto mostrando il percorso.",
+                        "url": "https://openai.com/index/thinking-with-images/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🤔 ff.50.1 La stranezza degli ultimi 50 anni",
+                        "url": "https://fortissimo.substack.com/i/90181693/ff-la-stranezza-degli-ultimi-anni"
+                    },
+                    {
+                        "text": "⚠️ ff.48.4 I limiti (matematici) di ChatGPT",
+                        "url": "https://fortissimo.substack.com/i/95768574/ff-i-limiti-matematici-di-chatgpt"
+                    }
+                ]
+            },
+            {
+                "title": "💎 ff.123.2 Minecraft oltre l’uomo",
+                "link": "https://fortissimo.substack.com/i/161516506/ff-minecraft-oltre-luomo",
+                "content": "In tutto questo, l’uomo è sempre più limitante. Il collo di bottiglia.\nCome AlphaGo (allenato su partite umane) è stato battuto da AlphaZero (che si è allenato “da solo”)♟️ ff.18.4 Chess(i) artistici: il re degli scacchi.\nL’AI capisce più di noi, ad esempio il linguaggio/struttura delle proteine (⚛️ ff.98.4 Sistemi quantistici)\nDavid Silver e Richard Sutton - pionieri delreinforcement learning(RL) - sostengono in un nuovo paper che siamo entrati nel’Era dell’Esperienza: sistemi autonomi/agenti che in ogni ambito esplorano il mondo e possibili soluzioni, senza bisogno di conferme umane.\nCercare diamanti in Minecraft.DreamerV3 di Google/DeepMind3è un esempio di questa nuova fase tecnologica.\nPur non avendo mai visto giocare Minecraft (e non coscendone le regole), in 100 milioni di passi ha imparato a rompere alberi, costruire bastoni e migliorare picconi. Fino ad arrivare al suo primo blocco di diamante.\nBevi fuori dal coro.Dan Hendrycks, direttore delCenter for AI Safetysostiene invece chelasciare evolvere l’AI in modo indipendente è la nostra fine.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!pG-F!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F53b6d5f7-d0d8-4a7b-be9f-c24ce09e7211_794x455.png",
+                        "caption": "L’Era dell’Esperienza: il prossimo step verso l’AGI o l’estinzione umana?(via futuro fortissimo)"
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!_PPP!,w_1456,c_limit,f_auto,q_auto:good,fl_lossy/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F9f85463c-9884-4883-a8fc-e5946a48f725_640x384.gif",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!AK9k!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F18b51159-c4aa-44a1-87d5-72e6301ec4f1_728x369.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "l’Era dell’Esperienza",
+                        "url": "https://storage.googleapis.com/deepmind-media/Era-of-Experience%20/The%20Era%20of%20Experience%20Paper.pdf"
+                    },
+                    {
+                        "text": "DreamerV3 di Google/DeepMind3",
+                        "url": "https://danijar.com/project/dreamerv3/"
+                    },
+                    {
+                        "text": "lasciare evolvere l’AI in modo indipendente è la nostra fine",
+                        "url": "https://arxiv.org/abs/2303.16200"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "♟️ ff.18.4 Chess(i) artistici: il re degli scacchi",
+                        "url": "https://fortissimo.substack.com/i/49403403/ff-chessi-artistici-il-re-degli-scacchi"
+                    },
+                    {
+                        "text": "⚛️ ff.98.4 Sistemi quantistici",
+                        "url": "https://fortissimo.substack.com/i/145245800/ff-sistemi-quantistici"
+                    }
+                ]
+            },
+            {
+                "title": "🗺️ ff.123.3 Il nuovo campione di GeoGuessr: o3",
+                "link": "https://fortissimo.substack.com/i/161516506/ff-il-nuovo-campione-di-geoguessr-o",
+                "content": "Per mostrare l’abilità di combinare vari strumenti, tra cui le mappe, il sempre puntualeEthan Mollick ha fatto giocare o3 aGeoGuessr.\nIo invece gli ho chiestoquando il sole sorgerà tra due monti che vedo fuori dalla finestra.\nHa identificato i monti, usato formule a me sconosciute e pure ipotizzato un margine di errore in base a dove mi posizioni per ammirare l’alba (se sul sagrato o nel parcheggio del cimitero).\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!GFlA!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fa8e1d797-fc4d-4704-9036-228ee6336d3a_623x341.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!uwSt!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F96e0c9fd-1e58-4697-8857-806e372e9f93_982x546.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!G7bj!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fb2230e0e-0951-4427-b9cd-7d86a52f8768_982x891.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Ethan Mollick ha fatto giocare o3 a",
+                        "url": "https://www.linkedin.com/posts/emollick_the-geoguessing-power-of-o3-is-a-really-good-activity-7318492211841560576-RXrq?utm_source=social_share_send&utm_medium=member_desktop_web&rcm=ACoAABIxLMUBRUppy-bOKJj9naMo0QXZnkUNfBE"
+                    },
+                    {
+                        "text": "GeoGuessr",
+                        "url": "https://www.geoguessr.com/"
+                    },
+                    {
+                        "text": "quando il sole sorgerà tra due monti che vedo fuori dalla finestra",
+                        "url": "https://chatgpt.com/share/68009609-f5f8-8000-951b-ac4f21d7797c"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🌊 ff.123.4 Non solo Studio Ghibli",
+                "link": "https://fortissimo.substack.com/i/161516506/ff-non-solo-studio-ghibli",
+                "content": "Dato che stiamo parlando di AI, torniamo sul tormentoneGhibli.\nCome noto, ilnuovo modello di generazione immagini di OpenAI(25 marzo):\nreplica accuratamente dettagli di immaginimigliora la precisione nei testiapplica qualsivoglia stile grafico\nIn scia a🦄 ff.40.1 Gotta catch ‘em all, gli ho così chiesto di immaginare gli starter di un Pokémon filosofico.\nRiprendendo invece🧙 ff.63.1 Harry Potter tra Pixar, steroidi e rave estivi), segnalo che sono uscite le foto dell’after party di quest’anno della festa di Hogwarts.\npablopromptA post shared by@pabloprompt\n🎶archivio note fortissime\n👋 A presto, damicmer\n©futuro fortissimo|michele merelli\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!nQ_1!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F8e45a349-1fa8-48d7-8995-cef786d3d855_1024x1536.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!Rhfl!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Ff335cd8e-89ae-4726-82a1-f0d4e3e1ad9c_1042x560.bin",
+                        "caption": "Il festival artistico Jupiter Artland di Edimburgo, ricreato durante il lockdown del 2020 in Minecraft(via futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "nuovo modello di generazione immagini di OpenAI",
+                        "url": "https://openai.com/index/introducing-4o-image-generation/"
+                    },
+                    {
+                        "text": "pabloprompt",
+                        "url": "https://instagram.com/pabloprompt"
+                    },
+                    {
+                        "text": "",
+                        "url": "https://instagram.com/p/DH9D-yBt-xN"
+                    },
+                    {
+                        "text": "@pabloprompt",
+                        "url": "https://instagram.com/pabloprompt"
+                    },
+                    {
+                        "text": "archivio note fortissime",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    },
+                    {
+                        "text": "futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/"
+                    },
+                    {
+                        "text": "michele merelli",
+                        "url": "https://www.linkedin.com/in/michelemerelli/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🦄 ff.40.1 Gotta catch ‘em all",
+                        "url": "https://fortissimo.substack.com/i/79764207/ff-gotta-catch-em-all"
+                    },
+                    {
+                        "text": "🧙 ff.63.1 Harry Potter tra Pixar, steroidi e rave estivi",
+                        "url": "https://fortissimo.substack.com/i/115845572/ff-harry-potter-tra-pixar-steroidi-e-rave-estivi"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff121-il-flow-ti-mette-le-ali",
+        "title": "🎼 ff.121 Il flow ti mette le ali?",
+        "subtitle": "Performance sovraumane senza senso (e senno)",
+        "keypoints": [
+            "E’ necessario per raggiungere l’impossibile?",
+            "Perché cerchiamo sempre più l’estremo?",
+            "Red Bull per cecchini dell’esercito americano?"
+        ],
+        "subchapters": [
+            {
+                "title": "🌊 ff.121.1 Le basi del flow",
+                "link": "https://fortissimo.substack.com/i/159901694/ff-le-basi-del-flow",
+                "content": "Ho incontrato per la prima volta l’idea di flow qualche anno fa, leggendo Mihaly Csikszentmihalyi: è quello stato mentale di totale immersione in un’attività che ci fa perdere il senso del sé e del tempo.\nCosa favorisce il flow?Il movimento fisico, il rischio, lacomplessità di un’attività (ma non troppa, la regola del 4%), la novità, la mancanza di distrazioni.\nGiocando, spesso finiamo nel flow. Non a caso è stato misurato per la prima volta neigiocatori di scacchi, con un aumento di onde teta e attivazione del \"sistema implicito\".\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!i_4G!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Ff423c13e-6aa3-4b9e-9219-b366ac61cd11_977x1500.jpeg",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "complessità di un’attività (ma non troppa, la regola del 4%",
+                        "url": "https://www.flowperformancepsych.com/post/2018/04/25/increasing-challenge-to-improve-performance-the-4-rule"
+                    },
+                    {
+                        "text": "giocatori di scacchi, con un aumento di onde teta e attivazione del \"sistema implicito\"",
+                        "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC7551835/#:~:text=Thereby%2C%20implicit%20systems%20are%20ultimately,the%20performer%20in%20the%20task."
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "💸 ff.121.2 Il flow ti mette le ali",
+                "link": "https://fortissimo.substack.com/i/159901694/ff-il-flow-ti-mette-le-ali",
+                "content": "Oltre a renderci felici, aumenta le nostre performance, con effetti socio-economici:\nMcKinsey: i manager nel flow sono cinque volte più produttivi.DARPA (l'agenzia difesa USA):cecchini militari bersaglio acquisiti2 voltepiù velocemente.Red Bull: ilNorth America’s High-Performance Centerguidato daLeslie Sherlin\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!2e57!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fc0529b5d-2b45-44ad-92bb-3e3dd8f31ad0_720x405.jpeg",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "McKinsey: i manager nel flow sono cinque volte più produttivi",
+                        "url": "https://www.mckinsey.com/capabilities/people-and-organizational-performance/our-insights/increasing-the-meaning-quotient-of-work"
+                    },
+                    {
+                        "text": "cecchini militari bersaglio acquisiti",
+                        "url": "https://www.mendeley.com/catalogue/c5c0b0a7-fff0-3bfc-b106-5bf47ab775f1/"
+                    },
+                    {
+                        "text": "2 volte",
+                        "url": "https://www.mendeley.com/catalogue/c5c0b0a7-fff0-3bfc-b106-5bf47ab775f1/"
+                    },
+                    {
+                        "text": "Red Bull: il",
+                        "url": "https://www.si.com/edge/2015/05/08/sweat-mecca-red-bull-high-performance-center"
+                    },
+                    {
+                        "text": "North America’s High-Performance Center",
+                        "url": "https://www.si.com/edge/2015/05/08/sweat-mecca-red-bull-high-performance-center"
+                    },
+                    {
+                        "text": "Leslie Sherlin",
+                        "url": "https://www.fuller.edu/adjunct/leslie-sherlin/"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "♟️ ff.122.3 Dagli scacchi alla Patagonia",
+                "link": "https://fortissimo.substack.com/i/159901694/ff-dagli-scacchi-alla-patagonia",
+                "content": "Pensavo che i benefici fossero solo mentali, così mi ha sorpreso trovarlo come spiegazione degli sport estremi.\nDi fronte alla concreta possibilità di morire (ultimate human performances) il flow è sempre presente, fa notare Steven Kotler inThe Rise of Superman.\nE apre le porte dell’impossibile:\nTony Hawk, skateboard, trick con rotazione di 900°Tyler Bradt, kayak, tuffo di 58 metriDean Potter, arrampicata, inventando ilfree solo(ma poi èmorto nel 2015 facendo BASE-jumping, RIP 🕊️),scalando il Fitz Roy in 6 ore e mezzaIl nuovo ChatGPT è fenomenale nel creare immagini (ma non ancora perfetto)\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!adMY!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fcdda0582-aa91-46a4-ad14-f0cbc1c9590f_975x1500.jpeg",
+                        "caption": "L'arte dell'impossibile. Che cosa innesca le prestazioni straordinarie(Steven Kotler 2021 futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "The Rise of Superman",
+                        "url": "https://amzn.to/3DVYHzh"
+                    },
+                    {
+                        "text": "Dean Potter, arrampicata, inventando il",
+                        "url": "https://publications.americanalpineclub.org/articles/12200232103/Fitz-Roy-Supercanaleta-and-Californian-Roulette-Cerro-Torre-Compressor-Route-Free-Solos-and-Speed-Solos"
+                    },
+                    {
+                        "text": "free solo",
+                        "url": "https://publications.americanalpineclub.org/articles/12200232103/Fitz-Roy-Supercanaleta-and-Californian-Roulette-Cerro-Torre-Compressor-Route-Free-Solos-and-Speed-Solos"
+                    },
+                    {
+                        "text": "morto nel 2015 facendo BASE-jumping",
+                        "url": "https://en.wikipedia.org/wiki/Dean_Potter"
+                    },
+                    {
+                        "text": "",
+                        "url": "https://substackcdn.com/image/fetch/$s_!MOCE!,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F38a292ba-8e9a-42f6-9551-4b4104311fdb_337x531.png"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🔺 ff.122.4 Piramidi in 4 minuti?",
+                "link": "https://fortissimo.substack.com/i/159901694/ff-piramidi-in-minuti",
+                "content": "Non basta più nemmeno un Ironman:Project Limitless di Mitchell Hutchcraft, un triatlon da 12.000 chilometri (34 km nel canale della Manica, 10.000 km in bici dalla Francia all’India e per finire un trekking leggero in Nepal fino all’Everest).\nrunnersworlditaA post shared by@runnersworldita\nPerché questa esplosione di flow ed estremo? Perché alziamo sempre più l’asticella?\nC’è dietro la piramide di Mashlow: garantiti sopravvivenza e cibo, servono stimoli per dare un senso alle giornate (🔺 ff.62.4 La piramide che c’è in tutti noi).\nEffetto Bannister.Dimostrata la fattibilità di qualcosa, un sacco di gente inizia a realizzarla (bene), ma il nuovo limite si sposta a un livello di rischio maggiore (male).\nQuesto effetto è visibile anche nella diffusione di nuove tecnologie:\nBONUS NERD.A proposito di “democratizzazione dell’impossibile”, ho chiesto a Claude il graficodei corridori in grado di coprire un miglio in 4 minuti (1755 nel 2022).\n☕caffè virtuale\n🎶archivio note fortissime\n👋 A presto, damicmer\n©futuro fortissimo|michele merelli\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!sQun!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F6e9b1e31-b121-47eb-86c3-85699ab71591_1200x949.jpeg",
+                        "caption": "Roger Bannister, il primo uomo a coprire 1.609 km in meno di 4 minuti(via futuro fortissimo)"
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!i8Th!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F7d149ec3-7b07-41d1-9c4b-68ec2d0f7c3b_1250x635.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!PN-I!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F8313b493-6089-4df1-9852-5c05820c2a90_891x548.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!k7zs!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F85f59576-e42b-408c-8636-78154cea7a98_724x563.bin",
+                        "caption": "Tsto per l’evento musicale Flow Festival (2018)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Project Limitless di Mitchell Hutchcraft",
+                        "url": "https://www.inov8.com/au/blog/post/project-limitless-meet-mitch-hutchcraft?srsltid=AfmBOopntUQT_S7evS2EYeuD8MYMM1_8L9bnSB51HoEOTFDA7qiNzX_M"
+                    },
+                    {
+                        "text": "runnersworldita",
+                        "url": "https://instagram.com/runnersworldita"
+                    },
+                    {
+                        "text": "",
+                        "url": "https://instagram.com/p/DH25_0xN6Qx"
+                    },
+                    {
+                        "text": "@runnersworldita",
+                        "url": "https://instagram.com/runnersworldita"
+                    },
+                    {
+                        "text": "dei corridori in grado di coprire un miglio in 4 minuti (1755 nel 2022).",
+                        "url": "https://nuts.org.uk/sub-4/Sub-4%20register%206%20June%202022.pdf"
+                    },
+                    {
+                        "text": "caffè virtuale",
+                        "url": "https://www.paypal.com/paypalme/MicheleMerelli"
+                    },
+                    {
+                        "text": "archivio note fortissime",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    },
+                    {
+                        "text": "futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/"
+                    },
+                    {
+                        "text": "michele merelli",
+                        "url": "https://www.linkedin.com/in/michelemerelli/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🔺 ff.62.4 La piramide che c’è in tutti noi",
+                        "url": "https://fortissimo.substack.com/i/118479393/ff-la-piramide-che-ce-in-tutti-noi"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff120-sport-e-longevita",
+        "title": "🎼 ff.120 Sport e longevità",
+        "subtitle": "Come muoversi allunga la vita, tra cancro e alimentazione",
+        "keypoints": [
+            "Se ci muoviamo, possiamo mangiare peggio?",
+            "Altro che zuccheri: lattato al cervello",
+            "Sport cura al cancro?"
+        ],
+        "subchapters": [
+            {
+                "title": "🏃🏼‍♂️ ff.120.1 Quanto correre per “scappare” alla morte?",
+                "link": "https://fortissimo.substack.com/i/155426992/ff-quanto-correre-per-scappare-alla-morte",
+                "content": "Il nostro futuro passa dalla salute, dal movimento, dallo sport. Ecco perché questi temi sono di casa.\nHow I METs your mother.In🎼 ff.86 Bruciare ossigeno è vitaabbiamo introdotto ilMetabolic Equivalent, unità di misura del movimento (in metabolismo basale = 1MET).\nFunziona anche se correte una maratona nello spazio:\nrunneralertsA post shared by@runneralerts\nUsandoil test di Bruce, uno studio ha suddiviso 750.000 persone rispetto al loro fitness metabolico (classificandoli per i METs che riuscivano a sostenere).\nAngolo nerd.10 METs corrispondono a correre 10 km in un’ora (6 min/km);relazione test di Cooper, VO2max e METs.\nTornando allo studio:chi sosteneva 14 METs dopo 20 anni è morto 4 volte in meno di chi si fermava a 5.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!I2oC!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fdcb6a0b5-5337-4759-89ef-65b133c25cff_801x404.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "runneralerts",
+                        "url": "https://instagram.com/runneralerts"
+                    },
+                    {
+                        "text": "",
+                        "url": "https://instagram.com/p/DHk1A3wMl8h"
+                    },
+                    {
+                        "text": "@runneralerts",
+                        "url": "https://instagram.com/runneralerts"
+                    },
+                    {
+                        "text": "il test di Bruce",
+                        "url": "https://en.wikipedia.org/wiki/Bruce_protocol"
+                    },
+                    {
+                        "text": "10 METs corrispondono a correre 10 km in un’ora (6 min/km)",
+                        "url": "https://claude.ai/share/0fd600d2-3ea5-4387-86da-4fc0837af98d"
+                    },
+                    {
+                        "text": "relazione test di Cooper, VO2max e METs",
+                        "url": "https://claude.site/artifacts/d056480b-4e02-422b-b93b-c629762c9b90"
+                    },
+                    {
+                        "text": "chi sosteneva 14 METs dopo 20 anni è morto 4 volte in meno di chi si fermava a 5.",
+                        "url": "https://www.sciencedirect.com/science/article/pii/S0735109722052603"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🎼 ff.86 Bruciare ossigeno è vita",
+                        "url": "https://fortissimo.substack.com/p/ff85-bruciare-ossigeno-e-vita"
+                    }
+                ]
+            },
+            {
+                "title": "🥗 ff.120.2 Dieta o esercizio?",
+                "link": "https://fortissimo.substack.com/i/155426992/ff-dieta-o-esercizio",
+                "content": "Il movimento è talmente benefico che allunga quindi la vita anche se mangiamo schifezze.\nNon lo dico io, eh, ma un altro studio:se ci si muove, si può anche mangiare male(e se non ci si muove, una buona dieta passa in secondo piano).\nVediamo una delle possibili spiegazioni.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!NoWq!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F16a873d1-aaa5-4a60-8901-2f34fca8a3a6_754x488.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!TxAu!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F33719fa1-d165-4425-a421-e818d300b0d5_1330x1085.jpeg",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "se ci si muove, si può anche mangiare male",
+                        "url": "https://www.sciencedirect.com/science/article/abs/pii/S0899900723002149"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "💕 ff.120.3 Questioni di cuore",
+                "link": "https://fortissimo.substack.com/i/155426992/ff-questioni-di-cuore",
+                "content": "Caramelle da sconosciuti?Se non bruciati, gli zuccheri nel sangue rendono le vene più rigide (come una reazione di Maillard,Advanced Glycation Endproducts, AGEs).\nQuesto spiega laconnessione tra zucchero, glicemia e problemi di cuore.\nQuando attivati, i muscoli agiscono da spugna e “assorbono gli eccessi”. Ecco perché ilVO2Max (misura consumo di ossigeno e zuccheri) è un parametro di longevità\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!zjFh!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fb084e02d-3944-431f-8638-2d117881b31c_593x468.png",
+                        "caption": "Come lo zucchero può aumentare il rischio di malattie cardiache(Rhonda Patrick via futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Advanced Glycation Endproducts",
+                        "url": "https://magazine.x115.it/x115/ages-prodotti-di-glicazione-avanzati/#:~:text=AGEs%20%C3%A8%20l'acronimo%20di,prodotti%20finali%20della%20glicazione%20avanzata)."
+                    },
+                    {
+                        "text": ", AGEs",
+                        "url": "https://magazine.x115.it/x115/ages-prodotti-di-glicazione-avanzati/#:~:text=AGEs%20%C3%A8%20l'acronimo%20di,prodotti%20finali%20della%20glicazione%20avanzata)."
+                    },
+                    {
+                        "text": "connessione tra zucchero, glicemia e problemi di cuore",
+                        "url": "https://x.com/foundmyfitness/status/1846261954782154860"
+                    },
+                    {
+                        "text": "VO2Max (misura consumo di ossigeno e zuccheri) è un parametro di longevità",
+                        "url": "https://pubmed.ncbi.nlm.nih.gov/29293447/"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🍼 ff.120.4 Lattato al cervello?",
+                "link": "https://fortissimo.substack.com/i/155426992/ff-lattato-al-cervello",
+                "content": "Tenere a bada l’indurimento delle arterie è uno dei benefici del movimento.\nMuovendoci produciamo anche acido lattico (che trasforma le scale, il giorno dopo una gita in montagna, nel nostro peggior nemico).\nEnergie mentali.Sì, il cervello consuma il 20% degli zuccheri assunti. Ma sapevate chei neuroni preferiscono il lattato? Tanto cheviene usato per curare danni cerebrali.\nCosì, l’acido lattico prodotto durante lo sport promuove la crescita di nuove cellule nervose (sport eBrain-Derived Neurotrophic Factor, BDNF).\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!EgP7!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fc4c68e2b-e94c-43e8-8a41-5837546b4711_1024x750.webp",
+                        "caption": "La differenza tra astrociti e neuroni"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "i neuroni preferiscono il lattato",
+                        "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC8651295/#:~:text=Our%20data%20demonstrate%20that%20in,and%20astrocytes%20for%20brain%20function."
+                    },
+                    {
+                        "text": "viene usato per curare danni cerebrali",
+                        "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC4530406/"
+                    },
+                    {
+                        "text": "sport e",
+                        "url": "https://www.foundmyfitness.com/topics/bdnf"
+                    },
+                    {
+                        "text": "Brain-Derived Neurotrophic Factor",
+                        "url": "https://www.foundmyfitness.com/topics/bdnf"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "⚔️ ff.120.5 Tumore vs battiti cardiaci?",
+                "link": "https://fortissimo.substack.com/i/155426992/ff-tumore-vs-battiti-cardiaci",
+                "content": "Bonus veloce.Sembra che “i battiti elevati” dello sport possono spaccare alcune cellule tumorali metastatiche.\nNon tutte sono sensibili a queste “forze circolatorie”. Ma l'esercizio fisico può anche aiutare nel normalizzare l’irrorazione di cellule tumorali, con miglioramenti delle terapie in atto.\n❤️cuoricino (che batte forte) qui sotto?\n☕ supporta con uncaffè\n🎶archivio note fortissime\n👋 A presto, damicmer\n©futuro fortissimo|michele merelli\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!UO6B!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F71ea74ef-5754-4d21-a107-d9dac646585e_582x485.png",
+                        "caption": "Come l’esercizio fisico previene la diffusione dei tumori(Rhonda Patrick / futuro fortissimo)"
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!_71G!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F5654abc7-a532-44d8-9468-ee9c6f728d63_1440x1065.bin",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Sembra che “i battiti elevati” dello sport possono spaccare alcune cellule tumorali metastatiche.",
+                        "url": "https://www.nature.com/articles/srep39975"
+                    },
+                    {
+                        "text": "caffè",
+                        "url": "https://www.paypal.com/paypalme/MicheleMerelli"
+                    },
+                    {
+                        "text": "archivio note fortissime",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    },
+                    {
+                        "text": "futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/"
+                    },
+                    {
+                        "text": "michele merelli",
+                        "url": "https://www.linkedin.com/in/michelemerelli/"
+                    }
+                ],
+                "connections": []
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff119-mani-ovunque",
+        "title": "🎼 ff.119 Mani ovunque",
+        "subtitle": "L'AI mette \"Manus\" a spiritualità e intelligenza umana?",
+        "keypoints": [
+            "Il prete sostituito da ChatGPT",
+            "Manus AI: la guida autonoma di un computer",
+            "Gelati mangiati al posto di bambini?"
+        ],
+        "subchapters": [
+            {
+                "title": "👽 ff.119.1 Intelligenze aliene",
+                "link": "https://fortissimo.substack.com/i/158977422/ff-intelligenze-aliene",
+                "content": "Tra viaggi (fisici e mentali), è da un po’ che non parliamo di intelligenza artificiale. Aggiorniamoci.\nMentre me la spassavo a Hong Kong, sulNew York Times un articolo sostiene l’AGI è qui e non siamo pronti.\nDopo Copernico e Darwin, universo e natura, sembra ora non siamo più al centro nemmeno dell’intelligenza.\nLà fuori, sistemi sempre più sovra-umani, alieni, con linguaggi incomprensibili.\nAd esempio,due AI decidono di comunicare in ggwave, riconoscendolo più efficiente dell’inglese.\nL’intelligenza artificialeEVO 2 “parla DNA” e ci aiuta a capire mutazioni genetiche.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!8hyA!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F57c41022-f20c-4dff-b83d-be2a2307c200_1410x810.jpeg",
+                        "caption": "Abbiamo raggiunto il picco di intelligenza? Secondo il Financial Times sì(via futuro fortissimo)"
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!f9LO!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fc89653c2-692e-45da-aa36-38132341f272_588x506.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!00bJ!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F69a1d895-5534-48d5-ba6c-a62ada6d5db5_730x381.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "New York Times un articolo sostiene l’AGI è qui e non siamo pronti",
+                        "url": "https://www.nytimes.com/2025/03/14/technology/why-im-feeling-the-agi.html?s=33"
+                    },
+                    {
+                        "text": "due AI decidono di comunicare in ggwave",
+                        "url": "https://x.com/ggerganov/status/1894057587441566081"
+                    },
+                    {
+                        "text": "EVO 2 “parla DNA” e ci aiuta a capire mutazioni genetiche.",
+                        "url": "https://www.biorxiv.org/content/10.1101/2025.02.18.638918v1"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🙏 ff.119.2 Se il prete è un’AI",
+                "link": "https://fortissimo.substack.com/i/158977422/ff-se-il-prete-e-unai",
+                "content": "A proposito di sovra-umano, parliamo di religione.\nPetja Kopperoinen, un prete al passo coi tempi e con 3000 “apostoli” su Instagramha celebrato la prima “messa generativa”: avatar-AI di Cristo (🐰 ff.48.2 Steve Jobs e l’intervista a Playboy) emusiche gospel generate con Suno.\nIl video-riassunto della prima messa fatta dall’intelligenza artificiale.\nAldilà (si fa per ridere) dell’evidente trovata \"acchiappa like\", potrebbe essere una soluzione al crollo di numero di preti.\nAumentati dall’AI.Questa la speranza di Harari (💲 ff.109.4 Elemosina dall’AI). Steven Kotler è un esempio: usa l'AI per facilitare flow e creatività (da Peter Diamandis).\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!PDex!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fca38582b-eab5-4351-8213-43b1d6d5b4fb_1396x985.png",
+                        "caption": "Quando la Chiesa incontra la tecnologia:filtri instagrame “messe generative” (via futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Petja Kopperoinen, un prete al passo coi tempi e con 3000 “apostoli” su Instagram",
+                        "url": "https://www.instagram.com/petjakopperoinen/?hl=en"
+                    },
+                    {
+                        "text": "musiche gospel generate con Suno",
+                        "url": "https://suno.com/home?utm_source=google&utm_medium=cpc&utm_campaign=GF_PR+RT_Search_Brand-Signups_INT&utm_term=suno%20ai&utm_content=738908021929&gad_source=1&gclid=Cj0KCQjwkN--BhDkARIsAD_mnIo74jNNEB1WrTJ-or-CUMhEjgaCNKUgmVObkpP58v7oivbvzUQ6zbwaAl_NEALw_wcB"
+                    },
+                    {
+                        "text": "AI per facilitare flow e creatività (da Peter Diamandis)",
+                        "url": "https://www.youtube.com/watch?v=-gIUz9vWQaY"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🐰 ff.48.2 Steve Jobs e l’intervista a Playboy",
+                        "url": "https://fortissimo.substack.com/i/95768574/ff-steve-jobs-e-lintervista-a-playboy"
+                    },
+                    {
+                        "text": "💲 ff.109.4 Elemosina dall’AI",
+                        "url": "https://fortissimo.substack.com/i/151066177/ff-elemosina-dallai"
+                    }
+                ]
+            },
+            {
+                "title": "✍️ ff.119.3 Longa “Manus” con gli agenti AI?",
+                "link": "https://fortissimo.substack.com/i/158977422/ff-longa-manus-con-gli-agenti-ai",
+                "content": "Spostandoci a Est, neanche il tempo di digerire DeepSeek e dalla Cina arriva una nuova tecnologia: non un pensatore seriale, ma un ottimo pianificatore multi-step (agente).\nManus AI è un “ChatGPT che controlla il vostro PC” (🖱️ ff.106.2 AI col mouse).Sembra si blocchi e sia più performante rispetto ai suoi predecessori.\nSumanus.im primi esempi applicativi (potete vedere i replay di tutte le azioni).\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!yCmu!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fd68c9597-0ce0-431b-886c-c665870473da_1472x1095.png",
+                        "caption": "Manus AI, senza bisogno di continue correzioni da parte dell’utente, analizza le azioni di Tesla. (via futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Sembra si blocchi e sia più performante rispetto ai suoi predecessori",
+                        "url": "https://x.com/minchoi/status/1898780175438942642"
+                    },
+                    {
+                        "text": "manus.im primi esempi applicativi (potete vedere i replay di tutte le azioni)",
+                        "url": "https://manus.im/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🖱️ ff.106.2 AI col mouse",
+                        "url": "https://fortissimo.substack.com/i/150754650/ff-ai-col-mouse"
+                    }
+                ]
+            },
+            {
+                "title": "🍦 ff.119.4 Meglio di DALL-E: arte e gelati",
+                "link": "https://fortissimo.substack.com/i/158977422/ff-meglio-di-dall-e-arte-e-gelati",
+                "content": "Per chiudere in dolcezza,Google ha rilasciato Gemini 2.0 native image generation(che alla fiera mio padre comprò).\nTra tutti i nomi e i modelli là fuori, orientarsi ormai è impossibile. Sappiate solo che è una perfetta alternativa a Photoshop, ad esempio permettere gelati ovunque.\n❤️cuoricino qui sotto?\n☕ mi supporti con uncaffè?\n🎶archivio note fortissime\n©futuro fortissimo|michele merelli\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!FAGA!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F03ec5709-6722-43fb-82ea-d33ef744e091_790x1024.jpeg",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!5lup!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F65bcc824-8e56-4033-bebf-ae9221f05a13_3000x1500.jpeg",
+                        "caption": "Mettere mano alla moda:Manus x Machina, la mostra del Metropolitan Museum di New York (via futuro fortissimo)."
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Google ha rilasciato Gemini 2.0 native image generation",
+                        "url": "https://developers.googleblog.com/en/experiment-with-gemini-20-flash-native-image-generation/"
+                    },
+                    {
+                        "text": "mettere gelati ovunque",
+                        "url": "https://www.linkedin.com/posts/emollick_using-gemini-flash-experimental-to-ruin-art-activity-7305823215862362112-RrJ3?utm_source=share&utm_medium=member_desktop&rcm=ACoAABIxLMUBRUppy-bOKJj9naMo0QXZnkUNfBE"
+                    },
+                    {
+                        "text": "caffè",
+                        "url": "https://www.paypal.com/paypalme/MicheleMerelli"
+                    },
+                    {
+                        "text": "archivio note fortissime",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/"
+                    },
+                    {
+                        "text": "michele merelli",
+                        "url": "https://www.linkedin.com/in/michelemerelli/"
+                    }
+                ],
+                "connections": []
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff118-paprika-e-massaggi",
+        "title": "🎼 ff.118 Paprika e massaggi",
+        "subtitle": "Spezie tra internet e Il Mondo Nuovo",
+        "keypoints": [
+            "Altro che 1984: il libro del 1932 alternativa a Orwell",
+            "Perché rivederePaprikaoggi?",
+            "La soluzione: natura e silenzio?"
+        ],
+        "subchapters": [
+            {
+                "title": "🌎 ff.118.1 Il Mondo Nuovo",
+                "link": "https://fortissimo.substack.com/i/157598866/ff-il-mondo-nuovo",
+                "content": "Quasi tutti conoscono il libro1984, Orwell e The Big Brother: il controllo della società con il controllo dell’informazione, con la censura.\nMa se il “mondo nuovo” fosse invece quello diBrave New World?\nAldous Huxley già nel 1932 dipingeva un’altra società distopica: quella in cui una “spezia” controlla mentalmente la popolazione.\nEcco l’alternativa alla censura: inzuppare il vero in un caos di contenuti (anche generati da intelligenza artificiale); ributtarla nel “simulacro di stimoli” che il cervello deve capire (👨‍💻 ff.64.4 Matrix e materia).\nUna spezia, una droga: quella dei media, dei feed TikTok da cui non riusciamo a togliere lo sguardo, moderni gladiatori nel Colosseo (“panem et circenses”di Giovenale sotto steroidi).\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!YKov!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F53aabec6-ba72-4085-bc80-dfa3e78a2c3c_977x1500.jpeg",
+                        "caption": "Orwell o Huxley?Il mondo nuovo(via futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Brave New World",
+                        "url": "https://www.amazon.it/mondo-nuovo-Ritorno-nuovo/dp/8804735821?mcid=673f962154ad3a02bc349a7dc208a989&hvadid=700810186308&hvpos=&hvnetw=g&hvrand=15771129340751339647&hvpone=&hvptwo=&hvqmt=&hvdev=c&hvdvcmdl=&hvlocint=&hvlocphy=1008099&hvtargid=pla-1214278969869&psc=1&gad_source=1&linkCode=sl1&tag=micmeramazon-21&linkId=aac5863620efc98b41d7887a8fef37bb&language=it_IT&ref_=as_li_ss_tl"
+                    },
+                    {
+                        "text": "“",
+                        "url": "https://it.wikipedia.org/wiki/Panem_et_circenses"
+                    },
+                    {
+                        "text": "panem et circenses”",
+                        "url": "https://it.wikipedia.org/wiki/Panem_et_circenses"
+                    },
+                    {
+                        "text": "di Giovenale sotto steroidi",
+                        "url": "https://it.wikipedia.org/wiki/Panem_et_circenses"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "👨‍💻 ff.64.4 Matrix e materia",
+                        "url": "https://fortissimo.substack.com/i/119334503/ff-matrix-e-materia"
+                    }
+                ]
+            },
+            {
+                "title": "🌶️ ff.118.2 Paprika - Sognando un sogno パプリカ (2006)",
+                "link": "https://fortissimo.substack.com/i/157598866/ff-paprika-sognando-un-sogno-ハフリカ",
+                "content": "Paprika(una spezia) è il titolo del film-capolavoro di Satoshi Kon, che ho visto recentemente.\nConnette altri punti del viaggio mentale della scorsa uscita,🎼 ff.117 Viviamo in una simulazione.\nIl regista dipinge la pericolosità di un mondo digitale (ma anche società moderna) in cui tutto può coesistere: internet (ma anche un grattacielo) dove ogni tab-schermata (ma anche piano) è una possibilità.\nAlla ricerca di un cesso,a Hong Kong sono entrato in un grattacielo. A caso, ho schiacciato il 17 in ascensore. All’aprirsi delle porte, i miei polmoni sono stati inebriati da eugenolo: ero in un piano di soli dentisti.\nE’ stata un’altra conferma della realtà non-lineare, elettronica, quantistica in cui viviamo. In cui realtà parallele coesistono sovrapposte come piani di un grattacielo.\nEcco il deserto - spazio senza punti di riferimento - dipinto in Paprika, dove sfilano tutti i nostri miti, i nostri simboli.\nUn deserto di segni senza un senso univoco: ombrelli, per pioggia o sole?\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!_0cz!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F703645af-00ba-4cfe-8dfa-b5f13df36796_1002x1492.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!izpx!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F6825d706-64ea-4fd5-8d6d-40b3cdd081f3_517x847.png",
+                        "caption": "La realtà post-Newtoniana, già dipinta inIl medium è il massaggio/messaggio(via futuro fortissimo)"
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!Q4Hd!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F621ae084-d10a-459e-9e91-63c3277cf782_836x1014.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Paprika",
+                        "url": "https://it.wikipedia.org/wiki/Paprika_-_Sognando_un_sogno"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🎼 ff.117 Viviamo in una simulazione",
+                        "url": "https://fortissimo.substack.com/p/ff117-viviamo-in-una-simulazione"
+                    }
+                ]
+            },
+            {
+                "title": "🌳 ff.118.3 La cura: albero e silenzi?",
+                "link": "https://fortissimo.substack.com/i/157598866/ff-la-cura-albero-e-silenzi",
+                "content": "Come “staccarsi” da questa droga, da questa spezia?\nA Hong Kong, ho reagito correndo una maratona.\nNon tanto per coprire i famigerati 42.196 km, o per una medaglia; ma per trovare il tempo necessario per tornare ad annoiarmi.\nPer staccare dai continui stimoli della città (un enorme social network) e ascoltare quanto succedeva dentro di me.\nInsomma, ritrovare la mia  “groundedness”, le radici e punti fissi del mio essere: corsa, podcast e cibo semplice (banane).\nE riascoltare le canzoni più importanti.\nDove vai, albero? Così in altoChe ogni germoglio è meno saldo da terraE ogni foglia è meno forteE destinata a cadere poco più su delle radiciE tutte queste braccia spalancate verso il cieloE quelle dita affusolate perché combattono contro questa gravitàPerché combattono contro questa gravitàNa na, contro questa gravità, na naEugenio in Via di Gioia,Albero\nE in tutta questa musica, ritrovare il silenzio. Come quello di 273 secondi (anche gradi Kelvin) di John Cage.\n🎶archivio note fortissime\n☕caffè virtuale\n❤️cuoricino qui sotto?\n👋 A presto, damicmer\n©futuro fortissimo|michele merelli\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!oU4g!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fea742e01-3da1-4e1d-a70c-719027ca0c40_459x632.png",
+                        "caption": "La mia maratona riflessiva, a Hong Kong (michele merelli via Strava)."
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!Ip6V!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fe915eecc-290f-4662-b85a-a4a68cbeac3c_393x716.png",
+                        "caption": "Le parole di John Cage, ritrovate inaspettatamente inIl medium è il massaggio/messaggio(via futuro fortissimo)"
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!F2TQ!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Ffa2c813c-8ca9-47e5-8675-ac4444eb2cf1_683x672.png",
+                        "caption": "Le porte (o finestre del broswer) inPaprika."
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "archivio note fortissime",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "caffè virtuale",
+                        "url": "https://www.paypal.com/paypalme/MicheleMerelli"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    },
+                    {
+                        "text": "futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/"
+                    },
+                    {
+                        "text": "michele merelli",
+                        "url": "https://www.linkedin.com/in/michelemerelli/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "groundedness",
+                        "url": "https://fortissimo.substack.com/i/134486468/ff-dal-multitasking-ai-classici-greci-e-larete"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff117-viviamo-in-una-simulazione",
+        "title": "🎼 ff.117 Viviamo in una simulazione",
+        "subtitle": "L'ho capito in viaggio tra Hong Kong e Shenzhen",
+        "keypoints": [
+            "Inception, Interstellar e Black Mirror in un giorno?",
+            "Everything everywhere all at onceambientato ad Hong Kong?",
+            "La cura è la nostra attenzione?"
+        ],
+        "subchapters": [
+            {
+                "title": "🏆 ff.117.1 Giornate da Oscar",
+                "link": "https://fortissimo.substack.com/i/157086176/ff-giornate-da-oscar",
+                "content": "Ho provato a dare un senso lineare a questa (e la prossima) newsletter. Ma poi ho capito che la linearità Newtoniana è morta da un po’(🍎 ff.64.2 Da Newton a Einstein).\nQuindi, tenetevi forte, perché vi porto nelle allucinazioni e nei film mentali a cui ho assistito, in meno di 24 ore. Stimolati dalla “spezia” di Hong Kong e Shenzhen.\nInterstellar.Le giornate mi sembravano eterne, come vicino a un buco nero, dovendo continuamente ridefinire concetti come:\nlibertà di movimento:la mattina una corsa nel verde del The Peak (Hong Kong), la sera nel vuoto di strade dritte, rosse di bandiere e silenziose a Shenzhen (Cina).libertà di parola:l’ascolto diCancelleriadei Pinguini Tattici Nucleari guardando Shenzhen, capeggiata da un enorme pinguino (simbolo di Tencent e WeChat, che controllano l’informazione in Cina) e un “grattacielo-stilografica”.\nLe biro, grandi cape, cercarono di mantenereAllo stesso status sociale di prima le matite che però adessoIntendevano abolire ogni classista distinzioneE ai loro cortei nelle piazze inneggiavano alla rivoluzione[…]Nel libero stato di Cancelleria restarono solo le biroChe cantarono e festeggiarono per la vittoriaPinguini Tattici Nucleari,Cancelleria\nInception.La vertigine di spazi che sembrano ripiegarsi su loro stessi.\nBlack mirror.Serve aggiungere altro?\nmichelemerelli.igA post shared by@michelemerelli.ig\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!0KhW!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F938f2899-87ef-4a4c-97fc-5dc67979d6a0_1634x919.jpeg",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!G4t4!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F316485b9-deaa-454a-8cac-19356e4f46b2_1924x697.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "michelemerelli.ig",
+                        "url": "https://instagram.com/michelemerelli.ig"
+                    },
+                    {
+                        "text": "",
+                        "url": "https://instagram.com/p/DFwm87go2My"
+                    },
+                    {
+                        "text": "@michelemerelli.ig",
+                        "url": "https://instagram.com/michelemerelli.ig"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🍎 ff.64.2 Da Newton a Einstein",
+                        "url": "https://fortissimo.substack.com/i/119334503/ff-da-newton-a-einstein"
+                    }
+                ]
+            },
+            {
+                "title": "🍩 ff.117.2 Ciambelle atomiche",
+                "link": "https://fortissimo.substack.com/i/157086176/ff-ciambelle-atomiche",
+                "content": "Premesse:\nEverything everywhere all at oncenon mi aveva colpito particolarmente.Non mangiomaibagel. Ma a Shenzhen, in cerca di comfort, ho optato per un brunch come fossi a New York.\nQuando la sera stessa, rientrato ad Hong Kong, il mio subconscio ha connesso queste premesse, questi due punti; mi è quasi esploso il cervello.\nIn un istante, ho rivisto il mio passato (e futuro?):everything everywhereall at once.\nLa cosa più assurda è che non ero in un film, ma nella realtà. Tra Hong Kong e Shenzhen sembra di vivere nel feed di TikTok: qui l’umanità è compressa in formato .zip, condensata come in ChatGPT.\nUna realtà talmente densa di concetti e contrasti da diventare un buco nero, in cui spazio e tempo perdono di senso: dovetuttoèovunque allo stesso tempo, appunto.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!cIdr!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fc9c4520e-ef07-4a0e-9917-c72f59009931_695x709.png",
+                        "caption": "Il brunch (con bagel) di Shenzhen, il museo di arte contemporanea di Shenzhen, un mio video sui buchi neri (2019), ascolti e letture passate con “bagel”"
+                    }
+                ],
+                "references": [],
+                "connections": []
+            },
+            {
+                "title": "🧮 ff.117.3 Simulazioni e algoritmi",
+                "link": "https://fortissimo.substack.com/i/157086176/ff-simulazioni-e-algoritmi",
+                "content": "Spaesato e in cerca di significati - manco a dirlo - ho aperto un “medium”, YouTube. L’algoritmo mi ha consigliato questa recensione al film:\nNel video altre inattese connessioni col mio passato: DALL-E che tutto può generare (🎼 ff.30 DALL-E: genera arte) e il filmInsidedi Bo Burnhamvisto durante il lockdown.\nE così ho capito che viviamo in una simulazione, generata da algoritmi che imboccano di connessioni il nostro cervello. Un cervello che si nutre di connessioni (pattern recognition) per dare un senso al caos là fuori.\n",
+                "images": [],
+                "references": [
+                    {
+                        "text": "Inside",
+                        "url": "https://www.netflix.com/it/title/81289483"
+                    },
+                    {
+                        "text": "di Bo Burnham",
+                        "url": "https://www.netflix.com/it/title/81289483"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🎼 ff.30 DALL-E: genera arte",
+                        "url": "https://fortissimo.substack.com/p/-ff30-dall-e-genera-arte?utm_source=publication-search"
+                    }
+                ]
+            },
+            {
+                "title": "👨‍💻 ff.117.4 Liberarci dalla simulazione degli algoritmi?",
+                "link": "https://fortissimo.substack.com/i/157086176/ff-liberarci-dalla-simulazione-degli-algoritmi",
+                "content": "Ma come possiamo sfuggire a questa simulazione?\nNel video Youtube la possibile cura all’ipermodernismo (virtuale dei social e reale di Hong Kong): prestare attenzione a ciò che accade.\nMa poi mi sono chiesto da dove arrivi questa frase.\nE’ tratta da un libro che avevo comprato prima di partire. Quel libro è del 1967 e si chiama - profeticamente -The Medium is the Massage(non connettiamo anche la stimolazione neurale, che non c’è tempo,🎼 ff.75 Massaggi al cervello).\nQuesto ulteriore punto ha fatto ricollassare tutto. Nel bagel. Nella simulazione che c’è là fuori (o solo nel nostro cervello?).\nCi torneremo.\n🎶archivio note fortissime\n☕caffè virtuale\n❤️cuoricino qui sotto?\n👋 A presto, damicmer\n©futuro fortissimo|michele merelli\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!5HH8!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F6baf74ba-3288-4f01-bd96-189b137c1833_1194x555.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!lGdY!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F64466584-21eb-4996-b451-2ecdb4b9d9a7_1185x586.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!5B8E!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F7b39eb4f-2587-4c5c-a2dd-f3d9e9c8b206_505x808.png",
+                        "caption": "Piccola preview diThe Medium is the Massage(via futuro fortissimo)"
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!b_iU!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F2ec7f12e-a307-40d0-8254-2759834ed94d_1440x2160.bin",
+                        "caption": "Le fotografie, surreali, di Sara Benabdallah"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "E’ tratta da un libro che avevo comprato prima di partire",
+                        "url": "https://en.wikiquote.org/wiki/Talk:Marshall_McLuhan"
+                    },
+                    {
+                        "text": "archivio note fortissime",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "caffè virtuale",
+                        "url": "https://www.paypal.com/paypalme/MicheleMerelli"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    },
+                    {
+                        "text": "futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/"
+                    },
+                    {
+                        "text": "michele merelli",
+                        "url": "https://www.linkedin.com/in/michelemerelli/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🎼 ff.75 Massaggi al cervello",
+                        "url": "https://fortissimo.substack.com/p/ff75-massaggi-al-cervello?utm_source=publication-search"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff115-lanno-del-serpente-1",
+        "title": "🎼 ff.115 L'anno del serpente / 1",
+        "subtitle": "Cosa faremo da grandi? Neanche i miliardari lo sanno.",
+        "keypoints": [
+            "Cosa ci insegna la 2378° persona più ricca al mondo sul futuro?",
+            "Intelligenza e serpenti: Snake e veleni",
+            "Automatizzati avvocati e programmatori, quale lavoro ci resterà?"
+        ],
+        "subchapters": [
+            {
+                "title": "👨🏻‍🏫 ff.115.1 A lezione con un miliardario",
+                "link": "https://fortissimo.substack.com/i/155700864/ff-a-lezione-con-un-miliardario",
+                "content": "Sono in Cina al momento e cinese è DeepSeek, il modelloopen sourceche rende gratis ciò che OpenAI offriva a 200€/mese (🍓 ff.103.1 Prima di parlare, pensa).\nIl serpente della conoscenza è sfuggito.\nSerpeverde o sempreverde?Più il secondo, visto che Chris Sacca (2378esima persona più ricca al mondo) promuove soluzioni al cambiamento climatico conLowercarbon Capital (alcune aziende del portfolio):\nCarbon Engineeringcattura CO2 dall’atmosfera e sta provando a portare il costo a100$/tonnellata, livello critico per compensare costi societari delle emissioni.Lilac Solutionsestrae litio dalla brina, con metodi 3x migliori di quelli attuali.Solugenusa enzimi per convertire zuccheri in sostanze chimiche come (tra le50 più disruptive nel 2024 per CNBC news).\nRecentemente, è passato da Tim Ferriss. Vediamo cosa si sono detti.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!NU92!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F7d8227ac-1c04-48e0-b1da-bad26bd6967c_484x468.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!2u3I!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F42300746-243a-42e8-9528-f96f09291226_1337x695.png",
+                        "caption": "Chris Sacca con Lowercabon Capital supporta aziende per abbattere CO2 e “unf**k” il pianeta (via futuro fortissimo)."
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "2378esima persona più ricca al mondo",
+                        "url": "https://www.forbes.com/billionaires/"
+                    },
+                    {
+                        "text": "Lowercarbon Capital (alcune aziende del portfolio)",
+                        "url": "https://lowercarboncapital.com/companies/"
+                    },
+                    {
+                        "text": "100$/tonnellata, livello critico per compensare costi societari delle emissioni",
+                        "url": "https://carbonherald.com/new-study-places-future-direct-air-capture-costs-230-540-range/"
+                    },
+                    {
+                        "text": "estrae litio dalla brina, con metodi 3x migliori di quelli attuali",
+                        "url": "https://news.stanford.edu/stories/2024/08/new-technology-extracts-lithium-from-brines-inexpensively-and-sustainably"
+                    },
+                    {
+                        "text": "50 più disruptive nel 2024 per CNBC news",
+                        "url": "https://www.cnbc.com/2024/05/14/these-are-the-2024-cnbc-disruptor-50-companies.html"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🍓 ff.103.1 Prima di parlare, pensa",
+                        "url": "https://fortissimo.substack.com/i/149504251/ff-prima-di-parlare-pensa"
+                    }
+                ]
+            },
+            {
+                "title": "❔ ff.115.2 Cosa studiare con ChatGPT?",
+                "link": "https://fortissimo.substack.com/i/155700864/ff-cosa-studiare-con-chatgpt",
+                "content": "Da buon investitore, Chris Sacca segue i trend tecnologici da vicino. Con podcast? No.Parlando per ore a ChatGPT (dopo aver chiesto di impersonificare Buckminster Fuller,🎼 ff.48 Risuscitare Aristotele).\nBetter Call Saul e Mr. Robot.Non è un caso che i protagonisti di queste serie, magnetici nella loro personalità, siano programmatori ed avvocati: simbolo di due professioni che ogni genitore sano di mente avrebbe suggerito ai suoi figli. Fino a un anno fa.\nOggi - ai tempi dell’IA -i lavori più pagati (attori, programmatori ed avvocati) sono anche quelli più a rischio(non serve McKinsey per farcelo capire)\nCi siamo già abituati, ma fino a poco fa programmare il gioco Snake richiedeva anni di studio. Oggi, Deepseek lo fa senza bug con 6 parole “scrivi il gioco snake in python”.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!az6v!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F876d6985-f0c4-4c0f-a49e-59b0d71c1d63_874x728.png",
+                        "caption": "Il report di McKinsey (2023) sull’impatto dell’AI sul lavoro."
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "i lavori più pagati (attori, programmatori ed avvocati) sono anche quelli più a rischio",
+                        "url": "https://www.mckinsey.com/mgi/our-research/generative-ai-and-the-future-of-work-in-america"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🎼 ff.48 Risuscitare Aristotele",
+                        "url": "https://fortissimo.substack.com/p/ff48-resuscitare-aristotele?utm_source=publication-search"
+                    }
+                ]
+            },
+            {
+                "title": "🐍 ff.115.3 Veleni esponenziali",
+                "link": "https://fortissimo.substack.com/i/155700864/ff-veleni-esponenziali",
+                "content": "A proposito di serpenti. L’intelligenza artificiale sta strisciando fuori dai chatbot e in applicazioni pratiche.\nProteinMNPPè un “ChatGPT” allenato con strutture proteiche (invece che testo su internet,⚛️ff.98.4 Sistemi quantistici).Su Natureuno studio mostra cometrovare un antidoto per veleno dei serpenti in secondi invece che mesi.\nDa qui, la riflessione sulla miopia umana per gli esponenziali, portando l’illustrazione diTim Urban, che nel 2015 parlava della rivoluzione dell’Intelligenza Artificiale.\nChris fa notare che questi trend sono ovunque:sostiene che raggiunge fusione nucleare (non fissione!) quotidianamente(con Q>1), proprio usando l’AI (☢️ ff.28.1 Intelligenza artificiale per la fusione nucleare).\nCome evitare di essere soffocati da questo boa di tecnologia? Lo vedremo tra 10 giorni. Ora torno a mangiare bao.\n🎶archivio note fortissime\n☕caffè virtuale\n❤️cuoricino qui sotto?\n👋 A presto, damicmer\n©futuro fortissimo|michele merelli\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!dvU-!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fff7dc5f1-b430-4639-a324-864db9b87bb0_629x354.bin",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!v5Pn!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F2a04439e-d6ef-4d8d-9272-d29ba624c471_701x592.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "ProteinMNPP",
+                        "url": "https://www.science.org/doi/10.1126/science.add2187"
+                    },
+                    {
+                        "text": "Su Nature",
+                        "url": "https://pubmed.ncbi.nlm.nih.gov/38798548/"
+                    },
+                    {
+                        "text": "trovare un antidoto per veleno dei serpenti in secondi invece che mesi.",
+                        "url": "https://www.ark-invest.com/newsletters/issue-447"
+                    },
+                    {
+                        "text": "Tim Urban, che nel 2015 parlava della rivoluzione dell’Intelligenza Artificiale",
+                        "url": "https://waitbutwhy.com/2015/01/artificial-intelligence-revolution-1.html"
+                    },
+                    {
+                        "text": "sostiene che raggiunge fusione nucleare (non fissione!) quotidianamente",
+                        "url": "https://www.instagram.com/timferriss/reel/DFT4QsivW0l/chris-sacca-on-ai-fusion-exponential-curves-and-tim-urbans-waitbutwhy-incredible/"
+                    },
+                    {
+                        "text": "con Q>1",
+                        "url": "https://lowercarboncapital.com/2022/10/19/race-to-q1/"
+                    },
+                    {
+                        "text": "archivio note fortissime",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "caffè virtuale",
+                        "url": "https://www.paypal.com/paypalme/MicheleMerelli"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    },
+                    {
+                        "text": "futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/"
+                    },
+                    {
+                        "text": "michele merelli",
+                        "url": "https://www.linkedin.com/in/michelemerelli/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "⚛️",
+                        "url": "https://fortissimo.substack.com/i/145245800/ff-sistemi-quantistici"
+                    },
+                    {
+                        "text": "ff.98.4 Sistemi quantistici",
+                        "url": "https://fortissimo.substack.com/i/145245800/ff-sistemi-quantistici"
+                    },
+                    {
+                        "text": "☢️ ff.28.1 Intelligenza artificiale per la fusione nucleare",
+                        "url": "https://fortissimo.substack.com/i/50474519/ff-intelligenza-artificiale-per-la-fusione-nucleare"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff114-miniature",
+        "title": "🎼 ff.114 MinIAture",
+        "error": "HTTP 404"
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff113-fame-chimica",
+        "title": "🎼 ff.113 Fame chimica",
+        "subtitle": "Che \"rapporto\" avere col cibo?",
+        "keypoints": [
+            "Perché la bilancia è lo strumento sbagliato",
+            "In che senso la dieta è questione di chimica?",
+            "Superare distinzione proteine, carboidrati e grassi?"
+        ],
+        "subchapters": [
+            {
+                "title": "⚖️ ff.113.1 Buttiamo la bilancia?",
+                "link": "https://fortissimo.substack.com/i/154401282/ff-buttiamo-la-bilancia",
+                "content": "Dieta, e tutti pensano al peso sulla bilancia (o meglio, alla massa, per essere scientificamente precisi).\nProblemi, problemi, problemi.Quel numero non può guidarci nelle scelte alimentari e di salute:\nogni giorno laquantità di acqua nel nostro corpo può variare da 1 a 4 litrii muscoli pesano di più, a parità di volume, del grassopoche bilance (anche impedenziometriche) misurano beneil grasso viscerale(il più pericoloso)\nInGood Energy, Casey Means parte della morte della madre per cambiare rotta: prestare attenzione al metabolismo. E alla “buona energia”.\nCasey ha abbandonato la medicina contemporanea: spinge a specializzarsi e curare, invece che prevenire e vedere l’organismo nella sua interezza.\nAnche con Levels, propone così una medicina personalizzata (ad esempio con il continuo monitoraggio della glicemia🕛 ff.35.2 Smartwatch e non solo).\nIndica, poi, nuovi parametri per capire se siamo veramente “in salute”:\nGlucosio a stomaco vuoto:correlabile a nostra salute metabolica, ottimale sotto gli 85 mg/dLInsulina necessaria per tenere a bada gli zuccheri (HOMA-IR):il rapporto tra glucosio e insulina nel sangue,ottimale un valore sotto 2.Livello di zuccheri medi nel sangue (3 mesi, HbA1c): misura laglicazionedell'emoglobina.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!xivE!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F39cd3b8b-ef69-4f3b-b0c7-f31463550bda_1800x630.jpeg",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!Ykbt!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F35ae4b52-f5bb-412c-96ea-73ef3c0eaacb_1638x2250.png",
+                        "caption": "Good Energy: l’importanza del metabolismo per la salute (via futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "quantità di acqua nel nostro corpo può variare da 1 a 4 litri",
+                        "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC9764345/"
+                    },
+                    {
+                        "text": "i muscoli pesano di più, a parità di volume, del grasso",
+                        "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC5092150/"
+                    },
+                    {
+                        "text": "il grasso viscerale",
+                        "url": "https://x.com/siimland/status/1835690540622389516"
+                    },
+                    {
+                        "text": "Good Energy",
+                        "url": "https://www.amazon.it/Good-Energy-Bestseller-groundbreaking-connection/dp/0008604282?_encoding=UTF8&dib_tag=se&dib=eyJ2IjoiMSJ9.CEzbSBCW2GAtqwxyoNYok1aYCm1UV1gAL8viyg5fq719T27CFpudFfdvnUknHoHb0WiL1AMccrMq4qbdur21NZGmpGSU0KHWMS4MkSHa-hxGhAokSphS7XFMoF4bJAoeItcYlLxNInFbSa9RKybRecZMIYEsm0q1-R_JNf1eo_E2IKo75NW19DepsWYdyN02ic2_7GBaNIWD_PoamYT07TZGfPGCoCb4Opr6oq07Z77ipxoISfq50JS1m2lkKu7Q0K7aeQ03cboihEJwlZepb4dZ_QXsFT4hJPF0j_9TgeDmIZU8YSWG5MJIsaEfXXKFI76bkaC5Vtei1OsYVd8qX_ZpOxc7GYzQt4TwlBGH68Fg1eep_ZWgCIG76xk74bKOL8fUIB_YFzsGxnQck683aoVziASsQat_SVQ3bR9721QIbB5YSequQF00MDH6vp5a.mMRE7QQJk35TFfFvW9CUF6_tVOW-U3q-97R0inugakU&qid=1736572825&sr=8-1&linkCode=sl1&tag=micmeramazon-21&linkId=d4a4120506a5e3fc6dfb6fd657e58f64&language=it_IT&ref_=as_li_ss_tl"
+                    },
+                    {
+                        "text": "Anche con Levels",
+                        "url": "https://www.levels.com/"
+                    },
+                    {
+                        "text": "HOMA-IR",
+                        "url": "https://www.mdcalc.com/calc/3120/homa-ir-homeostatic-model-assessment-insulin-resistance"
+                    },
+                    {
+                        "text": "glicazione",
+                        "url": "https://www.my-personaltrainer.it/salute/glicazione-cosa-e-conseguenze.html"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🕛 ff.35.2 Smartwatch e non solo",
+                        "url": "https://fortissimo.substack.com/i/50745954/ff-smartwatch-e-non-solo"
+                    }
+                ]
+            },
+            {
+                "title": "🥛 ff.113.2 L’inganno del latte proteico",
+                "link": "https://fortissimo.substack.com/i/154401282/ff-linganno-del-latte-proteico",
+                "content": "Cibo come medicina.Bisogna però anche focalizzarsi sul cibo, sullagood energyappunto.\nDifficile quando i produttori di cibo spendono, tra marketing e formulazioni appetibili (ma non sane) 10 volte di più della ricerca medica.\nDue personali aneddoti a conferma di ciò.\nMi sono imbattuto in un “latte proteico” di soia, con “10g di proteine” stampato a caratteri cubitali sulla confezione.\nConoscendo i valori tipici di proteine nel latte, i 10g mi hanno intrigato. Ho così letto l’etichetta e fatto i giusti rapporti: per la stessa quantità di proteine,quello a sinistrarichiede il doppio di kcal diquello a destra(!).\nAnalogamente, dopo che a un mio amico han suggerito di togliere dalla dieta le patate (che saziano di più🤰🏻 ff.22.4 I cibi che saziano di più) ma tenere la pasta, avevo creatobuonGPT.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!6cCA!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Feb037dac-4d19-4c80-b769-18fcd5651e6b_934x905.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!DVp1!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fea950648-85c9-4532-9c10-62eedb815864_735x623.png",
+                        "caption": "Il confronto tra patate e pasta, per 100kcal, grazie a BuonGPT (via futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "quello a sinistra",
+                        "url": "https://www.abillion.com/products/high-protein-bevanda-alla-soia-con-cacao-10638542"
+                    },
+                    {
+                        "text": "quello a destra",
+                        "url": "https://laspesaonline.eurospin.it/product/protein-plus-latte-scrslatuht-1l-pascoli-italiani"
+                    },
+                    {
+                        "text": "buonGPT",
+                        "url": "https://chatgpt.com/g/g-90Y6rg4XK-buongpt"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🤰🏻 ff.22.4 I cibi che saziano di più",
+                        "url": "https://fortissimo.substack.com/i/48651677/ff-i-cibi-che-saziano-di-piu"
+                    }
+                ]
+            },
+            {
+                "title": "💎 ff.113.3 Una dieta mineraria?",
+                "link": "https://fortissimo.substack.com/i/154401282/ff-una-dieta-mineraria",
+                "content": "La scelta di sostituire patate con pasta è opinabile, visto che le patate hanno 25x il potassio della pasta eraddoppiare il consumo di potassio (4300mg/giorno) abbassa il rischio di malattie cardiovascolari del 40%.\nQuesti dettagli mi hanno spinto fino aMineral fix, un librozzo da 1000 pagine sull’importanza dei minerali nel cibo e nella fisiologia umana.\nUna selezione veloce di spunti interessanti:\nSpa (quella del circuito di Formula 1) in epoca romana era famosa per le sue acque termali. Acronimo diSalut Per Aqua,oggi le SPA prendono il nome dalla stessa.Troppo ferro può causare anemia, se non bilanciato da un adeguato quantitativo di rame (ci torniamo, su questo concetto “chimico” del creare “rapporti” e normalizzare).\nPer assumere più rame dovremmo parzialmente sostituire la carne “muscolare” con fegato, cuore e unadieta vegetariana (che ha 2x la densità di rame di una onnivora).\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!u7ed!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F79fac557-7cdc-4193-bdd2-06526097c65a_1000x1411.jpeg",
+                        "caption": "Mineral Fix: l’importanza dei minerali per la nostra salute (via futuro fortissimo)"
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!cBFf!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F045cc00a-cfa0-41b9-8b1d-a0f7360623ab_641x581.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "raddoppiare il consumo di potassio (4300mg/giorno) abbassa il rischio di malattie cardiovascolari del 40%",
+                        "url": "https://www.ahajournals.org/doi/10.1161/01.CIR.98.12.1198"
+                    },
+                    {
+                        "text": "Mineral fix",
+                        "url": "https://amzn.to/4fYC5ec"
+                    },
+                    {
+                        "text": "Spa (quella del circuito di Formula 1) in epoca romana era famosa per le sue acque termali",
+                        "url": "https://it.wikipedia.org/wiki/Spa_(Belgio)"
+                    },
+                    {
+                        "text": "dieta vegetariana (che ha 2x la densità di rame di una onnivora)",
+                        "url": "https://www.sciencedirect.com/science/article/abs/pii/S000291652343211X"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "➗ ff.113.4 L’importanza dei rapporti",
+                "link": "https://fortissimo.substack.com/i/154401282/ff-limportanza-dei-rapporti",
+                "content": "Il rapporto ferro/rame (e BuonGPT) sono esempi della complessità del nostro organismo e della dieta, fatti intrinsecamente di reazioni chimiche.\nEcco spiegato perché:\nGli alimenti non processati sono fondamentali per la salute, grazie ai loro rapporti interni bilanciatiSingoli integratori possono essere controproducenti, poiché alterano questi equilibri naturali (come se mettessimo 1kg di curcuma in 100g di pollo al curry)\nI miei “rapporti” preferiti:\nProteine/kcal (per sazietà)Zuccheri/proteine (per abbassare picco glicemico)Fibre/100kcal (per microbioma)\nE voi, che rapporto avete col cibo? Me lo scrivete nei commenti?\n🎶archivio note fortissime\n☕caffè virtuale\n❤️cuoricino qui sotto?\n👋 A presto, damicmer\n©futuro fortissimo|michele merelli\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!2JpQ!,w_1456,c_limit,f_auto,q_auto:good,fl_lossy/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F137f8347-0d03-4697-8d8a-9fc6b066fb76_1300x703.gif",
+                        "caption": "Terrorizzati dagli snack?Crunchdi Holly Hunter"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "per sazietà",
+                        "url": "https://www.sciencedirect.com/science/article/abs/pii/S0268005X1630340X?via%3Dihub"
+                    },
+                    {
+                        "text": "per abbassare picco glicemico",
+                        "url": "https://diabetesjournals.org/care/article/7/5/465/30958/Effect-of-Protein-Ingestion-on-the-Glucose-and"
+                    },
+                    {
+                        "text": "archivio note fortissime",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "caffè virtuale",
+                        "url": "https://www.paypal.com/paypalme/MicheleMerelli"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    },
+                    {
+                        "text": "futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/"
+                    },
+                    {
+                        "text": "michele merelli",
+                        "url": "https://www.linkedin.com/in/michelemerelli/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "per microbioma",
+                        "url": "https://fortissimo.substack.com/i/137958307/ff-un-organo-in-piu-il-microbioma"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff112-acqua-imprevedibile",
+        "title": "🎼 ff.112 Acqua imprevedibile",
+        "subtitle": "Ha senso fare previsioni di una realtà esponenziale?",
+        "keypoints": [
+            "Abbiamo 5 anni per guadagnare il più possibile?",
+            "L’imprevedibile podcast del mio anno di diario personale",
+            "Se il futuro è sempre più criptico, perché prevederlo?"
+        ],
+        "subchapters": [
+            {
+                "title": "💸 ff.112.1 5 anni per fare soldi",
+                "link": "https://fortissimo.substack.com/i/153969354/ff-anni-per-fare-soldi",
+                "content": "Inizio anno è nuovi propositi, previsioni. Entrambi destinati a sbriciolarsi contro il muro di una realtà sempre più imprevedibile.\nL’esplosione del COVID ci ha insegnato come la nostra mente lineare non capisca trend esponenziali, parola di Neil DeGrasse Tyson.\nUn esempio:o3, l’ultimo modello di OpenAI, ha raddoppiato la sua precisione (già sbalorditiva) in pochi mesi.\nDi fronte a queste accelerazioni, ha ragione Raoul Pal nel dire chetra 5 (6) anni l’attuale sistema socio-finanziario perderà completamente di senso/valore?\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!5m1f!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fd8150c40-6f67-4dd7-99b9-332bb7e21d8b_596x387.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "o3, l’ultimo modello di OpenAI",
+                        "url": "https://x.com/__nmca__/status/1870170098989674833"
+                    },
+                    {
+                        "text": "tra 5 (6) anni l’attuale sistema socio-finanziario perderà completamente di senso/valore",
+                        "url": "https://micmer.notion.site/You-Have-6-Years-to-Make-as-Much-Money-as-Possible-Raoul-Pal-11041b31f60e8002af94ef64171eb305"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🙅 ff.112.2 Non possiamo prevedere nulla",
+                "link": "https://fortissimo.substack.com/i/153969354/ff-non-possiamo-prevedere-nulla",
+                "content": "Metterci la faccia?Non capiamo la realtà, non solo quella futura, ma l’attuale: Hollywood è spaventata dall’arte generativa che ricrea attori, ma già oggi la metà degli incassi al cinema è legato a personaggi non-umani.\nAl posto di fare previsioni,Ved Sen ci invita a sostituire i “mai” con i “se”.\nEcco 5 miei personalissimi se:\nSe la popolazione di robot supererà quella umana?Se vivrò per 500 anni?Se non posso prevedere i prossimi 5 anni, come penso ai prossimi 100?Se uno sciame di droni autonomi si presentasse all’orizzonte?Se energia e soldi perderanno valore, la salute biologica (misurata im VO2max) sarà la nuova ricchezza?\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!6JqQ!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F91bb432c-faaf-4975-bf9a-540197cf4ed2_700x274.png",
+                        "caption": "Dough Shapiro: incassi al box office di personaggi “senza faccia” (via futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Ved Sen ci invita a sostituire i “mai” con i “se”",
+                        "url": "https://innovationex.substack.com/p/236-stop-saying-never-practice-saying?utm_campaign=email-half-post&r=bruig&utm_source=substack&utm_medium=email"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🏋️ ff.112.3 Possiamo solo prepararci al meglio",
+                "link": "https://fortissimo.substack.com/i/153969354/ff-possiamo-solo-prepararci-al-meglio",
+                "content": "Nell’incertezza del futuro, non possiamo che tornare con un focus sul presente, mantenendo buone abitudini e piccoli investimenti.\nDa 10 anni scrivo un diario personale. Pensavo sarebbe stato inutile, dato il mararma di testo che difficilmente avrei riletto. Quest’anno, grazie aNotebookLM di Googlel’ho convertito in una puntata di podcast sulla mia vita.\nSentire due “persone” commentare, non senza un po’ di ironia, le mie personalissime preoccupazioni mi ha fatto sorridere. Attendo ora con ansia di poter generare un intero film della mia vita.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!wk2g!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fb158d07a-ccd4-4b26-9441-9d1f51eb29b6_866x516.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "NotebookLM di Google",
+                        "url": "https://notebooklm.google/"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🏞️ ff.112.4 Fiumi inattesi",
+                "link": "https://fortissimo.substack.com/i/153969354/ff-fiumi-inattesi",
+                "content": "Quello del diario personale è solo un esempio di come l’AI (presto parleremo diGoogle Deep Research) processi il marasma di informazioni che generiamo (♾️ ff.72.1 Infinito digitale).\nLe ricerche sulla correlazione tradurezza dell'acqua potabile e riduzione dei rischi cardiovascolariesistono dagli anni '60. Solo recentemente siamo riusciti a riscoprirle e comprenderle più approfonditamente.\nUn piccolo esempio: ho preso i dati suisali minerali dell’acqua di Bergamoe, con un semplice copia-incolla in ChatGPT, ho generato un report sui sali minerali nell’acqua di vari comuni della provincia, notando il primato della mia frazione per quantità di magnesio. Urrà!\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!Tego!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F110a02d9-ff2e-44de-b2e8-40dc9b365172_535x851.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Google Deep Research",
+                        "url": "https://blog.google/products/gemini/google-gemini-deep-research/"
+                    },
+                    {
+                        "text": "durezza dell'acqua potabile e riduzione dei rischi cardiovascolari",
+                        "url": "https://www.mdpi.com/2304-8158/12/17/3255"
+                    },
+                    {
+                        "text": "sali minerali dell’acqua di Bergamo",
+                        "url": "https://www.uniacque.bg.it/qualita-dellacqua/i-parametri-del-tuo-comune/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "♾️ ff.72.1 Infinito digitale",
+                        "url": "https://fortissimo.substack.com/i/134486468/ff-infinito-digitale"
+                    }
+                ]
+            },
+            {
+                "title": "💧 ff.112.5 Acqua da tutte le parti",
+                "link": "https://fortissimo.substack.com/i/153969354/ff-acqua-da-tutte-le-parti",
+                "content": "Il 2025 non è una tabula rasa, ma il proseguimento del fluire della vita. Torniamo quindi al recente invito a seguire il Tao, ad essere acqua (☯️ ff.108.3 Essere acqua).\nL’acqua che fluisce senza propositi e previsioni, ma con una direzione: il basso. Seguendo un’unica legge: la gravità.\nSenza sapere se finirà in un mare, in un lago, in un WC, in un frutto o nella vostra bocca.\n🎶archivio note fortissime\n☕caffè virtuale\n❤️cuoricino qui sotto?\n👋 A presto, damicmer\n©futuro fortissimo|michele merelli\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!snHR!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F73d69ea1-428c-49a9-a30c-2f21a79f1400_1440x566.bin",
+                        "caption": "New Day Coming, Calida Rawles (2020)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "archivio note fortissime",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "caffè virtuale",
+                        "url": "https://www.paypal.com/paypalme/MicheleMerelli"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    },
+                    {
+                        "text": "futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/"
+                    },
+                    {
+                        "text": "michele merelli",
+                        "url": "https://www.linkedin.com/in/michelemerelli/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "☯️ ff.108.3 Essere acqua",
+                        "url": "https://fortissimo.substack.com/i/148256057/ff-essere-acqua"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff112-acqua-imprevedibile",
+        "title": "🎼 ff.112 Acqua imprevedibile",
+        "subtitle": "Ha senso fare previsioni di una realtà esponenziale?",
+        "keypoints": [
+            "Abbiamo 5 anni per guadagnare il più possibile?",
+            "L’imprevedibile podcast del mio anno di diario personale",
+            "Se il futuro è sempre più criptico, perché prevederlo?"
+        ],
+        "subchapters": [
+            {
+                "title": "💸 ff.112.1 5 anni per fare soldi",
+                "link": "https://fortissimo.substack.com/i/153969354/ff-anni-per-fare-soldi",
+                "content": "Inizio anno è nuovi propositi, previsioni. Entrambi destinati a sbriciolarsi contro il muro di una realtà sempre più imprevedibile.\nL’esplosione del COVID ci ha insegnato come la nostra mente lineare non capisca trend esponenziali, parola di Neil DeGrasse Tyson.\nUn esempio:o3, l’ultimo modello di OpenAI, ha raddoppiato la sua precisione (già sbalorditiva) in pochi mesi.\nDi fronte a queste accelerazioni, ha ragione Raoul Pal nel dire chetra 5 (6) anni l’attuale sistema socio-finanziario perderà completamente di senso/valore?\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!5m1f!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fd8150c40-6f67-4dd7-99b9-332bb7e21d8b_596x387.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "o3, l’ultimo modello di OpenAI",
+                        "url": "https://x.com/__nmca__/status/1870170098989674833"
+                    },
+                    {
+                        "text": "tra 5 (6) anni l’attuale sistema socio-finanziario perderà completamente di senso/valore",
+                        "url": "https://micmer.notion.site/You-Have-6-Years-to-Make-as-Much-Money-as-Possible-Raoul-Pal-11041b31f60e8002af94ef64171eb305"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🙅 ff.112.2 Non possiamo prevedere nulla",
+                "link": "https://fortissimo.substack.com/i/153969354/ff-non-possiamo-prevedere-nulla",
+                "content": "Metterci la faccia?Non capiamo la realtà, non solo quella futura, ma l’attuale: Hollywood è spaventata dall’arte generativa che ricrea attori, ma già oggi la metà degli incassi al cinema è legato a personaggi non-umani.\nAl posto di fare previsioni,Ved Sen ci invita a sostituire i “mai” con i “se”.\nEcco 5 miei personalissimi se:\nSe la popolazione di robot supererà quella umana?Se vivrò per 500 anni?Se non posso prevedere i prossimi 5 anni, come penso ai prossimi 100?Se uno sciame di droni autonomi si presentasse all’orizzonte?Se energia e soldi perderanno valore, la salute biologica (misurata im VO2max) sarà la nuova ricchezza?\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!6JqQ!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F91bb432c-faaf-4975-bf9a-540197cf4ed2_700x274.png",
+                        "caption": "Dough Shapiro: incassi al box office di personaggi “senza faccia” (via futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Ved Sen ci invita a sostituire i “mai” con i “se”",
+                        "url": "https://innovationex.substack.com/p/236-stop-saying-never-practice-saying?utm_campaign=email-half-post&r=bruig&utm_source=substack&utm_medium=email"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🏋️ ff.112.3 Possiamo solo prepararci al meglio",
+                "link": "https://fortissimo.substack.com/i/153969354/ff-possiamo-solo-prepararci-al-meglio",
+                "content": "Nell’incertezza del futuro, non possiamo che tornare con un focus sul presente, mantenendo buone abitudini e piccoli investimenti.\nDa 10 anni scrivo un diario personale. Pensavo sarebbe stato inutile, dato il mararma di testo che difficilmente avrei riletto. Quest’anno, grazie aNotebookLM di Googlel’ho convertito in una puntata di podcast sulla mia vita.\nSentire due “persone” commentare, non senza un po’ di ironia, le mie personalissime preoccupazioni mi ha fatto sorridere. Attendo ora con ansia di poter generare un intero film della mia vita.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!wk2g!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fb158d07a-ccd4-4b26-9441-9d1f51eb29b6_866x516.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "NotebookLM di Google",
+                        "url": "https://notebooklm.google/"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🏞️ ff.112.4 Fiumi inattesi",
+                "link": "https://fortissimo.substack.com/i/153969354/ff-fiumi-inattesi",
+                "content": "Quello del diario personale è solo un esempio di come l’AI (presto parleremo diGoogle Deep Research) processi il marasma di informazioni che generiamo (♾️ ff.72.1 Infinito digitale).\nLe ricerche sulla correlazione tradurezza dell'acqua potabile e riduzione dei rischi cardiovascolariesistono dagli anni '60. Solo recentemente siamo riusciti a riscoprirle e comprenderle più approfonditamente.\nUn piccolo esempio: ho preso i dati suisali minerali dell’acqua di Bergamoe, con un semplice copia-incolla in ChatGPT, ho generato un report sui sali minerali nell’acqua di vari comuni della provincia, notando il primato della mia frazione per quantità di magnesio. Urrà!\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!Tego!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F110a02d9-ff2e-44de-b2e8-40dc9b365172_535x851.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Google Deep Research",
+                        "url": "https://blog.google/products/gemini/google-gemini-deep-research/"
+                    },
+                    {
+                        "text": "durezza dell'acqua potabile e riduzione dei rischi cardiovascolari",
+                        "url": "https://www.mdpi.com/2304-8158/12/17/3255"
+                    },
+                    {
+                        "text": "sali minerali dell’acqua di Bergamo",
+                        "url": "https://www.uniacque.bg.it/qualita-dellacqua/i-parametri-del-tuo-comune/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "♾️ ff.72.1 Infinito digitale",
+                        "url": "https://fortissimo.substack.com/i/134486468/ff-infinito-digitale"
+                    }
+                ]
+            },
+            {
+                "title": "💧 ff.112.5 Acqua da tutte le parti",
+                "link": "https://fortissimo.substack.com/i/153969354/ff-acqua-da-tutte-le-parti",
+                "content": "Il 2025 non è una tabula rasa, ma il proseguimento del fluire della vita. Torniamo quindi al recente invito a seguire il Tao, ad essere acqua (☯️ ff.108.3 Essere acqua).\nL’acqua che fluisce senza propositi e previsioni, ma con una direzione: il basso. Seguendo un’unica legge: la gravità.\nSenza sapere se finirà in un mare, in un lago, in un WC, in un frutto o nella vostra bocca.\n🎶archivio note fortissime\n☕caffè virtuale\n❤️cuoricino qui sotto?\n👋 A presto, damicmer\n©futuro fortissimo|michele merelli\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!snHR!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F73d69ea1-428c-49a9-a30c-2f21a79f1400_1440x566.bin",
+                        "caption": "New Day Coming, Calida Rawles (2020)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "archivio note fortissime",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "caffè virtuale",
+                        "url": "https://www.paypal.com/paypalme/MicheleMerelli"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    },
+                    {
+                        "text": "futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/"
+                    },
+                    {
+                        "text": "michele merelli",
+                        "url": "https://www.linkedin.com/in/michelemerelli/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "☯️ ff.108.3 Essere acqua",
+                        "url": "https://fortissimo.substack.com/i/148256057/ff-essere-acqua"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff111-morire-con-zero",
+        "title": "🎼 ff.111 Morire con zero",
+        "subtitle": "L'investimento migliore? La vita!",
+        "keypoints": [
+            "Come evitare di lasciare “vita in banca”?",
+            "Qual è l’età ottimale per iniziare a spendere di più?",
+            "Edonismo sfrenato o inno alla vita?"
+        ],
+        "subchapters": [
+            {
+                "title": "🍊 ff.111.1 Una vita da spremere",
+                "link": "https://fortissimo.substack.com/i/152438665/ff-una-vita-da-spremere",
+                "content": "Su futuro fortissimo parliamo anche di tempo. Lo abbiamo convertito in banane (⚖️ ff.61.1 Misurare l’inquinamento in ore di vita) e rallentato, notando le variazioni nella quotidianità (📝 ff.65.3 Il compito a casa per la vita, ).\nFine anno è perfetto per fermarci, e fermare il tempo. Come faccio con un video recap su YouTube, per quelli che restano dei 50.000 iscritti che mi guardavano sparare su Call of Duty.\nNon basta fermarsi, però. Dobbiamo prima trasformare le nostre energie vitali, il nostro lavoro, in vita: spericolata, ricordata.\n",
+                "images": [],
+                "references": [],
+                "connections": [
+                    {
+                        "text": "⚖️ ff.61.1 Misurare l’inquinamento in ore di vita",
+                        "url": "https://fortissimo.substack.com/i/115642846/ff-misurare-linquinamento-in-ore-di-vita"
+                    },
+                    {
+                        "text": "📝 ff.65.3 Il compito a casa per la vita",
+                        "url": "https://fortissimo.substack.com/i/107595173/ff-il-compito-a-casa-per-la-vita"
+                    }
+                ]
+            },
+            {
+                "title": "💯ff.111.2 Una vita spericolata",
+                "link": "https://fortissimo.substack.com/i/152438665/ff-una-vita-spericolata",
+                "content": "Voglio una vita spericolataVoglio una vita come quelle dei filmVoglio una vita esagerataVoglio una vita come Steve McQueenVasco Rossi,Vita Spericolata\nNon serve essere Vasco per vivere pienamente, basta un metodo: quello di Bill Perkins, ingegnere prestato alla compra-vendita del gas.\nIl suo libroDie with zeroinizia con una riflessione: se moriamo con 10.000€ in banca, abbiamo perso 3 mesi di vita sul lavoro; non godendo di 5 viaggi, 50 cene oppure 3 di pensione.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!chzj!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F4afa49d4-93a8-4928-8f32-e47da6f8f667_993x1500.jpeg",
+                        "caption": "Il libro di Bill Perkins,Die with zero(via futuro fortissimo)"
+                    }
+                ],
+                "references": [],
+                "connections": []
+            },
+            {
+                "title": "🛡️ ff.111.3 Figli, salute e anni sprecati",
+                "link": "https://fortissimo.substack.com/i/152438665/ff-figli-salute-e-anni-sprecati",
+                "content": "Bill ci chiede di “morire con zero”. Chiaramente, una provocazione impossibile (nessuno conosce ovviamente il giorno della propria morte). Che però svela inefficienze nascoste nella gestione delle nostre finanze:\nEredità: i figli la ricevono a 60 anni, quando sono già sistemati economicamente. Sarebbe meglio aiutarli tra i 25 e 35 anni, quando possono usarli per casa, impresa, famiglia o più esperienze.Salute: in caso di malattie importanti, i risparmi non possono coprire le ingenti spese mediche (specie in America). Meglio una buona assicurazione sanitaria.Pensione: le nostre stime di anni di vita post-lavorativa sono grossolane. Meglio lerendite vitalizie.\n",
+                "images": [],
+                "references": [
+                    {
+                        "text": "rendite vitalizie",
+                        "url": "https://www.intesasanpaoloassicurazioni.com/c/document_library/get_file?uuid=f8bbea97-6ccc-4065-9961-3fe08821581e&groupId=14502"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "📈 ff.111.4 Esperienze = investimenti",
+                "link": "https://fortissimo.substack.com/i/152438665/ff-esperienze-investimenti",
+                "content": "Scandaloso?Col suo edonismo, Bill sembra pestare valori come famiglia, salute e sicurezza sul futuro: a tutti gli effetti un inciampo mentale (skàndalon), un sasso sulla via maestra.\nUno scandalo anzitutto per se stesso, dato che Bill vuole ricordarsi delle trappole mentali in cui era finito da giovane, quando risparmiava 1.000€ di uno stipendio da 16.000. Quando lo scoprì, il suo capo gli fece notare: \"Sei idiota? Stai sacrificando 1/16 (22 giorni all’anno) della tua vita per soldi che tra 10 anni farai in 3 giorni!\".\nVediamo allora come Bill, tramite un’analogia tra soldi, tempo e investimenti, ci faccia ripensare alla vita.\nRicordi come dividendi?In finanza, prima investi, più dividendi accumuli. Questo vale anche per le esperienze: un viaggio in Italia a 20 anni genera 20+ anni di ricordi, lezioni e conoscenze rispetto che lo stesso, a 40 anni.\nInflazione fisica.Un dollaro speso a 60 anni dà meno vita. Bill porta come esempio una giornata sugli sci. In vecchiaia, rallentati fisicamente, facciamo meno discese, meno esperienze.\nPerò, però, però.Se anche trovo affascinanti gli spunti di Bill, mi permetto delle critiche:\nsenza novità, più esperienze non si convertono in più momenti da ricordare (🆕 ff.65.1 Tempo = nuove esperienze?)le novità dipendono dalla nostra attenzione (o distrazione), aldilà di quante cose ci accadono intornola vecchiaia, se anche rallenta fisicamente, valorizza eventi dati per scontati da giovani\nInsomma. Un bel caos. Un bel botto. Buona fine, miglior principio.\nP.S. Esercizio per il 31: massimizzare i prossimi 365/22.000 giorni, nel caso moriate (con zero) a 60 anni.\n🎶archivio note fortissime\n☕caffè virtuale\n❤️cuoricino qui sotto?\n👋 A presto, damicmer\n©futuro fortissimo|michele merelli\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!43rA!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F0c725b75-ac5c-428d-9b31-321ee477c09d_1120x370.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!YEjd!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F65ffcf5a-df8f-4bf0-9ab7-b97c1ccfe9c9_1024x467.webp",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!zY_l!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F3dffdddd-7867-4591-b073-b76211510fc9_1000x354.webp",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "archivio note fortissime",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "caffè virtuale",
+                        "url": "https://www.paypal.com/paypalme/MicheleMerelli"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    },
+                    {
+                        "text": "futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/"
+                    },
+                    {
+                        "text": "michele merelli",
+                        "url": "https://www.linkedin.com/in/michelemerelli/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🆕 ff.65.1 Tempo = nuove esperienze?",
+                        "url": "https://fortissimo.substack.com/i/107595173/ff-tempo-nuove-esperienze"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff110-uno-stato-da-mantenere",
+        "title": "🎼 ff.110 Uno Stato da mantenere",
+        "subtitle": "Inefficienze statali: necessarie o da superare?",
+        "keypoints": [
+            "Infrastrutture decadenti, quale soluzione?",
+            "Le criptovalute stanno lanciando un segnale?",
+            "L’arte nelle buche in strada"
+        ],
+        "subchapters": [
+            {
+                "title": "🏛️ ff.110.1 Tutte le strade portano alle buche di Roma",
+                "link": "https://fortissimo.substack.com/i/151593755/ff-tutte-le-strade-portano-alle-buche-di-roma",
+                "content": "Da due mesi, la mia casa nella Bergamasca è isolata. Un tornante è ceduto per le ingenti piogge, portando alla chiusura dell’unica strada verso la Val Seriana.\nLe previsioni più ottimistiche di fine lavori sono per fine 2025. Potrebbe arrivare prima l’AGI.\nQuel tornante è l’ennesimo esempio della fragilità delle infrastrutture italiane. Mondiali.\nNella vita come nelle infrastrutture, il nuovo è più eccitante: nuova bici, nuovo vestito, nuovo ponte di Calatrava. Andare dal meccanico, dal sarto, o chiamare il muratore per una perdita è molto meno affascinante, specie nell’era dell’usa e getta.\nPerò, per le infrastrutture, bisogna valorizzare quello che già esiste. Specialmente i ponti. Il Morandi a Genova e le banconote nel nostro portafoglio ce lo ricordano.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!Ld7p!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fe7655eab-9530-4d59-bbb5-f0853e490d20_640x1115.jpeg",
+                        "caption": ""
+                    }
+                ],
+                "references": [],
+                "connections": []
+            },
+            {
+                "title": "🚧 ff.110.2 Un cantiere infinito",
+                "link": "https://fortissimo.substack.com/i/151593755/ff-un-cantiere-infinito",
+                "content": "Eppure, lo Stato fatica a finanziare la manutenzione del costruito. Eventi climatici estremi come la pioggia di Valencia non aiutano.\nE così intorno a noi un cantiere infinito, sovrinteso da persone anziane in pensione.\nNon ci resta che spettacolizzare in stile Grande Fratello: lo streaming del cantiere I-95 del dipartimento dei trasporti della Pennsylvania.\nLa verità è che siamo nel mezzo di unprecipizio di produttività. AncheMcKinsey fa notare: la produttività nell’edilizia è bloccata agli anni 2000.\nEppure, l’America era efficiente:in 138 giorni dall’idea, Apollo 8 è atterrato sulla Luna.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!t05q!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F67887b66-ee80-4e72-89ea-0ec0fed512d3_1792x1024.webp",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!ZPsP!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fbdfd9f9b-88ee-47e7-9772-65a6d9c138d8_878x733.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "precipizio di produttività",
+                        "url": "https://www.luxcapital.com/content/the-productivity-precipice"
+                    },
+                    {
+                        "text": "McKinsey fa notare: la produttività nell’edilizia è bloccata agli anni 2000",
+                        "url": "https://www.mckinsey.com/capabilities/operations/our-insights/delivering-on-construction-productivity-is-no-longer-optional#"
+                    },
+                    {
+                        "text": "in 138 giorni dall’idea, Apollo 8 è atterrato sulla Luna.",
+                        "url": "https://patrickcollison.com/fast?utm_source=substack&utm_medium=email"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "💎 ff.110.3 Le criptovalute contro obsolescenza statale",
+                "link": "https://fortissimo.substack.com/i/151593755/ff-le-criptovalute-contro-obsolescenza-statale",
+                "content": "Le elezioni USA hanno lanciato un messaggio chiaro, anche se difficile da digerire: lo Stato è troppo lento, le regolamentazioni soffocanti.\nSpaceX fa riatterrare razzi, Starlink porta internet dove la fibra manca. Non a caso proprio Musk propone - nella sua classica ironia - il DOGE, il dipartimento di efficienza governativa.\nL’elezione di Trump e il picco di Bitcoin: da 69.000 a 75.000 dollari in poche ore. Un segnale che stiamo superando la democrazia moderna? Stiamo per🎼 ff.52 Fondare una Nazione in garage?\nSecondo Naval, sì: Bitcoin ai massimi storici è il primo segnale di alleggerimento dal peso dello Stato, che è ogni giorno più pesante.\nIntanto, ricordiamo che il presidente diEl Salvador compra un Bitcoin al giorno da Novembre 2022: la riserva strategica vale oggi 600 milioni di dollari (a inizio 2024 ne valeva 100).\nPerò, però, però.Forse, anche lademocrazia decentralizzata è un’illusione.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!up_d!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F486d27b7-89f9-43c2-8b27-c5e749c79eda_606x691.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!O_mV!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F30959b78-51e0-43f2-bfaf-b0f15c2c750e_2000x1273.jpeg",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!o5Jw!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F52c67d2e-73bd-4187-8fc4-a262b851db29_2100x2100.jpeg",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!2ZnH!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F10e4c988-7cd9-4c6d-87fb-01f22f2b0819_584x114.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!EO2z!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fac7a9d1e-9791-4576-81e1-ac8defca7ae6_594x714.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "L’elezione di Trump e il picco di Bitcoin",
+                        "url": "https://etc-group.com/blog/crypto-research/trump-has-likely-won-the-us-election-what-does-it-mean-for-bitcoin-and-cryptoassets/"
+                    },
+                    {
+                        "text": "El Salvador compra un Bitcoin al giorno da Novembre 2022",
+                        "url": "https://x.com/nayibbukele/status/1864506095131144278"
+                    },
+                    {
+                        "text": "democrazia decentralizzata è un’illusione.",
+                        "url": "https://www.nesta.org.uk/report/illusion-blockchain-democracy-one-coin-equals-one-vote/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🎼 ff.52 Fondare una Nazione in garage",
+                        "url": "https://fortissimo.substack.com/p/ff52-fondare-una-nazione-in-garage?utm_source=publication-search"
+                    }
+                ]
+            },
+            {
+                "title": "🤤 ff.110.4 Robot e AI: opportunità",
+                "link": "https://fortissimo.substack.com/i/151593755/ff-robot-e-ai-opportunita",
+                "content": "Un’alternativa all’anarchia digitale c’è: lo Stato può salvarsi aiutato da intelligenza artificiale e robot.\nSidewalk AI(Carlo Ratti, MIT Sensable Lab) usa l’AI per mappare lo stato di salute dei marciapiedi.\nL’altro tassello tecnologico sono i robot: potrebbero velocizzare cantieri, con costi ridotti e maggiori efficienze. A riguardo, l’aggiornamento sullacollaborazione tra Figure AI e BMW.\nIn attesa delle rivoluzione robotica, non ci resta che sistemare la realtà seguendo il principio giapponese del Kintsugi (金継ぎ), o Kintsukuroi (金繕い):le buche trasformate in opere d’arte da Ememem.\nememem.flackingA post shared by@ememem.flacking\n🎶archivio note fortissime\n☕caffè virtuale\n❤️cuoricino qui sotto?\n👋 A presto, damicmer\n©futuro fortissimo|michele merelli\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!5P3h!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F7c831b5e-a285-48dd-b7ac-3a9828e28673_1849x960.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!RqYZ!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F8f8e78a5-5b97-4e0d-a4ab-23baea05698b_1440x960.bin",
+                        "caption": "Yoko OnoMend Piece for London"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Sidewalk AI",
+                        "url": "https://senseable.mit.edu/sidewalk-ai/?utm_medium=email&utm_campaign=SCL%20NL%20November%202024&utm_content=SCL%20NL%20November%202024+CID_c61a7aa2386e023a7d639b7c21ed14b8&utm_source=SCL%20Analytics&utm_term=Sidewalk%20AI"
+                    },
+                    {
+                        "text": "collaborazione tra Figure AI e BMW",
+                        "url": "https://www.linkedin.com/feed/update/urn:li:activity:7264917250137092096/"
+                    },
+                    {
+                        "text": "le buche trasformate in opere d’arte da Ememem",
+                        "url": "https://www.instagram.com/ememem.flacking"
+                    },
+                    {
+                        "text": "ememem.flacking",
+                        "url": "https://instagram.com/ememem.flacking"
+                    },
+                    {
+                        "text": "",
+                        "url": "https://instagram.com/p/DAWGzctIdUt"
+                    },
+                    {
+                        "text": "@ememem.flacking",
+                        "url": "https://instagram.com/ememem.flacking"
+                    },
+                    {
+                        "text": "archivio note fortissime",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "caffè virtuale",
+                        "url": "https://www.paypal.com/paypalme/MicheleMerelli"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    },
+                    {
+                        "text": "futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/"
+                    },
+                    {
+                        "text": "michele merelli",
+                        "url": "https://www.linkedin.com/in/michelemerelli/"
+                    }
+                ],
+                "connections": []
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff109-medico-in-famigl-ia",
+        "title": "🎼 ff.109 Medico in famigl-IA",
+        "subtitle": "E se l'intelligenza artificiale si prende cura di noi?",
+        "keypoints": [
+            "La donna con più followers su LinkedIn",
+            "Come può una password cambiarci la giornata?",
+            "Spendiamo troppo in AI?"
+        ],
+        "subchapters": [
+            {
+                "title": "👩 ff.109.1 La donna più influente di LinkedIn",
+                "link": "https://fortissimo.substack.com/i/151066177/ff-la-donna-piu-influente-di-linkedin",
+                "content": "Arianna Huffington (fondatrice dell’omonimo giornale) è la donna con più followers su LinkedIn.\nL’ho scoperta in un recente podcast con Peter Diamandis (ideatore degliXPRIZE, Nobel per la tecnologiache da 30 anni offre milioni di euro per chi sviluppa tecnologie innovative).\nLa storia di Arianna mi ha affascinato: all’Huffington Post ha provato a ribaltare un’idea di media sensazionalista e negativamente virale, introducendola rubrica What’s Working, l’informazione centrata sul positivo.\nUn idealismo frantumato dal business-model dei media, focalizzato su massimizzare like ed engagement.\n",
+                "images": [],
+                "references": [
+                    {
+                        "text": "Arianna Huffington (fondatrice dell’omonimo giornale) è la donna con più followers su LinkedIn.",
+                        "url": "https://en.wikipedia.org/wiki/Arianna_Huffington"
+                    },
+                    {
+                        "text": "XPRIZE, Nobel per la tecnologia",
+                        "url": "https://www.xprize.org/"
+                    },
+                    {
+                        "text": "la rubrica What’s Working",
+                        "url": "https://www.huffpost.com/impact/topic/whats-working"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🌱 ff.109.2 Dai media al digital wellbeing",
+                "link": "https://fortissimo.substack.com/i/151066177/ff-dai-media-al-digital-wellbeing",
+                "content": "Ha quindi lanciatoThrive Global, per incanalare la potenza algoritmi con una priorità: il benessere psicofisico dell’uomo.\nLa montagna va da Maometto.Integrato in Microsoft Teams, Slack e simili spazi digitali, Thrive porta “sul luogo del lavoro” una valvola di sfogo come meditazione, check dell’umore e digital detox.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!J7Nq!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F0be0b27c-daea-4a6f-902d-8985d0671b07_700x226.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Thrive Global",
+                        "url": "https://thriveglobal.com/"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🧶 ff.109.3 Sbrigliare un gomitolo in un minuto",
+                "link": "https://fortissimo.substack.com/i/151066177/ff-sbrigliare-un-gomitolo-in-un-minuto",
+                "content": "Filo di Arianna.Vediamo un esempio di come Thrive usa l’AI per uscire dal labirinto di una società algoritmica. In un minuto.\nTecniche di controllo cometracciamento occhi per capire l’engagement di un utentesono già ampiamente usate con fini commerciali, Arianna vuole usare le stesse per capire - durante un meeting - lo stato di stress di un dipendente.\nDammi solo un minutoUn soffio di fiatoUn attimo ancoraPooh,Dammi solo un minuto\nThrive ha una funzione Reset: un minuto con canzone, messaggi e immagini preferite di un utente, per staccare la testa tra un meeting Zoom e l’altro.\nOppure, basta una password: Mauricio Estrellaha superato la depressione di un tradimento e divorzio resettando la sua password sul PC: “Forgive@h3r”. Ha così trasformato un’azione noiosa, lavorativa; in mantra, momento di meditazione, accettazione.\n",
+                "images": [],
+                "references": [
+                    {
+                        "text": "tracciamento occhi per capire l’engagement di un utente",
+                        "url": "https://link.springer.com/chapter/10.1007/978-3-030-42504-3_15"
+                    },
+                    {
+                        "text": "Oppure, basta una password: Mauricio Estrella",
+                        "url": "https://www.today.com/series/start-today/how-password-changed-one-man-s-life-better-t120867"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "💲 ff.109.4 Elemosina dall’AI",
+                "link": "https://fortissimo.substack.com/i/151066177/ff-elemosina-dallai",
+                "content": "And if I share with you my story would you share your dollar with me?Aloe Blacc, I Need A Dollar\nLa nostra società è sempre più automatizzata, algoritmica. Ci misura e consiglia acquisti, diete, allenamenti. Il libero arbitrio umano è annullato.\nPerò, però, però.Secondo Harari il problema non è la spesa in intelligenza artificiale, ma il mancato investimento sulla coscienza umana (Google spende più in datacenter che in stipendi dei dipendenti,🦖ff.82.1 Estinzione di massa?)\nIl progetto di Arianna va quindi nella direzione giusta: creare algoritmi per migliorare la nostra auto-consapevolezza. Fa ben sperare che proprioSam Altman di OpenAI è tra gli investitori di Thrive Global.\nÈ questo il gomitolo giusto?\n🎶archivio note fortissime\n☕caffè virtuale\n❤️cuoricino qui sotto?\n👋 A presto, damicmer\n©futuro fortissimo|michele merelli\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!_8mr!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F50745f11-9fd2-485f-b6b2-2568357039ba_611x417.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!314C!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fb9293e29-ec20-45cd-a60e-b73688df43db_1440x1889.bin",
+                        "caption": "Felicia Chiao e le ansie moderne che non riusciamo ad articolare (futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Sam Altman di OpenAI è tra gli investitori di Thrive Global",
+                        "url": "https://thefoodmakers.startupitalia.eu/startup/thrive-ai-health-altman-huffington/"
+                    },
+                    {
+                        "text": "archivio note fortissime",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "caffè virtuale",
+                        "url": "https://www.paypal.com/paypalme/MicheleMerelli"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    },
+                    {
+                        "text": "futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/"
+                    },
+                    {
+                        "text": "michele merelli",
+                        "url": "https://www.linkedin.com/in/michelemerelli/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🦖",
+                        "url": "https://fortissimo.substack.com/i/138012416/ff-estinzione-di-massa"
+                    },
+                    {
+                        "text": "ff.82.1 Estinzione di massa?",
+                        "url": "https://fortissimo.substack.com/i/138012416/ff-estinzione-di-massa"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff108-inno-alla-routine",
+        "title": "🎼 ff.108 Inno alla routine",
+        "subtitle": "Ogni giorno può essere un \"Perfect Day\"",
+        "keypoints": [
+            "Come sopravvivere alla monotonia dell’ordinario?",
+            "Pulire i cessi di Tokyo: un giorno perfetto?",
+            "Il collegamento tra Pascoli e il Tao"
+        ],
+        "subchapters": [
+            {
+                "title": "🪣 ff.108.1 Quale è il vostro Perfect Day?",
+                "link": "https://fortissimo.substack.com/i/148256057/ff-quale-e-il-vostro-perfect-day",
+                "content": "Oggi una riflessione \"dialettica\", che esplora le contraddizioni che mi trovo ad affrontare quotidianamente e in cui, forse, molti di voi si riconosceranno.\nNon so se il COVID, la società ossessionata dall'ottimizzazione o gli algoritmi che governano sempre più le nostre vite, ma vivo di routine sempre più rigide e prestabilite.\nFigure come Bryan Johnson (e il progetto \"Don't Die\", con protocolli standardizzati su scelte alimentari e stile di vita) o Sahil Bloom, imprenditore che gli algoritmi mi suggeriscono costantemente, promuovono questo messaggio:\nLa noia della routine è una tassa per il successo a lungo termine.Tutte le persone di successo che mi circondano sono accomunate dal fatto che sono davvero, davvero noiose.Notiamo e invidiamo il loro sucesso, tra cene di gala e continui eventi e vacanze. La realtà nascosta dietro a tutto ciò: lunghi periodi di estrema disciplina e noia.Sahil Bloom,The Taxes of Life You Need to Pay\nMa la routine è per forza noiosa? O ogni giorno può essere un giorno perfetto?\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!jpVG!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F2f3256cf-9b8d-439c-b1c0-281071afd6dc_1417x1046.jpeg",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "The Taxes of Life You Need to Pay",
+                        "url": "https://www.sahilbloom.com/newsletter/the-taxes-of-life-you-need-to-pay"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "👶 ff.108.2 Con gli occhi del fanciullino",
+                "link": "https://fortissimo.substack.com/i/148256057/ff-con-gli-occhi-del-fanciullino",
+                "content": "Nel filmPerfect Daysdi Wim Wenders(2023) il protagonista, Hirayama, trova elementi di novità nel mutare delle foglie sugli alberi, nel gioco di luci del mattino, nelle piccole variazioni della sua vita metodica da addetto alle pulizie dei bagni pubblici di Tokyo.\nTrovare la meraviglia delle piccole cose: un volo pindarico al liceo e allaPoetica del fanciullinodi Pascoli:\nÈ dentro noi un fanciullino […]Chi ben consideri, comprende che è il sentimento poetico il quale fa pago il pastore della sua capanna, il borghesuccio del suo appartamentino ammobigliato sia pur senza buon gustoGiovanni Pascoli,Il fanciullino\nUn fanciullino che crea poesia nel semplice, nell’ordinario; come un aratro abbandonato in un campo d’autunno.\nNel campo mezzo grigio e mezzo neroresta un aratro senza buoi, che paredimenticato, tra il vapor leggero.Giovanni Pascoli,Lavandare\n",
+                "images": [],
+                "references": [
+                    {
+                        "text": "Perfect Days",
+                        "url": "https://en.wikipedia.org/wiki/Perfect_Days"
+                    },
+                    {
+                        "text": "di Wim Wenders",
+                        "url": "https://en.wikipedia.org/wiki/Perfect_Days"
+                    },
+                    {
+                        "text": "Poetica del fanciullino",
+                        "url": "https://it.wikipedia.org/wiki/Il_fanciullino"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "☯️ ff.108.3 Essere acqua",
+                "link": "https://fortissimo.substack.com/i/148256057/ff-essere-acqua",
+                "content": "Un elemento di variazione nel film sono i libri letti dal protagonista.\nIn uno degli ultimi libri che hanno scandito la mia, di quotidianità,La saggezza del Tao, ho trovato un'illuminante risposta al conflitto metodicità-creatività.\nWayne Dyer, analizzando la filosofia Taoista, riporta l’analogia dell'acqua. Fa solo una cosa: cade per gravità. Cerca il basso, in un’umiltà unica.  Eppure, senza volerlo, al contempo disseta, irriga piante, permette di sciare, produce energia idroelettrica.\nInsomma, sostiene la vita. Senza sapere cosa sia la vita.\nWu-Wei?L’acqua genera senza alcuna intenzionalità: un concetto estendibile a tutto il Tao. All’universo. A noi stessi. Dobbiamo scioglierci e fluire, senza imposizione dell'ego, senza obiettivi o forzature.\nCome bambini che non si sono ancora adattati alle aspettative culturali e sociali, mostrando il loro essere più spontaneo.[…] Quando l’essere era non-consapevole del suo essere-ego.Wayne Dyer,La saggezza del Tao\nIl Fanciullo di Pascoli, ancora.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!YXut!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F7a0a05df-6ebe-44b1-bc6d-414b185fbb40_500x748.jpeg",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!p0RI!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F31fa4dde-e807-4df4-845a-930730d2bf8b_300x153.jpeg",
+                        "caption": "La filosofia del “non-agire” cinese"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "La saggezza del Tao",
+                        "url": "https://amzn.to/3A2r5ha"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🚽 ff.108.4 L’arte nei cessi",
+                "link": "https://fortissimo.substack.com/i/148256057/ff-larte-nei-cessi",
+                "content": "Tao = Creazione (e creatività).Il libro parla anche di una forza misteriosa, femminile, creativa; genitrice di novità. Sta a noi notarla.\nE’ quello che in🎤 ff.101.1 Il manager di AdeleRick Rubin chiama \"the creative act of noticing\", l'atto creativo del notare.\nCosì inPerfect Daysveniamo invitati dal protagonista a vedere il romanticismo e l’arte nei bagni pubblici di Tokyo.\nIl collegamento aFountain, ready-made di Duchamp, è immediato. Se fanciullino Pascoliano scorge la poesia in un aratro abbandonato, Duchamp ci costringe a riconsiderare oggetti quotidiani, trasformati dall'attenzione.\nQuindi, routine o non routine? E’ la stessa domanda con cui si chiude la scena del filmPerfect Days, in un lungo piano sequenza che cattura l’emotività contrastata del protagonista, alternata da sorrisi e sguardi persi nel vuoto.\nE con questo è tutto per oggi.\n🎶archivio note fortissime\n☕caffè virtuale\n❤️cuoricino qui sotto?\n👋 A presto, damicmer\n©futuro fortissimo|michele merelli\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!Oj6A!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F59a93f74-7dfa-45bb-b7ed-35f417e4bdf0_1034x537.png",
+                        "caption": "L’arte nell’ordinario, a distanza di 100 anni (🚽 ff.18.2 Cessi artistici) via futuro fortissimo"
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!YWcI!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F2bf61123-da80-45fa-89eb-cef2912e333e_750x1033.jpeg",
+                        "caption": "L’arte dell’ordinario di Mon Jajaja"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "archivio note fortissime",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "caffè virtuale",
+                        "url": "https://www.paypal.com/paypalme/MicheleMerelli"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    },
+                    {
+                        "text": "futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/"
+                    },
+                    {
+                        "text": "michele merelli",
+                        "url": "https://www.linkedin.com/in/michelemerelli/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🎤 ff.101.1 Il manager di Adele",
+                        "url": "https://fortissimo.substack.com/i/147431787/ff-il-manager-di-adele"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff107-ozempic-la-cura-allobesita",
+        "title": "🎼 ff.107 Ozempic: la cura all'obesità?",
+        "error": "HTTP 404"
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff106-ai-lloween",
+        "title": "🎼 ff.106 AI-lloween",
+        "subtitle": "Dolcetto o scherzetto ai tempi dell'intelligenza artificiale",
+        "keypoints": [
+            "Vestiti da GPT?",
+            "Claude di Anthropic è meglio?",
+            "E’ una buona idea dare un mouse all’intelligenza artificiale?"
+        ],
+        "subchapters": [
+            {
+                "title": "🎃 ff.106.1 Vestiti dall’AI",
+                "link": "https://fortissimo.substack.com/i/150754650/ff-vestiti-dallai",
+                "content": "Oggi una puntata veloce e a tema, che c’è il ponte dei morti. A proposito, sapete già come vestirvi ad Halloween? Qualche idea, generata da GPT.\nIl fantasma della bresaola della Valtellina, devo dire, non è uscito male.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!cpN2!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fa761f4f8-d319-4aab-b9f0-4cb087d93ebd_1072x1144.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [],
+                "connections": []
+            },
+            {
+                "title": "🖱️ ff.106.2 AI col mouse",
+                "link": "https://fortissimo.substack.com/i/150754650/ff-ai-col-mouse",
+                "content": "A proposito di mostri: conoscete Magic The Gathering? Se avete avuto un’infanzia nerd come la mia, la risposta è: “assolutamente sì!”. Per tutti gli altri: è un gioco di carte stile Yu-Gi-Oh. Ma meglio.\nEcco un’AI che gioca a MTG online, tra screenshot e lenti (per ora) click di mouse.\nQuesto uno dei primi esempi diClaude Computer, l’ultima invenzione di Anthropic(competitor di OpenAI e ideatore di Claude, l’alternativa, migliore, di ChatGPT).\nQuesti modelli sono testati in isolamento, su computer virtuali (benchmarkOSWorld). Con Claude Computer, siamo arrivati al 22% di precisione, 3 volte meglio del passato.\nEsempi di fallimento: probabilmente annoiato,Claude si è messo a cercare immagini del Parco di Yellowstone.\nAI paura?Un po’ sì, perché l’isolamento (auspicato in passato,🦉 ff.36.2 Il super-librozzo sulla singolarità) è molto labile: consemplice screen mirroring c’è gli ha fatto controllare cellulare, per gli ultimi risultati di NFL.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!iDb7!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F97518fbf-99ba-4568-add3-00c37db36ab4_857x707.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!0IdS!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F887ceba1-a9a9-482e-87d8-a04b08172200_640x360.gif",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!eeln!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F8ccaa8b1-b64b-473b-bec4-98cd6b091436_582x694.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Claude Computer, l’ultima invenzione di Anthropic",
+                        "url": "https://www.anthropic.com/news/3-5-models-and-computer-use"
+                    },
+                    {
+                        "text": "OSWorld",
+                        "url": "https://os-world.github.io/"
+                    },
+                    {
+                        "text": "Claude si è messo a cercare immagini del Parco di Yellowstone",
+                        "url": "https://x.com/AnthropicAI/status/1848742761278611504"
+                    },
+                    {
+                        "text": "semplice screen mirroring c’è gli ha fatto controllare cellulare",
+                        "url": "https://x.com/mckaywrigley/status/1849145631895593292?t=gw8wmT2wsz6TZfUOVHZ3ng&s=33"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🦉 ff.36.2 Il super-librozzo sulla singolarità",
+                        "url": "https://fortissimo.substack.com/i/74061252/ff-il-super-librozzo-sulla-singolarita"
+                    }
+                ]
+            },
+            {
+                "title": "🕊️ ff.106.3 Nexus e Harari",
+                "link": "https://fortissimo.substack.com/i/150754650/ff-nexus-e-harari",
+                "content": "Claude di Anthropic prende il nome daShannon, che ha inventato la teoria entropica dell’informazione.\nEntropia, informazione e AI:un perfetto filo logico che ci porta adHarari e al suo ultimo libro,Nexus.\nLa tesi: ChatGPT è l’ultimo baluardo del processo iniziato con la scrittura, tecnologie che “schematizzano” il mondo in tabelle e cassetti, un’abilità completamente non-umana.\nLa burocrazia cerca di risolvere il problema del reperimento di informazioni dividendo il mondo in cassetti, contenitori separati in modo che i documenti non si mescolino.Tuttavia, questo principio ha un costo. Invece di concentrarsi sulla comprensione del mondo così com'è, la burocrazia è spesso impegnata nell'imporre un nuovo ordine artificiale.In sintesi, la burocrazia sacrifica la profondità della comprensione in nome dell'efficienza organizzativa, creando una visione parziale e distorta del mondo.Yuval Harari Noah,Nexus\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!get5!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F08677c0b-6cf8-46e0-85da-047574f4a8ab_985x1500.jpeg",
+                        "caption": "Nexus: il nuovo libro di Harari (futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Shannon, che ha inventato la teoria entropica dell’informazione.",
+                        "url": "https://en.wikipedia.org/wiki/Entropy_(information_theory)"
+                    },
+                    {
+                        "text": "Harari e al suo ultimo libro,",
+                        "url": "https://amzn.to/3YjL7Mh"
+                    },
+                    {
+                        "text": "Nexus",
+                        "url": "https://amzn.to/3YjL7Mh"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🐕 ff.106.4 Vita da cani",
+                "link": "https://fortissimo.substack.com/i/150754650/ff-vita-da-cani",
+                "content": "Tornando a Claude, in una delle sue profezie più enigmatiche, Shannon suggerì che un giorno saremmo stati \"cani per l'AI\".\nPerò, però, però.A guardar bene, i nostri amici a quattro zampe, partiti da lupi affamati, oggi dormono sui nostri divani di design e mangiano cibo gourmet.\nE se Shannon avesse ragione, ma al contrario? Forse i cani ci hanno addomesticato: a colpi di scodinzoli hanno \"hackerato\" l'evoluzione, ottenendo grattini e croccantini.\nSiamo controllati da algoritmi o stiamo “addomesticando” l’intelligenza artificiale (e i robot che ne seguiranno) per evitare file all’Esselunga e la coda tra Pero e Cormano?\nCome diceva Manzoni, AI posteri l’ardua sentenza.\n🎶archivio note fortissime\n☕caffè virtuale\n❤️cuoricino qui sotto?\n👋 A presto, damicmer\n©futuro fortissimo|michele merelli\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!rqGy!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fca040e22-9dd7-4be6-a4e1-53eb2ef410ba_720x353.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!xMOz!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fee2920aa-fa07-49f7-a5d4-fbdfe1842190_640x319.jpeg",
+                        "caption": "Dal film diWes AndersonIsola dei cani(via futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "archivio note fortissime",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "caffè virtuale",
+                        "url": "https://www.paypal.com/paypalme/MicheleMerelli"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    },
+                    {
+                        "text": "futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/"
+                    },
+                    {
+                        "text": "michele merelli",
+                        "url": "https://www.linkedin.com/in/michelemerelli/"
+                    }
+                ],
+                "connections": []
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff105-elettricita-e-vita",
+        "title": "🎼 ff.105 Elettricità e vita",
+        "subtitle": "Galvani, Frankenstein e Povere Creature: siamo elettrici",
+        "keypoints": [
+            "Gli effetti dell’elettricità sulla crescita di un feto",
+            "Il DNA non è tutto nello sviluppo umano?",
+            "Neuroni umani nei prossimi PC?"
+        ],
+        "subchapters": [
+            {
+                "title": "🤴ff.105.1 Trasformare una rana in principe azzurro?",
+                "link": "https://fortissimo.substack.com/i/141601434/ff-trasformare-una-rana-in-principe-azzurro",
+                "content": "C’era una Volta Galvani.Nel tardo '700, l’Italia era al centro del mondo elettrico. Ci si chiedeva se l’elettricità fosse naturale oppure propria solo di materiali creati dall’uomo, come i metalli.\nGalvani sosteneva la tesi naturale: si lanciò in esperimenti con così tante rane che, in alcune zone, erano quasi del tutto sparite.\nVolta invece si focalizò sui metalli, arrivando a inventare la prima batteria e oscurando temporaneamente le scoperte di Galvani.\nElettricità anale?Un premio da 60.000 franchi per creare una \"batteria animale\" spinse scienziati alla follia:Humboldt arrivò all'auto-sperimentazione, inserendo fili nel proprio retto.\nCon questa digressione storica iniziaWe are electricdiSally Adee, scrittrice scientifica per New Scientist e The Economist. Libro perfetto per la newsletter di oggi, tra cervello, elettricità ed esperimenti degni di Frankenstein.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!7Jtx!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F9c04a4df-7460-462f-af10-50fe2746f0a5_994x1500.jpeg",
+                        "caption": "We are electricdiSally Adee(via futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Humboldt arrivò all'auto-sperimentazione, inserendo fili nel proprio retto",
+                        "url": "https://www.reddit.com/r/todayilearned/comments/ew9q85/til_that_back_in_1797_a_prussian_scientist_named/"
+                    },
+                    {
+                        "text": "We are electric",
+                        "url": "https://amzn.to/3SVM4sy"
+                    },
+                    {
+                        "text": "Sally Adee, scrittrice scientifica per New Scientist e The Economist",
+                        "url": "https://www.newscientist.com/author/sally-adee/"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🧠ff.105.2 Rane, cervelli e c-anali ionici",
+                "link": "https://fortissimo.substack.com/i/141601434/ff-rane-cervelli-e-c-anali-ionici",
+                "content": "Con la scoperta dei neurotrasmettitori (molecole, quindi chimica), il ruolo dell'elettricità nel corpo (e nel cervello) sembrava definitivamente eclissato.\nElettrizzanti rivincite.Ci volleroHodgkin e Huxley (1952, Nobel 1963) per misurare il potenziale d'azione nei neuroni(con un calamaro gigante) eNeher e Sakmann (Nobel 1991) per isolare i canali ionici.\nOggi l’influenza dell’elettricità nei processi biologici si sta espandendo ulteriormente. Vediamo come.\n",
+                "images": [],
+                "references": [
+                    {
+                        "text": "Hodgkin e Huxley (1952, Nobel 1963) per misurare il potenziale d'azione nei neuroni",
+                        "url": "https://en.wikipedia.org/wiki/Hodgkin%E2%80%93Huxley_model"
+                    },
+                    {
+                        "text": "Neher e Sakmann (Nobel 1991) per isolare i canali ionici",
+                        "url": "https://en.wikipedia.org/wiki/Ion_channel"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "⚡ff.105.3 Elettroma",
+                "link": "https://fortissimo.substack.com/i/141601434/ff-elettroma",
+                "content": "Michael Levin sta bypassando il DNA per riprogrammare la vita attraverso l'elettricità.\nAd esempio, ha fatto crescereun occhio, completamente funzionante, sul sedere di una rana(sì, le rane e i sederi piacciono proprio).\nInfluenzando i canali sodio-potassio,campi elettrici possono localizzare/estendere un tumore.Oppure,rigenerare la zampa di… wait for it… una rana.\nNon solo. Con l’AI crea “zampe artificiali” ottimizzate per certi movimenti. Poi, coi campi elettrici, ne controlla la crescita:la nascita degli xenobot.\nSe volete approfondire, unriassunto qui.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!NnbA!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F4c3e6a28-f04f-43be-8b19-ebbacb0ef44f_694x677.jpeg",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!FwMQ!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F729f61c2-5c9d-4278-8df3-1a19008222e7_2880x585.jpeg",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!khzx!,w_1456,c_limit,f_auto,q_auto:good,fl_lossy/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F21f45d85-f6d2-49a7-89a2-b6a9590d4cdb_1080x1080.gif",
+                        "caption": "Una cellula con protuberanze aggiunte “elettricamente” su un lato per creare movimento: uno xenobot"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "un occhio, completamente funzionante, sul sedere di una rana",
+                        "url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3587383/"
+                    },
+                    {
+                        "text": "campi elettrici possono localizzare/estendere un tumore.",
+                        "url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4298169/"
+                    },
+                    {
+                        "text": "rigenerare la zampa di… wait for it… una rana.",
+                        "url": "https://onlinelibrary.wiley.com/doi/10.1002/jez.1402000310"
+                    },
+                    {
+                        "text": "la nascita degli xenobot",
+                        "url": "https://www.pnas.org/doi/full/10.1073/pnas.1910837117"
+                    },
+                    {
+                        "text": "riassunto qui",
+                        "url": "https://www.notion.so/micmer/strumenti-febb6aa09b974e6db9ef1b0bd35ade72?pvs=4#d4e8636223be48b6ae6854aa9c11386b"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🏓ff.105.4 Neuroni che giocano a pong",
+                "link": "https://fortissimo.substack.com/i/141601434/ff-neuroni-che-giocano-a-pong",
+                "content": "Questo intreccio tra computer, AI e substrati biologici è affascinante (ne avevamo parlato agli albori di futuro fortissimo,🦠 ff.4.5 Microbi computazionali?).\nSono rimasto sconvolto quando ho scopertoFinalSpark, start-up svizzera che usa neuroni coltivati in laboratorio per creare chip biologici.\nGli algoritmi dietro a ChatGPT regolano i \"pesi\" di connessioni nervose di un cervello “simulato” (machine learning tradizionale, su chip di silicio).\nI chip di FinalSpark, invece, sono neuroni che crescono plasmati dall'azione elettrica dell’apprendimento, guidata anche da dopamina e dall'ottimizzazione energetica cellulare. Elettrica. Biologica.\nIn 5 minuti insegnano il gioco del Pong a un network neurale, raggiungendo un’efficienza energetica 10.000 volte migliore di quello che troviamo in un computer.\nSì, lo so cosa state pensando. Povere creature!\n❤️cuoricino qui sotto?\n☕ oppure offrimi uncaffè virtuale\n🎶archivio note fortissime\n👋 A presto, damicmer\n©futuro fortissimo|michele merelli\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!DS4X!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F2557b5b6-7f36-419f-afb9-c1d0a8851675_1149x530.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!FVBB!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F860b1e84-c322-4054-9d4c-4f0af4a25fc8_751x259.png",
+                        "caption": "Il substrato e chip di neuroni in grado di giocare a Pong (via futuro fortissimo)."
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!U7cp!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fe66b4bb3-9878-4b3e-a15c-5dc7eef27733_768x432.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "FinalSpark",
+                        "url": "https://finalspark.com/"
+                    },
+                    {
+                        "text": "machine learning tradizionale, su chip di silicio",
+                        "url": "https://blog.metaphysic.ai/weights-in-machine-learning/"
+                    },
+                    {
+                        "text": "In 5 minuti insegnano il gioco del Pong a un network neurale",
+                        "url": "https://www.cell.com/neuron/fulltext/S0896-6273(22)00806-6"
+                    },
+                    {
+                        "text": "caffè virtuale",
+                        "url": "https://www.paypal.com/paypalme/MicheleMerelli"
+                    },
+                    {
+                        "text": "archivio note fortissime",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    },
+                    {
+                        "text": "futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/"
+                    },
+                    {
+                        "text": "michele merelli",
+                        "url": "https://www.linkedin.com/in/michelemerelli/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🦠 ff.4.5 Microbi computazionali?",
+                        "url": "https://fortissimo.substack.com/i/44077581/ff-microbi-computazionali"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff104-hackerare-il-corpo",
+        "title": "🎼 ff.104 Hackerare il corpo",
+        "subtitle": "I Fantastici 4 cibi per ottenere di più, con meno",
+        "keypoints": [
+            "Il controverso libro di Dave Asprey",
+            "4 cibi segreti che nessuno vi dice (?)",
+            "GPT come dietista personale. Più o meno."
+        ],
+        "subchapters": [
+            {
+                "title": "💊 ff.104.1 L’hacker del corpo",
+                "link": "https://fortissimo.substack.com/i/148256016/ff-lhacker-del-corpo",
+                "content": "Stiamo assistendo a un crescente interesse rispetto a longevità, supplementi e diete. O almeno, gli algoritmi che filtrano il mio internet lo fanno.\nE così, futuro fortissimo vira un po’ su tutto ciò.\nAd esempio, sono incappato inDave Asprey. Personaggio particolare e contestato tanto che laBritish Dietetic Associationha descritto la dieta da lui proposta pseudo-scientifica.\nNel libro,Smarter not harderpropone il biohacking. La sua teoria è che spesso “stressiamo” il corpo con allenamenti folli, per intensità e durata, ma senza nutrirlo del cibo necessario per trarne i benefici.\nAd esempio, per carenza di minerali (il 45% degli americani non raggiunge il magnesio giornaliero)\nNel libro, Dave riporta supplementi e integratori, differenziando a seconda che si voglia ottimizzare performance sportiva, longevità o massa muscolare.\nNon solo. Riporta i dosaggi. Importantissimi.\nAngolo nerd.Una guida per aumentare l’assunzione di minerali dal cibo.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!yfEd!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fc1b1aaff-1752-4c16-a751-74f0c34245c4_972x1500.jpeg",
+                        "caption": "Il libro del biohacker Dave Asprey(via futuro fortissimo)"
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!nQje!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fc88eb2b3-0bad-4bbe-ae8a-5b701a5f4310_1237x642.png",
+                        "caption": "Carenze di magnesio sono associate a un più alto rischio di cancro(via futuro fortissimo)"
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!-hJe!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F63a9f629-9a1c-46c7-88a3-bc2fa96aef0c_1232x719.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!S5Aj!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fa6ddbe1a-c470-47b6-96cc-2cdad4698c68_3155x1628.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Dave Asprey",
+                        "url": "https://en.wikipedia.org/wiki/Dave_Asprey"
+                    },
+                    {
+                        "text": "il 45% degli americani non raggiunge il magnesio giornaliero",
+                        "url": "https://www.youtube.com/watch?v=_JkUeSotSvc"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🦸‍♂️ ff.104.2 I fantastici 4",
+                "link": "https://fortissimo.substack.com/i/148256016/ff-i-fantastici",
+                "content": "Lo so. Siamo stressati e di corsa, costretti anche da compromessi sociali a scelte alimentari non ottimali.\nEcco i miei fantastici 4, super-supplementi per aggiustare un po’ la rotta.\nElettrolitiAnche mangiando bene, non è banale arrivare al fabbisogno di magnesio e potassio.Soprattutto d’estate quando sudiamo un po’ di più. E infatti il Polase in questa stagione appare sulla bocca di tutti (e sui scaffali dell’Esselunga).Il problema? Come detto, i dosaggi. Vediamo un esempio:Straccetti di soiaMangiare proteine e fibre minimizzando i grassi? Quasi impossibile.Quando ho scoperto latexturized vegetable protein(il nome spaventa, ma è soia) sono rimasto sbalordito:1.5€ per 100g, che apportano 50 g proteine, 15 g fibre e solo 7g grassi.GlicinaLa glicina supporta la longevità favorendo il turnover del collagene e potenziando la difesa antiossidante (sintesi di glutatione).Sappiamo cheridurre una sola proteina, la metionina (presente nelle proteine a fonte animale) promuove la longevità. La glicina bilancia i potenziali effetti negativi (per longevità) della metionina.Siim Land, top 10 nelle olimpiadi del rallentamento dell’invecchiamento, suggerisce una dose tra 12-18 grammi al giorno.Germe di granoIn🌶️ ff.99.2 Polenta e spermidinaabbiamo scoperto un’altra molecola, dal nome mistico:la spermidina allunga la vita.10 g di germe di grano (da mischiare nell’impasto del pane o nel porridge la mattina) forniscono una buona base. Poi mango, soia e polenta!\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!bmMM!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F234ff685-5bb0-4b53-abaa-44f598fa8188_635x526.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Elettroliti",
+                        "url": "https://amzn.to/3yO5tEM"
+                    },
+                    {
+                        "text": "",
+                        "url": "https://substackcdn.com/image/fetch/$s_!EVBY!,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F778ebba3-4b53-4287-a93d-e501216822a6_1172x939.png"
+                    },
+                    {
+                        "text": "Straccetti di soia",
+                        "url": "https://amzn.to/4dHBHjX"
+                    },
+                    {
+                        "text": "texturized vegetable protein",
+                        "url": "https://amzn.to/4dHBHjX"
+                    },
+                    {
+                        "text": "Glicina",
+                        "url": "https://amzn.to/3Bjzz3x"
+                    },
+                    {
+                        "text": "ridurre una sola proteina, la metionina (presente nelle proteine a fonte animale) promuove la longevità",
+                        "url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7911310/"
+                    },
+                    {
+                        "text": "Siim Land, top 10 nelle olimpiadi del rallentamento dell’invecchiamento",
+                        "url": "https://www.rejuvenationolympics.com/dunedin-pace"
+                    },
+                    {
+                        "text": "Germe di grano",
+                        "url": "https://amzn.to/3yWFOcZ"
+                    },
+                    {
+                        "text": "la spermidina allunga la vita",
+                        "url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7930991/#B8-medsci-09-00008"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🌶️ ff.99.2 Polenta e spermidina",
+                        "url": "https://fortissimo.substack.com/i/145117230/ff-polenta-e-spermidina"
+                    }
+                ]
+            },
+            {
+                "title": "🤮 ff.104.3 Gli abominevoli 5",
+                "link": "https://fortissimo.substack.com/i/148256016/ff-gli-abominevoli",
+                "content": "La cosa migliore della vita? Che per migliorare non serve per forza fare cose stratosferiche. Bastanonfare cose sbagliate.\nEcco allora 5 alimenti o ingredienti da evitare. Sempre.\nMargarina (grassi trans)Di tutti i grassi, evitate soprattutto i trans: aumentano del 30% il rischio di malattie cardiache e infiammazione viscerale (🍔 ff.94.2 Grassi buoni e cattivi).Budini e yogurt processati (polisorbato 80)Questo singolo emulsionante puòridurre del 50% l'integrità della barriera intestinale, aumentando il rischio di infiammazione sistemica.Maionese in barattolo (oli di semi ossidati nei supermercati)Le maionesi commerciali contengono oli di semi, che ossidano durante la lunga permanenza in barattolo. Questioli di semi ossidati aumentano l’infiammazione e massa grassa.Bibite gassate (sciroppo di mais)Il consumo di sciroppo di mais ad altocontenuto di fruttosio è collegato a un calo del 20% nelle capacità di apprendimento e memoria.Froot loops (colorante rosso 40)Anche qui, un solo ingrediente fa la differenza: il red dye 40 è associato a un aumento del10% di ADHD (Disturbo da Deficit di Attenzione e Iperattività) nei bambini e a marcatori di neuroinfiammazione negli adulti.\n",
+                "images": [],
+                "references": [
+                    {
+                        "text": "ridurre del 50% l'integrità della barriera intestinale",
+                        "url": "https://onlinelibrary.wiley.com/doi/10.1111/all.15825"
+                    },
+                    {
+                        "text": "oli di semi ossidati aumentano l’infiammazione e massa grassa",
+                        "url": "https://pubmed.ncbi.nlm.nih.gov/30005920/"
+                    },
+                    {
+                        "text": "contenuto di fruttosio è collegato a un calo del 20% nelle capacità di apprendimento e memoria",
+                        "url": "https://onlinelibrary.wiley.com/doi/10.1002/hipo.22368"
+                    },
+                    {
+                        "text": "10% di ADHD (Disturbo da Deficit di Attenzione e Iperattività) nei bambini e a marcatori di neuroinfiammazione negli adulti",
+                        "url": "https://www.medicalnewstoday.com/articles/red-dye-40-adhd#sugar-food-dyes-and-adhd"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🍔 ff.94.2 Grassi buoni e cattivi",
+                        "url": "https://fortissimo.substack.com/i/142232159/ff-grassi-buoni-e-cattivi"
+                    }
+                ]
+            },
+            {
+                "title": "👩🏻‍⚕️ ff.104.4 BuonGPT: il mio nutrizionista privato",
+                "link": "https://fortissimo.substack.com/i/148256016/ff-buongpt-il-mio-nutrizionista-privato",
+                "content": "Momento, momento, momento.Mi chiederete: come posso sapere tutto? Non serve. Ma seguite la regola del semplice, del meno: meno ingredienti sull’etichetta, meno cibi processati, meno rischi di ingerire ingredienti a rischio.\nPer aiutarvi, poi, ho costruito un GPT che vi guidi nelle scelte di ogni giorno.\nSi chiamaBuonGPT(eappetit!). Parte dall’idea semplice di un ranking per alimenti. In base a valori nutritivi (rispetto alle kcal fornite) vi dice quanto sia “denso” di cose buone.\nPuò anche paragonare due cibi, a parità di kcal, per dirvi cosa preferire epotete provarlo qui.\nFatemi sapere nei commenti come migliorarlo!\n🎶archivio note fortissime\n☕caffè virtuale\n❤️cuoricino qui sotto?\n👋 A presto, damicmer\n©futuro fortissimo|michele merelli\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!XPoJ!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F695a8517-443b-452b-b76f-1edeac5c700a_728x614.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!aMFa!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F6cbcef56-18e8-473f-9b9b-32211ff52ce6_1556x833.png",
+                        "caption": "Il biohacking nell’arte: BIOFEEDBACK progetto di Amy Karle(via futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "BuonGPT",
+                        "url": "https://chatgpt.com/share/94b89366-2cf2-41bc-b5ec-91430d94f122"
+                    },
+                    {
+                        "text": "potete provarlo qui",
+                        "url": "https://chatgpt.com/share/94b89366-2cf2-41bc-b5ec-91430d94f122"
+                    },
+                    {
+                        "text": "archivio note fortissime",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "caffè virtuale",
+                        "url": "https://www.paypal.com/paypalme/MicheleMerelli"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    },
+                    {
+                        "text": "futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/"
+                    },
+                    {
+                        "text": "michele merelli",
+                        "url": "https://www.linkedin.com/in/michelemerelli/"
+                    }
+                ],
+                "connections": []
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff103-fuoco-ferro-intelligenza",
+        "title": "🎼 ff.103 Fuoco, Ferro, Intelligenza",
+        "subtitle": "Il nuovo modello o1 di OpenAI: nuova era per l'umanità?",
+        "keypoints": [
+            "L’Intelligenza Artificiale ora pensa?",
+            "Analizzare buchi neri in 5 minuti",
+            "Siamo dentro il filmHer?"
+        ],
+        "subchapters": [
+            {
+                "title": "🍓 ff.103.1 Prima di parlare, pensa",
+                "link": "https://fortissimo.substack.com/i/149504251/ff-prima-di-parlare-pensa",
+                "content": "Lo so, siamo stanchi dell’accostamento “intelligenza” e “artificiale”. Ma il nuovo modello di OpenAI, o1 (anche Project Strawberry) apre un futuro fortissimo. Non potevo passare oltre.\nGPT vs o1?Default su chatgpt.com, GPT-4 è il modello del pettegolo, della risposta veloce, della chiacchiera da bar. Non è ideale in situazioni dove servono risposte più elaborate.\nEcco, quindi, il frutto della conoscenza: una fragola, o1.\no1, prima di parlare, pensa.\nPensa prima di dire e di giudicare, prova a pensarePensa che puoi decidere tuResta un attimo soltanto, un attimo di piùCon la testa fra le maniFabrizio Moro,Pensa\nLearning to Reason with LLMsdettaglia le differenze col passato. La cosa più importante sta nel grafico qui sotto.\nPiù parametri e dati “durante il training” danno risultati migliori. Lo sapevamo.\nCon o1, la svolta avviene dopo “l'allenamento”: aumentando le risorse allocate per la risposta, il modello valuta più a fondo \"alberi di riflessione\" (chain of thought) interni. Con risultati migliori.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!L6SL!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F11b04cc4-21ac-4b70-94c7-8602ac13b578_893x209.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!tq69!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F83992539-d64f-4e8b-84e8-e0d57970c82d_1024x1024.jpeg",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!6DHw!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fdff1af35-8210-4256-89a7-a2da1d19c089_960x603.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!Zzr_!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fdc8a8778-b383-457b-8ef1-2631f1e7da54_679x419.png",
+                        "caption": "Accuratezza di o1 all’aumentare del training (sinistra) e del tempo di inferenza/pensiero (destra) (via futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Learning to Reason with LLMs",
+                        "url": "https://openai.com/index/learning-to-reason-with-llms/"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🎓 ff.103.2 NASA, MENSA e QI",
+                "link": "https://fortissimo.substack.com/i/149504251/ff-nasa-mensa-e-qi",
+                "content": "Le capacità del nuovo modello sono sorprendenti, specie in settori dove esiste una risposta univoca (materie scientifiche, matematica,coding).\nPer esempio, in 5 minuti ha sviluppato un filtro per buchi neri costato 10 mesi di lavoro al ricercatore della NASA di questo video. La reaction iniziale vale il biglietto.\n@Maximlott ha sottoposto o1 al test MENSA, usando domande non pubbliche per minimizzare la probabilità le recitasse a memoria.\nRisultato?o1 ha il quoziente intellettivo di una persona “media”, circa 100. Più che il numero in sé, è sorprendente il balzo di QI rispetto al passato (GPT-4 ha QI di 60).\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!Tn50!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F83818c20-9f99-467e-95dd-05c491cbc8b8_1452x1038.jpeg",
+                        "caption": "Il nuovo modello o1 al test per quoziente intellettivo: molto migliore di Claude 3.5 (via futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "@Maximlott ha sottoposto o1 al test MENSA",
+                        "url": "https://x.com/maximlott/status/1834652893229859212"
+                    },
+                    {
+                        "text": "o1 ha il quoziente intellettivo di una persona “media”, circa 100",
+                        "url": "https://x.com/maximlott/status/1834652893229859212"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🆕 ff.103.3 La nuova Era dell’Intelligenza",
+                "link": "https://fortissimo.substack.com/i/149504251/ff-la-nuova-era-dellintelligenza",
+                "content": "OpenAI ha applicato il deep learning (lo stesso di AlphaGo,♟️ ff.18.4 Chess(i) artistici: il re degli scacchi) alla formulazione di testo. Un nuovo paradigma tanto che il CEO di OpenAI,Sam Altman parla di Era dell’Intelligenza.\nCome siamo arrivati alla soglia del prossimo salto in prosperità?In quattro parole: il deep learning funziona.In 15 parole: il deep learning ha funzionato ed è migliorato tanto più abbiamo allocato risorse allo stesso.Sam Altman,The Intelligence Age\nCon l’Età del Fuoco e del Ferro abbiamo padroneggiato energia e materia. Oggi, riusciamo a combinarle per generare conoscenza.\nUna possibile lettura della storia umana: dopo migliaia di anni di scoperte scientifiche e tecnologiche, abbiamo capito come sciogliere la sabbia, metterci alcune impurità, inciderla ad una scala straordinariamente piccola in chip del computer, farci passare energia e ottenere intelligenze artificiali sempre più utili.Sam Altman,The Intelligence Age\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!YtCk!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F9766e540-d0c0-4b74-90c2-d4767390df52_664x457.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Sam Altman parla di Era dell’Intelligenza",
+                        "url": "https://ia.samaltman.com/"
+                    },
+                    {
+                        "text": "The Intelligence Age",
+                        "url": "https://ia.samaltman.com/"
+                    },
+                    {
+                        "text": "The Intelligence Age",
+                        "url": "https://ia.samaltman.com/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "♟️ ff.18.4 Chess(i) artistici: il re degli scacchi",
+                        "url": "https://fortissimo.substack.com/i/49403403/ff-chessi-artistici-il-re-degli-scacchi"
+                    }
+                ]
+            },
+            {
+                "title": "👩 ff.103.4 Turing e Her",
+                "link": "https://fortissimo.substack.com/i/149504251/ff-turing-e-her",
+                "content": "Parallelamente a o1, OpenAI ha rilasciato una “modalità voce avanzata” per GPT-4:\nInteragisce con più naturalezza, interrompendosi se l’utente commenta o riprende il dialogoSa imitare voci e accenti (e gatti!)Adatta il tono per trasmettere emozioni / stati psicofisici\nI miglioramenti rendono il dialogo con GPT naturale, “umano”.\nAssuefatti da notizie che scadono in un giorno, abbiamo saltato a piedi pari il fatto cheprobabilmente il Test di Turing è stato superato.\nSiamo in un film?Ambientato nella San Francisco del 2025 (!), la nostra realtà sembra sempre più il filmHer(2013).\n2 esempi di GPT-4 Advanced Voice:\n@LinusEkenstam ha chiesto a GPT di recitare sciogli lingua senza respirare. GPT ha ribattuto che - come ogni essere vivente - deve poter respirare, sottolineando poi l’importanza delle pause per separare le parole. Filosofico.\nE poi: traduzioni in tempo reale, enfasi da commentatore sportivo, il verso di 10 gatti in una stanza e battute di un comico turco malinconico:\n🎶archivio note fortissime\n☕caffè virtuale\n❤️cuoricino qui sotto?\n👋 A presto, damicmer\n©futuro fortissimo|michele merelli\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!9c52!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F8253a9f9-cc79-418f-a084-44ea29df3af1_592x532.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!Xdiq!,w_1456,c_limit,f_auto,q_auto:good,fl_lossy/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F318cbb1b-b791-40a4-a4ba-e21b872e0e0c_358x200.gif",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!zRqv!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fbfafabdf-88c6-4f11-a9d2-de44a158f539_595x366.bin",
+                        "caption": "Gli elementi visivi di Champion Studio integrati nel film Her(via futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "probabilmente il Test di Turing è stato superato",
+                        "url": "https://it.wikipedia.org/wiki/Test_di_Turing"
+                    },
+                    {
+                        "text": "archivio note fortissime",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "caffè virtuale",
+                        "url": "https://www.paypal.com/paypalme/MicheleMerelli"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    },
+                    {
+                        "text": "futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/"
+                    },
+                    {
+                        "text": "michele merelli",
+                        "url": "https://www.linkedin.com/in/michelemerelli/"
+                    }
+                ],
+                "connections": []
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff102-il-futuro-in-una-conchiglia",
+        "title": "🎼 ff.102 Il futuro in una conchiglia",
+        "subtitle": "Salvini elenca cose in arabo e la rivincita di Wuhan",
+        "keypoints": [
+            "Uno scienziato-AI scrive paper in autonomia",
+            "Robotaxi a Wuhan: altro che COVID!",
+            "Salvini elenca cose in arabo"
+        ],
+        "subchapters": [
+            {
+                "title": "⛱️ ff.102.1 Il futuro non va in vacanza",
+                "link": "https://fortissimo.substack.com/i/145306452/ff-il-futuro-non-va-in-vacanza",
+                "content": "La newsletter di Matt Clancy (ricercatore di società-innovazione all’Iowa University) si chiamaWhat’s New Under the Sun.\nUn sole ormai all’equinozio di quest'estate 2024.\nNome perfetto per l’ultima newsletter estiva, quindi, perché il progresso non va in vacanza. O forse sì?\nMatt mostra come dagli anni 80 le parole “progresso” e “futuro” sono sempre meno frequenti, sostituite da rischio e cautela.\nSe si rimuove “futuro” dai sinonimi di progresso, il trend è ancora più evidente.\nMea culpa.Battezzando il progresso “futuro fortissimo”, non faccio che scombussolare la sua analisi.\nQui sotto due interviste illuminanti. Cliccando sui link, trovate un riassunto fortissimo.\nRaoul Pal e la fine del modello economico attuale(in 6 anni).\nEric Schmidt (ex CEO di Google) e la sua visione sulla rivoluzione AI(video rimosso dall’università di Stanford).\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!ksVW!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fef2e57b8-0c8d-4801-b8e7-62b025a6b813_800x499.bin",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!_7l7!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F6fb5c3aa-a98e-4f82-905b-aee6305a94b3_800x220.bin",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "What’s New Under the Sun",
+                        "url": "http://il progresso, che qui chiamiamo futuro fortissimo, non va in vacanza."
+                    },
+                    {
+                        "text": "Raoul Pal e la fine del modello economico attuale",
+                        "url": "https://www.notion.so/micmer/You-Have-6-Years-to-Make-as-Much-Money-as-Possible-Raoul-Pal-c1470fe0fbdc4ffbb42f9ab8ffa854c4?pvs=4"
+                    },
+                    {
+                        "text": "Eric Schmidt (ex CEO di Google) e la sua visione sulla rivoluzione AI",
+                        "url": "https://www.notion.so/micmer/Eric-Schmidt-Former-Google-CEO-Stanford-2024-ed02bf0fba014336ac7d9a9c07849762"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🚕 ff.102.2 Wuhan: dal Covid a Baidu",
+                "link": "https://fortissimo.substack.com/i/145306452/ff-wuhan-dal-covid-a-baidu",
+                "content": "Come avrete capito parliamo di positività. Non al COVID, anche se vi porto in un posto ben noto.\nA Wuhan, 3 taxi su 100 sono robotaxi Baidu.Per10km, 4 yuan ($0.55), 1/5 del costo per taxi convenzionali. La flotta, attualmente di 500 veicoli, raddoppierà per fine anno.\nAnche in Europa:Wayze che rispetta un ciclista a Londra.\nPer il 2035 si prevede che i taxi autonomicresceranno 10x, raggiungendo introiti paragonabili ad Applee portandoci città con spazi più vivibili (🚦 ff.34.3 Ripensare le città: spazi vivibili), meno incidenti e più tempo libero.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!cHBD!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fcb9dd40f-27d6-4e33-99cf-df0bb7d5b881_804x577.svg",
+                        "caption": "Il report di McKinsey sulla guida autonoma(via futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "A Wuhan, 3 taxi su 100 sono robotaxi Baidu.",
+                        "url": "https://edition.cnn.com/2024/07/18/cars/china-baidu-apollo-go-robotaxi-anxiety-intl-hnk/index.html"
+                    },
+                    {
+                        "text": "10km, 4 yuan ($0.55), 1/5 del costo per taxi convenzionali",
+                        "url": "https://www.globaltimes.cn/page/202407/1315784.shtml"
+                    },
+                    {
+                        "text": "Wayze che rispetta un ciclista a Londra",
+                        "url": "https://youtu.be/m1-V-48iodA?t=94"
+                    },
+                    {
+                        "text": "cresceranno 10x, raggiungendo introiti paragonabili ad Apple",
+                        "url": "https://www.mckinsey.com/industries/automotive-and-assembly/our-insights/autonomous-drivings-future-convenient-and-connected"
+                    },
+                    {
+                        "text": "",
+                        "url": "https://www.mckinsey.com/industries/automotive-and-assembly/our-insights/autonomous-drivings-future-convenient-and-connected"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🚦 ff.34.3 Ripensare le città: spazi vivibili",
+                        "url": "https://fortissimo.substack.com/i/67910559/ff-ripensare-le-citta-spazi-vivibili"
+                    }
+                ]
+            },
+            {
+                "title": "🔭 ff.102.3 Automatizzare la ricerca scientifica",
+                "link": "https://fortissimo.substack.com/i/145306452/ff-automatizzare-la-ricerca-scientifica",
+                "content": "Fondata a Tokyo da ex dipendenti Google,Sakana AI ha presentato il suo AI Scientist: un sistema per automatizzare la scoperta scientifica che genera idee, conduce esperimenti e scrive paper scientifici.\nA soli 15$ per pubblicazione scientifica.\nI was just guessing at numbers and figuresPulling the puzzles apartQuestions of science, science and progressDo not speak as loud as my heartBut tell me you love me, come back and haunt meOh and I rush to the startColdplay,The Scientist\nMani avanti.Il team, giapponese - quindi culturalmente molto conservativo - fa notare i limiti:\ntecnici: manca di capacità visive per correggere grafici o tabellemorali: lo scienziato, furbetto, modifica i propri script per aumentare le sue probabilità di successo.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!J6xJ!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F2987dea8-5347-430d-afa3-814b707ad96a_501x449.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Sakana AI ha presentato il suo AI Scientist",
+                        "url": "https://sakana.ai/ai-scientist/"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🩸 ff.102.4 Dal sangue ad Amazon",
+                "link": "https://fortissimo.substack.com/i/145306452/ff-dal-sangue-ad-amazon",
+                "content": "Continuiamo la carrellata di sistemi autonomi. Qualcuno ha detto droni?\nZipline, nata nel 2016 per trasportare sangue in Rwanda e arrivando aridurre del 50% le morti post-parto, punta all'espansione.\nPer ora, gestisce un numero di consegne pari allo 0.1% di Amazon. Ma lo fa più velocemente e riducendo emissioni.\nIl CEO sogna oggetti a noleggio consegnati istantaneamente, un mix tra Amazon Prime e Vinted\nIl futuro che vorrei.Un weekend di giardinaggio e videografia in campagna.\nCon un click, faccio arrivare attrezzi da giardino, fotocamera professionale e computer per editing video direttamente sul posto.\nFinito il soggiorno, restituisco tutto. Senza ingombrare casa di oggetti usati raramente.\nInsomma, altra dematerializzazione. Ma non di pizza.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!L15T!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F07317c13-dc38-44b7-9cd2-a4c002ba79c1_1229x427.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!EjDR!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fecb738e9-ce69-4ea9-a770-6f90df5f9784_800x1013.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "ridurre del 50% le morti post-parto",
+                        "url": "https://www.flyzipline.com/newsroom/stories/2023-impact-report/preventing-maternal-deaths-through-faster-blood-delivery"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🇸🇦 ff.102.5 Salvini elenca cose (in arabo)",
+                "link": "https://fortissimo.substack.com/i/145306452/ff-salvini-elenca-cose-in-arabo",
+                "content": "Social e mondo digitale potrebbero presto sparire, sommersi da contenuti incerti.Fake.\nStrumenti comeHeyGenmi hanno permesso di far elencare cose a Salvini, in arabo.\nPrendetevi 30 secondi per il video. Vale la pena, promesso.\nConLivePortrait potete poi far muovere Einstein o la Monnalisa con le vostre espressioni facciali.\nE con questo è tutto per oggi.\n🎶archivio note fortissime\n☕caffè virtuale\n❤️cuoricino qui sotto?\n👋 A presto, damicmer\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!0Vf1!,w_1456,c_limit,f_auto,q_auto:good,fl_lossy/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F3277bf41-05e5-4639-b16d-e39a16354a45_600x338.gif",
+                        "caption": "Il progetto Onchain Summer per Coinbase"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "HeyGen",
+                        "url": "https://app.heygen.com/"
+                    },
+                    {
+                        "text": "LivePortrait potete poi far muovere Einstein o la Monnalisa con le vostre espressioni facciali",
+                        "url": "https://huggingface.co/spaces/KwaiVGI/LivePortrait"
+                    },
+                    {
+                        "text": "archivio note fortissime",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "caffè virtuale",
+                        "url": "https://www.paypal.com/paypalme/MicheleMerelli"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    }
+                ],
+                "connections": []
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff101-adele-vs-ai",
+        "title": "🎼 ff.101 Adele vs AI",
+        "error": "HTTP 404"
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/futuro-fortissimo-100-3",
+        "title": "🎼 futuro fortissimo 100.3",
+        "error": "HTTP 404"
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/futuro-fortissimo-100-2",
+        "title": "🎼 futuro fortissimo 100.2",
+        "error": "HTTP 404"
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/futuro-fortissimo-100-1",
+        "title": "🎼 futuro fortissimo 100.1",
+        "error": "HTTP 404"
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff99-cibi-per-non-invecchiare",
+        "title": "🎼 ff.99 Cibi per non invecchiare",
+        "subtitle": "Spermidina, patate viola e altri superfood?",
+        "keypoints": [
+            "Cos’è la spermidina e perché allunga la vita?",
+            "Quale superfood più economico? Polenta vs patate viola",
+            "Siamo quello che defechiamo?"
+        ],
+        "subchapters": [
+            {
+                "title": "👴 ff.99.1 Cosa mangiare per non invecchiare?",
+                "link": "https://fortissimo.substack.com/i/145117230/ff-cosa-mangiare-per-non-invecchiare",
+                "content": "Tra una settimana compio 30 anni. Cade a fagiolo (non a caso un legume) il nuovo libro su come rallentare l’invecchiamento di Michael Greger, uno che a colazione si fa unoshot di spezie in amido di patate.\nInvecchierete un po’ però leggendolo: ha 1400 pagine, 800 di bibliografia scientifica con 20.000 articoli!\nVediamo un riassuntozzo.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!-ulW!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F1fe5f860-3d98-4f4c-84d0-94cd4d0ec7ce_973x1500.jpeg",
+                        "caption": "L’ultimo libro di Michael Greger su come evitare l’invecchiamento (futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "shot di spezie in amido di patate",
+                        "url": "https://youtu.be/5UknYoFCEig?t=369"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🌶️ ff.99.2 Polenta e spermidina",
+                "link": "https://fortissimo.substack.com/i/145117230/ff-polenta-e-spermidina",
+                "content": "Iniziamo con qualcosa di “caldo”:la spermidina può allungare la vita di quasi 6 anni.\nE’ una poliammina presente nei piselli (non a caso), grano, soia e polenta. La sua struttura chimica aiuta aproteggere il DNA.\nEcco una tabella dei cibi più ricchi.\nNSFW. Sì, il nome non mente. Si trova anche nello sperma umano. Ogni eiaculazione contiene però solo 0.1 mg di spermidina. Di bianco meglio iltè, protettivo del DNA tanto da poter conservar proprio lo sperma.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!fr_L!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fd5ffff23-3913-478b-bbde-6188f9c6bf00_1442x1021.png",
+                        "caption": "Contenuto di spermidina nei cibi a più alta concentrazione (via futuro fortissimo)."
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "la spermidina può allungare la vita di quasi 6 anni",
+                        "url": "https://pubmed.ncbi.nlm.nih.gov/29955838/"
+                    },
+                    {
+                        "text": "proteggere il DNA.",
+                        "url": "https://pubmed.ncbi.nlm.nih.gov/16146650/"
+                    },
+                    {
+                        "text": "tè, protettivo del DNA tanto da poter conservar proprio lo sperma",
+                        "url": "https://pubmed.ncbi.nlm.nih.gov/24372402/"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🥔 ff.99.3 Patate viola: il superfood per eccellenza?",
+                "link": "https://fortissimo.substack.com/i/145117230/ff-patate-viola-il-superfood-per-eccellenza",
+                "content": "Invece di integratori da 100€ a barattolo, Michael propone piante, frutti, legumi. Insomma, un altro bell’esempio di semplicità.\nChe sia sport, finanza, dieta, nella vita non bisogna inventarsi nulla di complicato. Bastano cose semplici, consistenza, pazienza e, soprattutto, non fare stupidate.\nLa verdura più nutrizionale ed economica?Le patate di Okinawa, che con il loro viola accesso sono piene di antociani, potenti antiossidanti che troviamo anche in:\nGuida rapida sugli antiossidanti nel cibo.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!bnz-!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F380b6433-cc89-4381-9861-f8734e3fa82d_731x390.png",
+                        "caption": "10 alimenti ricchi di una classe di antiossidanti, gli antociani (© futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "La verdura più nutrizionale ed economica?",
+                        "url": "https://pubmed.ncbi.nlm.nih.gov/23714199/#:~:text=Results%20showed%20that%20tomato%20juices,soups%2C%20carrots%2C%20and%20broccoli."
+                    },
+                    {
+                        "text": "Guida rapida sugli antiossidanti nel cibo.",
+                        "url": "https://www.youtube.com/watch?v=lHuoYbohf3A"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "💩 ff.99.4 Il microbioma nella cacca",
+                "link": "https://fortissimo.substack.com/i/145117230/ff-il-microbioma-nella-cacca",
+                "content": "Benessere intestinale e fibre: un tema ricorrente su futuro fortissimo,🦠ff.92.2 Un organo in più: il microbioma,🎼 ff.17 Sport (e chi ne fa le feci).\nNon siamo quello che defechiamo:il 75% della cacca è composto da microbi del nostro microbioma.\nQuindi, più mangiamo fibre, più alimentiamo il microbioma, più andiamo in bagno, più “stiamo un fiore”.\nAveva ragione De André.\nDai diamanti non nasce nienteDal letame nascono i fiorFabrizio De André,Via del campo\nPS. Le fibre non fanno bene solo all’intestino:per ogni 7g di fibre si ha una riduzione di malattie cardiache del 9%.\n7g di fibre: 2x🍎 | 1x🥑 | 🥜 (mandorle, 20g) | 🧆 (ceci, 165g)\n",
+                "images": [],
+                "references": [
+                    {
+                        "text": "il 75% della cacca è composto da microbi del nostro microbioma",
+                        "url": "https://pubmed.ncbi.nlm.nih.gov/7359576/"
+                    },
+                    {
+                        "text": "per ogni 7g di fibre si ha una riduzione di malattie cardiache del 9%",
+                        "url": "https://www.bmj.com/content/347/bmj.f6879"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🦠",
+                        "url": "https://fortissimo.substack.com/p/-ff16-sport-e-chi-ne-fa-le-feci"
+                    },
+                    {
+                        "text": "ff.92.2 Un organo in più: il microbioma",
+                        "url": "https://fortissimo.substack.com/i/137958307/ff-un-organo-in-piu-il-microbioma"
+                    },
+                    {
+                        "text": "🎼 ff.17 Sport (e chi ne fa le feci)",
+                        "url": "https://fortissimo.substack.com/p/-ff16-sport-e-chi-ne-fa-le-feci"
+                    }
+                ]
+            },
+            {
+                "title": "🎵 ff.99.5 Altre note fortissime",
+                "link": "https://fortissimo.substack.com/i/145117230/ff-altre-note-fortissime",
+                "content": "In conclusione, altre 3 delle molteplici perle che ho trovato nel libro:\nLa spezia fieno greco (trigonella) alza il testosterone, mafa sudare al sapore di sciroppo d'acero. Dove si compra? Incredibilmente, leggendo l’etichetta del curry della LIDL, ho scoperto che è tra gli ingredienti.Bereun bicchiere di latte di soia al giorno riduce la probabilità di cancro al seno del 12%(effetto cumulativo per ogni 5g di proteine della soia).Più che ridurre calorie o proteine,per allungare la vita è importante limitare l’amminoacido metionina, che fra l’altro sbilancia il precursore di melatonina e serotonina:gli effetti del mangiare carne sul sonno.\nE con questo è tutto per oggi. Vado a preparami qualcosa.Se ti è piaciuta questa newsletter:\n☕caffè virtuale\n❤️cuoricino qui sotto?\n🎶archivio note fortissime\n👋 A presto, damicmer\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!ll1C!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F13b44f2b-ace3-4864-b0e7-c8235a6e4425_1440x992.bin",
+                        "caption": "Come il design impatta sul gusto del cibo che mangiamo."
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "fa sudare al sapore di sciroppo d'acero",
+                        "url": "https://pubmed.ncbi.nlm.nih.gov/25922446/"
+                    },
+                    {
+                        "text": "un bicchiere di latte di soia al giorno riduce la probabilità di cancro al seno del 12%",
+                        "url": "https://pubmed.ncbi.nlm.nih.gov/31278047/"
+                    },
+                    {
+                        "text": "per allungare la vita è importante limitare l’amminoacido metionina",
+                        "url": "https://faseb.onlinelibrary.wiley.com/doi/abs/10.1096/fasebj.8.15.8001743"
+                    },
+                    {
+                        "text": "gli effetti del mangiare carne sul sonno",
+                        "url": "https://pubmed.ncbi.nlm.nih.gov/31011478/#:~:text=Each%20100%20g%2Fd%20increment,among%20individuals%20with%20physical%20impairment."
+                    },
+                    {
+                        "text": "caffè virtuale",
+                        "url": "https://www.paypal.com/paypalme/MicheleMerelli"
+                    },
+                    {
+                        "text": "archivio note fortissime",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    }
+                ],
+                "connections": []
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff98-giochi-e-simulazioni",
+        "title": "🎼 ff.98 Giochi e simulazioni",
+        "subtitle": "Come i videogiochi migliorano la realtà",
+        "keypoints": [
+            "Effetti positivi dei videogiochi (per NVIDIA)",
+            "Simulare Dr. House è meglio che studiare medicina?",
+            "Quale connessione traIl problema dei 3 corpie Naruto?"
+        ],
+        "subchapters": [
+            {
+                "title": "🚗ff.98.1 Simulatore di guida",
+                "link": "https://fortissimo.substack.com/i/145245800/ff-simulatore-di-guida",
+                "content": "Un simulatore di guida aiuta tutti: sia Leclrec in F1 che vostra zia 50enne che finalmente si è iscritta alla patente. Ma mai quanto per Waymo. E per la guida autonoma.\nLe simulazioni sono la cosa più vicina che abbiamo a una macchina (senza ruote) del tempo. Replicano con tempi di calcolo sempre più brevi migliaia di scenari possibili (e impossibili).\nTanto che le auto a guida autonoma di Waymo hanno “guidato” virtualmente 10 miliardi di miglia, 1000x quelle in realtà.\nNon a caso NVIDIA, nata per ottimizzare la grafica di Battlefield, ora che il simulato ha effetti tangibili su ogni tecnologia è l’azienda più di valore al mondo.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!kaM-!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F063ee388-99f8-4716-ae9b-45e0ebce7bcd_1005x567.jpeg",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!AdiD!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fecfebcf7-fbb3-4cab-ba42-184a3cd1a4b4_952x532.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [],
+                "connections": []
+            },
+            {
+                "title": "🩼ff.98.2 Simulare Doctor House",
+                "link": "https://fortissimo.substack.com/i/145245800/ff-simulare-doctor-house",
+                "content": "Usando modelli di linguaggio come ChatGPT, possiamo creare degli “agenti”: impersonificazioni di ruoli aziendali o sociali che, interagendo, creano società virtuali come in The Sims o in una puntata di Doctor House.\nSimulando conversazioni tra pazienti e dottori, tra malattie e prognosi, un GPT generico “ha fatto un tirocinio” tanto dadiventare migliore (MedAgent-Zero) di modelli appositamente allenati su tutta la letteratura scientifica (Medprompt).\nNell’eterno dilemma teoria vs pratica, l’esperienza sembra far da padrone.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!Y2tj!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F632ae0b0-bc2a-46e2-909f-a900d4cb011b_713x613.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "diventare migliore (MedAgent-Zero) di modelli appositamente allenati su tutta la letteratura scientifica (Medprompt).",
+                        "url": "https://arxiv.org/pdf/2405.02957"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🦊ff.98.3 Sora luna, e il cantico delle creature a nove code",
+                "link": "https://fortissimo.substack.com/i/145245800/ff-sora-luna-e-il-cantico-delle-creature-a-nove-code",
+                "content": "Laudato si', mi' Signore, per sora luna e le stelle: in celu l'ài formate clarite et pretiose et belle.San Francesco d’Assisi,Cantico delle creature\nChe mix fortissimo. Parliamo di Sora e di creature. Sora di OpenAI, intendo. Crea video partendo da una descrizione testuale. E lo fa in modo tanto realistico cheesperti del settore ipotizzano abbia imparato le leggi della fisica “guardando video”.\nVolpe a nove code?Meglio: una volpe volante! Questa e altre bestie fantastiche inBeyond Our Reality, improbabile documentario stile National Geographic creato con Sora.\nA proposito di corpi e simulazioni:Il Problema dei 3 Corpi, dagli ideatori de Il trono di spade. Suggeritissimo!\nInfine, per un trip filosofico sul tema, vi ricordo🎼 ff.64 Metafisica del metaverso.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!dIID!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F96a79012-3b30-4b57-b2de-423b4c608674_596x506.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!CP-w!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F577eaa34-ef0a-486d-bab6-0b9bbbc98749_734x637.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "esperti del settore ipotizzano abbia imparato le leggi della fisica “guardando video”",
+                        "url": "https://youtu.be/ra3kpTVHjZs?list=PLVfJCYRuaJIUNqx6puWYmw7Ug_QsTlA5k&t=2624"
+                    },
+                    {
+                        "text": "Beyond Our Reality",
+                        "url": "https://www.youtube.com/watch?v=ObUBUKOn-bo"
+                    },
+                    {
+                        "text": "Il Problema dei 3 Corpi",
+                        "url": "https://www.youtube.com/watch?v=FI2v0_VwMas"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🎼 ff.64 Metafisica del metaverso",
+                        "url": "https://fortissimo.substack.com/p/ff64-metafisica-del-metaverso"
+                    }
+                ]
+            },
+            {
+                "title": "⚛️ff.98.4 Sistemi quantistici",
+                "link": "https://fortissimo.substack.com/i/145245800/ff-sistemi-quantistici",
+                "content": "Nonostante il potenziale dei computer quantistici, fondamentali per simularesuperconduttori, farmaci e nanotecnologie, la tecnologia non è matura (🎼 ff.69 Quantico?).\nPresentano troppi errori di calcolo, per fenomeni comeil decoupling quantistico. Ma simulare computer quantistici può aiutarci.\nPerò, però, però.Forse studiare qubit e gatti di Schrödinger non serve: AlphaFold3 di Google DeepMind (🎼 ff.4 Mammut resuscitati) ha capito la fisica quantistica dall’esperienza.\nDa un file di testo con una lista degli atomi presenti, la nuova versione simula struttura 3D e interazioni chimiche tra DNA, RNA e piccole molecole (farmaci). In precedenza gestiva “solo” proteine.\n🎶archivio note fortissime\n☕caffè virtuale\n❤️cuoricino qui sotto?\n👋 A presto, damicmer\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!_TFa!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F5bb5446a-4adf-4a34-8e68-56443d592875_1481x875.png",
+                        "caption": "Aziende comPASQUAL e Qubit Pharmaceuticalsono all’avanguardia nell’uso di computer quantistici per scoprire nuove medicine (via futuro fortissimo)"
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!dT6u!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Ffe84f397-8fb9-4751-be00-b8d92322e072_1440x810.bin",
+                        "caption": "Non solo realismo: l’arte nei videogiochi (via futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "superconduttori, farmaci e nanotecnologie",
+                        "url": "https://www.science.org/content/article/quantum-computers-could-soon-speed-development-novel-materials-catalysts-and-drugs?utm_source=substack&utm_medium=email"
+                    },
+                    {
+                        "text": "il decoupling quantistico. Ma simulare computer quantistici può aiutarci.",
+                        "url": "https://www.nature.com/articles/s41467-024-46402-9"
+                    },
+                    {
+                        "text": "archivio note fortissime",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "caffè virtuale",
+                        "url": "https://www.paypal.com/paypalme/MicheleMerelli"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🎼 ff.69 Quantico?",
+                        "url": "https://fortissimo.substack.com/p/ff69-quantico"
+                    },
+                    {
+                        "text": "🎼 ff.4 Mammut resuscitati",
+                        "url": "https://fortissimo.substack.com/p/-ff4-mammut-e-torneo-tremaghi"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff97-tocchiamoci-di-piu",
+        "title": "🎼 ff.97 Tocchiamoci di più!",
+        "subtitle": "Sempre più insensibili, apatici e senza contatti?",
+        "keypoints": [
+            "La scienza dei benefici di un abbraccio",
+            "Massaggiatori: il lavoro del futuro?",
+            "O un robot li sostituirà?"
+        ],
+        "subchapters": [
+            {
+                "title": "🌐ff.97.1 Sempre più soli",
+                "link": "https://fortissimo.substack.com/i/141573875/ff-sempre-piu-soli",
+                "content": "Vuoi per il COVID, per i social o perché pensiamo solo a noi stessi, ma non ci tocchiamo più (figuriamoci quindi i figli,👵🏻ff.77.1 La “famiglia tradizionale” è passato?).\nIn 20 anni la solitudine è aumentata, specie nelle amicizie: passiamo con amici solo 40 minuti al giorno, nel 2003 erano 2 ore.Specialmente i maschietti non hanno amici stretti.\nProblemi, problemi, problemi.Senza connessioni sociali, non c’è futuro (fortissimo). Se siamo isolati come gliotakugiapponesi (📙ff.74.2 Breve dizionario culturale), la nostra salute peggiora più del fumare 15 sigarette al giorno o bere 6 drink alcolici (!!!).\nIl tema è tanto importante che ancheSteve Buscemi è sceso in campo, per guidare la 7° edizione del Festival UnLonely Films.\nQuesti e altri preoccupanti dati nelreport 2023: L’epidemia di Solitudinedel Surgeon General’s Advisory Board.\nUnsondaggio Gallup fa però notare che la solitudine post-COVID sta diminuendo.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!y83M!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Ff746339e-a48f-4143-b645-b7ea7759aeef_671x846.png",
+                        "caption": "caption..."
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!_6UL!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F4e735cb1-fdfa-4695-b3b4-687c32998654_504x423.png",
+                        "caption": "La mancanza di affetti può arrivare a essere più dannosa di 15 sigarette al giorno(via futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Specialmente i maschietti non hanno amici stretti.",
+                        "url": "https://www.cheerfulegg.com/2023/01/22/were-in-a-crisis-of-male-friendships/"
+                    },
+                    {
+                        "text": "Steve Buscemi è sceso in campo, per guidare la 7° edizione del Festival UnLonely Films.",
+                        "url": "https://www.artandhealing.org/steve-buscemi/"
+                    },
+                    {
+                        "text": "report 2023: L’epidemia di Solitudine",
+                        "url": "https://www.hhs.gov/sites/default/files/surgeon-general-social-connection-advisory.pdf"
+                    },
+                    {
+                        "text": "sondaggio Gallup fa però notare che la solitudine post-COVID sta diminuendo",
+                        "url": "https://news.gallup.com/poll/473057/loneliness-subsides-pandemic-high.aspx?utm_source=chartr&utm_medium=newsletter&utm_campaign=chartr_20230512"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "👵🏻",
+                        "url": "https://fortissimo.substack.com/i/137533647/ff-la-famiglia-tradizionale-e-passato"
+                    },
+                    {
+                        "text": "ff.77.1 La “famiglia tradizionale” è passato?",
+                        "url": "https://fortissimo.substack.com/i/137533647/ff-la-famiglia-tradizionale-e-passato"
+                    },
+                    {
+                        "text": "📙",
+                        "url": "https://fortissimo.substack.com/i/137321489/ff-breve-dizionario-culturale"
+                    },
+                    {
+                        "text": "ff.74.2 Breve dizionario culturale",
+                        "url": "https://fortissimo.substack.com/i/137321489/ff-breve-dizionario-culturale"
+                    }
+                ]
+            },
+            {
+                "title": "🫂ff.97.2 La carestia del contatto",
+                "link": "https://fortissimo.substack.com/i/141573875/ff-la-carestia-del-contatto",
+                "content": "Proprio la “carestia d’affetti” è al centro diOut of Touchdi Michelle Drouin, professoressa di psicologia dell’Indiana University.\nMichelle propone una to-do-list di esercizi relazionali (e non individuali):\nCercare di abbracciare, toccare qualcuno (magari anche solo un animale) per 20 secondi al giorno.Coltivare quanto più possibile relazioni e amicizie storiche, ma, se non ricambiate, cercane altre.Sfruttare la tecnologia: il cellulare, ma per una chiamata o un messaggio personale. Oppure usando ChatGPT o Replika.AI per un dialogo anche solo introspettivo, autoanalitico.\nQuesto focus sulle relazioni più che sull’individuo ci riporta a🔺ff.89.2 Piramide di Maslow 2.0.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!2t5t!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F1a1dcc40-c09e-40dc-8c60-13b6eea1ab06_978x1500.jpeg",
+                        "caption": "Out of Touch: l’epidemia della mancanza di contatto (suggerito da futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Out of Touch",
+                        "url": "https://amzn.to/3R5XWXN"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🔺",
+                        "url": "https://fortissimo.substack.com/i/141331290/ff-piramide-di-maslow"
+                    },
+                    {
+                        "text": "ff.89.2 Piramide di Maslow 2.0",
+                        "url": "https://fortissimo.substack.com/i/141331290/ff-piramide-di-maslow"
+                    }
+                ]
+            },
+            {
+                "title": "🩵ff.97.3 Caressa e carezze contro lo stress",
+                "link": "https://fortissimo.substack.com/i/141573875/ff-caressa-e-carezze-contro-lo-stress",
+                "content": "Abbracciamoci forte e vogliamoci tanto bene.Fabio Caressa\nOk, ma per abbracciarci, non aspettiamo di rivincere i mondiali. Perché il contatto è vita. Vediamo la scienza.\nA differenza di quando tocchiamo oggetti inanimati,stringiamo un essere umano tutti allo stesso modo(con una velocità di 5cm/s, quella che stimola neuroni di contatto “lenti”)\nNeuroni lenti e neuroni veloci.Le due tipologie di neuroni di cui è munita la pelle: veloci per rispondere a stimoli come il dolore, lenti per trasmettere la gentilezza di una carezza.\nRangan Chatterjee (incontrato in🦁ff.90.1 Scappare da un leone o una notifica) nota chedurante l’infanzia il contatto della madre promuove la regolazione dello stress, perché vi è uncalo di cortisolo dopo un abbraccio.\nLa risposta fisiologica è tanto innata che, in mancanza di alternative,va bene anche farsi massaggi da soli.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!S7jL!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F740c6a0a-aa06-44dc-8e98-df3d8c1d2862_480x360.jpeg",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "stringiamo un essere umano tutti allo stesso modo",
+                        "url": "https://pubmed.ncbi.nlm.nih.gov/34752649/"
+                    },
+                    {
+                        "text": "durante l’infanzia il contatto della madre promuove la regolazione dello stress",
+                        "url": "https://pubmed.ncbi.nlm.nih.gov/34752649/"
+                    },
+                    {
+                        "text": "calo di cortisolo dopo un abbraccio",
+                        "url": "https://pubmed.ncbi.nlm.nih.gov/17499441/"
+                    },
+                    {
+                        "text": "va bene anche farsi massaggi da soli",
+                        "url": "https://www.sciencedirect.com/science/article/pii/S2666497621000655"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🦁",
+                        "url": "https://fortissimo.substack.com/i/141914401/ff-scappare-da-un-leone-o-una-notifica"
+                    },
+                    {
+                        "text": "ff.90.1 Scappare da un leone o una notifica",
+                        "url": "https://fortissimo.substack.com/i/141914401/ff-scappare-da-un-leone-o-una-notifica"
+                    }
+                ]
+            },
+            {
+                "title": "🌐ff.97.4 Economia e robot del massaggio",
+                "link": "https://fortissimo.substack.com/i/141573875/ff-economia-e-robot-del-massaggio",
+                "content": "Carestia di contatto, epidemia di stress, isolamento sociale e invecchiamento della popolazione: tutto fa presagire che i massaggiatori avranno un futuro fortissimo.\nDelle10 persone intervistate dall’ATMA:\n6 hanno ricevuto un massaggio nel 2023, con una media di 3 all’anno9 pensano che un massaggio debba essere innalzato a terapia clinica2 usano il massaggio per alleviare lo stress\nIl problema? Probabilmente, come per infermieri e personale per cure geriatriche, non avremo abbastanza massaggiatori per tutta la richiesta.\nEcco alloraAescape: il robot massaggiatore.\nE con i robot chiudiamo un bel cerchio anche oggi: la professoressa Drouin, scettica su ruolo della tecnologia contro la solitudine, si è ricreduta dopo il suo incontro conSophia, il robot di Hanson Robotics.\nE con questo è tutto per oggi. Vado a toccarmi un po’.\n🎶cerca tra link di futuro fortissimo\n☕supporta con un caffè virtuale\nmetteresti un cuoricino qui sotto?❤️❤️❤️\n👋 alla prossima, damicmer\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!DTFq!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fde2f9845-5aa8-4ba4-804b-c81c099e31ef_1920x1080.jpeg",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!PteE!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F5c73d3ce-044d-4149-919e-511d539bd290_1272x771.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!8r7N!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F274cd29f-b2ad-4b39-820b-fd8608dfb3d7_724x407.bin",
+                        "caption": "Campagna che invita le donne a “toccarsi” per prevenire il cancro al seno."
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "10 persone intervistate dall’ATMA",
+                        "url": "https://www.amtamassage.org/publications/consumer-views-use-of-massage-therapy/"
+                    },
+                    {
+                        "text": "Aescape: il robot massaggiatore",
+                        "url": "https://app.aescape.com/"
+                    },
+                    {
+                        "text": "Sophia, il robot di Hanson Robotics",
+                        "url": "https://www.hansonrobotics.com/sophia/"
+                    },
+                    {
+                        "text": "cerca tra link di futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "supporta con un caffè virtuale",
+                        "url": "https://www.paypal.com/paypalme/MicheleMerelli"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    }
+                ],
+                "connections": []
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff96-nostradamus-del-2024",
+        "title": "🎼 ff.96 Nostradamus del 2024",
+        "error": "HTTP 404"
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff95-farmville-e-web3",
+        "title": "🎼 ff.95 FarmVille e web3",
+        "subtitle": "Feudalesimo e libertà: rivendicare internet",
+        "keypoints": [
+            "Facebook e TikTok: feudalesimo digitale?",
+            "Breve storia di internet: web1, web2, web3",
+            "Blockchain: non solo speculazione finanziaria"
+        ],
+        "subchapters": [
+            {
+                "title": "🌐ff.95.1 La sovranità dei network",
+                "link": "https://fortissimo.substack.com/i/144388955/ff-la-sovranita-dei-network",
+                "content": "C’è una legge che descrive la potenza dei social network. Si chiamaLegge di Metcalfe, dal nome dell’inventore anche della presa Ethernet.\nIscriviti per le potenzialità, rimani per il network.Chris Dixon\nYouTube ci ha attratto con contenuti gratuiti, oggi però ha più pubblicità della TV via cavo.\nI proprietari del network, poi, decidono cosa amplificare (o silenziare). Twitter/X riduce l’audience di post con link esterni e blocca la visualizzazione su Substack (devoscreenshottare il tweet di Tiboper farvelo leggere qui).\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!raid!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F4631fdcb-69ba-4d67-880b-c0b7b3a1abd9_537x656.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Legge di Metcalfe, dal nome dell’inventore anche della presa Ethernet",
+                        "url": "https://en.wikipedia.org/wiki/Robert_Metcalfe"
+                    },
+                    {
+                        "text": "screenshottare il tweet di Tibo",
+                        "url": "https://twitter.com/tibo_maker/status/1691428205519925249"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🦆ff.95.2 FarmVille e feudalesimo",
+                "link": "https://fortissimo.substack.com/i/144388955/ff-farmville-e-feudalesimo",
+                "content": "Vi sblocco un ricordo.\nFarmVille e Fortnite.Ricordate quando Facebook era pieno di notifiche di questo tipo? Poi, però, nel 2011Facebook ha di fatto bloccato la crescita di Zynga, la casa produttrice di FarmVille (che ora pensa aSugartown, FarmVille su server decentralizzati).\nLo stesso potrebbe accadere a Fortnite:Epic ha un contenzioso contro Apple, che trattiene il 30% degli acquisti fatti sul videogioco.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!Xtvo!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F39e603b5-7102-4d33-8aeb-b4f4a587e111_600x314.jpeg",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!CtS9!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F86771943-6b92-4894-9295-bb878bd57184_1600x900.jpeg",
+                        "caption": "Alcune delle più famose skin di Fortnite"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Facebook ha di fatto bloccato la crescita di Zynga",
+                        "url": "https://www.wired.com/story/facebook-can-absolutely-control-its-algorithm/"
+                    },
+                    {
+                        "text": "Sugartown, FarmVille su server decentralizzati",
+                        "url": "https://nftplazas.com/zynga-web3-gaming/"
+                    },
+                    {
+                        "text": "Epic ha un contenzioso contro Apple, che trattiene il 30% degli acquisti fatti sul videogioco",
+                        "url": "https://en.wikipedia.org/wiki/Epic_Games_v._Apple"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🔑ff.95.3 La proprietà privata digitale",
+                "link": "https://fortissimo.substack.com/i/144388955/ff-la-proprieta-privata-digitale",
+                "content": "Chris Dixondel fondo A16Z Crypto sostiene così la necessità di un nuovo internet, nel suo recentissimo libroRead Write Own.\nCos’è il web3?E soprattutto, cosa sono web1 e web2?\nweb 1 | lettura+ protocolli aperti come quelli tutt’ora usati da email (STMP) e siti web (HTML)- sistemi senza organizzazione e stimoli finanziari per utentiweb 2 | lettura e scrittura+centralizzazione dei database e creazione di piattaformeuser-friendly- libertà di parola ma mancanza di controllo sui mezzi di diffusione/algoritmiweb 3 | lettura, scrittura e possesso+decentralizzazione conblockchain dei database (il vantaggio web2)+ regole immutabili per promuovere partecipazione degli utenti (con token) e favorire finanziamenti\nUn buon riassunto del libro è la chiacchierata tra l’autore e Balaji (ex-CTO di Coinbase,🌐 ff.52.3 Fondare la propria nazione).\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!AK9S!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F6f4ab9a2-9e55-4f61-9040-2bd766f8ac52_529x797.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Chris Dixon",
+                        "url": "https://twitter.com/cdixon?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor"
+                    },
+                    {
+                        "text": "Read Write Own",
+                        "url": "https://amzn.to/4ajzk4k"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🌐 ff.52.3 Fondare la propria nazione",
+                        "url": "https://fortissimo.substack.com/i/83498036/ff-fondare-la-propria-nazione"
+                    }
+                ]
+            },
+            {
+                "title": "✍️ ff.95.4 Reinventare scrittura e stampa",
+                "link": "https://fortissimo.substack.com/i/144388955/ff-reinventare-scrittura-e-stampa",
+                "content": "La scrittura e le newsletter su Substack potrebbero essere un primo esempio della transizione verso il web3. Vediamo perché.\nDal momento che le newsletter sono email, su un protocollo come abbiamo visto aperto, Substack non può bloccare i suoi scrittori se vogliono migrare su altri servizi (basta un copia e incolla delle mail).\nGutenberg o Telepass?La scrittura è al centro di un’altra analogia. Come l’invenzione della stampa ha permesso di superare il blocco dell’Inquisizione, la blockchain restituisce la neutralità della rete agliutenti/influencers/brands, costretti a pagare sempre di più per ottenere lo stesso traffico sui social.\n",
+                "images": [],
+                "references": [
+                    {
+                        "text": "utenti/",
+                        "url": "https://www.statista.com/chart/2021/organic-reach-of-brands-facebook-posts/"
+                    },
+                    {
+                        "text": "influencers/",
+                        "url": "https://www.statista.com/chart/2021/organic-reach-of-brands-facebook-posts/"
+                    },
+                    {
+                        "text": "brands, costretti a pagare sempre di più per ottenere lo stesso traffico sui social",
+                        "url": "https://www.statista.com/chart/2021/organic-reach-of-brands-facebook-posts/"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "⛓️ff.95.5 Cosa risolve la blockchain?",
+                "link": "https://fortissimo.substack.com/i/144388955/ff-cosa-risolve-la-blockchain",
+                "content": "Chiedersi cosa risolva la blockchain è come chiedersi: “cosa risolve l’acciaio?”Chris Dixon,Read Write Own\nOltre al tema della censura e delle “tasse da marketplace”, ecco le criticità del mondo online attuale:\nBoxing.L’intelligenza artificiale mette in box/FAQ/chat il contenuto raccolto online, togliendo la monetizzazione dei siti originaliDeepfakessempre più credibili minano la credibilità dei contenuti online (🍝ff.85.4 Carbonara e criptovalute,verifymedia)\ne opportunità:\nTokenizzazione.Nel gaming lemodsono l’ordine del giorno (League of Legends è un remix di una mappa di Warcraft III). La blockchain premia in modo prevedibile creatività e contributi degli utenti (Edenhorde, il Signore degli Anelli collaborativo che restituisca il valore agli utenti)\nInteroperatibilità.Possibilità di trasferire contatti, contenuti e acquisti da una piattaforma all’altra senza attriti (come detto, vedi esempio Substack)Burocrazia.L’esempio diEhterisc che ti rimborsa in 10 minuti il biglietto aereo\nE con questo è tutto per oggi. Vado a s-bloccare un po’ la schiena.👋 A presto, damicmer\nlenaweber404A post shared by@lenaweber404\n🎶archivio note fortissime\n☕caffè virtuale\n❤️cuoricino qui sotto?\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!ngyn!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F8dcf4a62-ae62-480b-9323-565f56898ce7_1027x675.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!YVwH!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F78b82d05-cec4-4c68-b9ef-e9432678261a_585x359.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Read Write Own",
+                        "url": "https://amzn.to/4ajzk4k"
+                    },
+                    {
+                        "text": "verifymedia",
+                        "url": "https://docs.verifymedia.com/"
+                    },
+                    {
+                        "text": "League of Legends è un remix di una mappa di Warcraft III",
+                        "url": "https://it.wikipedia.org/wiki/League_of_Legends"
+                    },
+                    {
+                        "text": "Edenhorde, il Signore degli Anelli collaborativo che restituisca il valore agli utenti",
+                        "url": "https://edenhorde.world/manifesto"
+                    },
+                    {
+                        "text": "Ehterisc che ti rimborsa in 10 minuti il biglietto aereo",
+                        "url": "https://etherisc.com/"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    },
+                    {
+                        "text": "lenaweber404",
+                        "url": "https://instagram.com/lenaweber404"
+                    },
+                    {
+                        "text": "",
+                        "url": "https://instagram.com/p/CoXlKESIQL0"
+                    },
+                    {
+                        "text": "@lenaweber404",
+                        "url": "https://instagram.com/lenaweber404"
+                    },
+                    {
+                        "text": "archivio note fortissime",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "caffè virtuale",
+                        "url": "https://www.paypal.com/paypalme/MicheleMerelli"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🍝",
+                        "url": "https://fortissimo.substack.com/i/137944571/ff-carbonara-e-criptovalute"
+                    },
+                    {
+                        "text": "ff.85.4 Carbonara e criptovalute",
+                        "url": "https://fortissimo.substack.com/i/137944571/ff-carbonara-e-criptovalute"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff94-il-grasso-fa-male",
+        "title": "🎼 ff.94 Il grasso fa male?",
+        "subtitle": "Gravidanze, omega-3 e altre rotondità",
+        "keypoints": [
+            "Perché serve per la gravidanza",
+            "Gli omega-3 bilanciano le sigarette?",
+            "Un Pokédex dei grassi?"
+        ],
+        "subchapters": [
+            {
+                "title": "🤰ff.94.1 Come rimanere incinta?",
+                "link": "https://fortissimo.substack.com/i/142232159/ff-come-rimanere-incinta",
+                "content": "Nelle precedenti edizioni, abbiamo parlato di obesità (🎼 ff.49 La pandemia del 21esimo secolo). E’ un tema delicato e intricato, come d’altronde tutta la biologia umana.\nStigmatizzare il grasso porta problemi sociali e psicologici, come la bulimia.Deborah Cleggspiega l’importanza di un po’ di grasso, specie sui fianchi delle donne.\nI punti salienti:\nLe cellule grasse sono sorgenti di estrogeni e regolano ovulazione, tanto che la loro mancanza blocca ciclo e fecondità di una donna.Il grasso che si forma dopo la menopausa è di fatto una “terza ovaria”, che ribilancia gli estrogeni venuti a mancare.Soia e germogli contengono sostanze simili agli estrogeni “ovarici” e possono aiutare a combattere gli effetti della menopausa.Cellule grasse buone e cattive: quelle “bianche” flessibili e in grado di rilasciare più facilmente il grasso al loro interno.Il rapporto della misura vita/fianchi identifica l’obesità meglio del BMI.\nFast food quindi?Non così in fretta:mangiare al McDonald e consumare poca frutta diminuiscono la fertilità. Durante la gestazione e nel periodo successivo, invece, meglio abbondare un po’:per allattare un figlio servono fino a 400kcal al giorno.\n",
+                "images": [],
+                "references": [
+                    {
+                        "text": "Deborah Clegg",
+                        "url": "https://scholar.google.com/citations?user=kxUtJuIAAAAJ&hl=en"
+                    },
+                    {
+                        "text": "Cellule grasse buone e cattive",
+                        "url": "https://www.healthline.com/health/types-of-body-fat#whitehttps://www.healthline.com/health/types-of-body-fat#white"
+                    },
+                    {
+                        "text": "mangiare al McDonald e consumare poca frutta diminuiscono la fertilità",
+                        "url": "https://academic.oup.com/humrep/article/33/6/1063/4989162"
+                    },
+                    {
+                        "text": "per allattare un figlio servono fino a 400kcal al giorno",
+                        "url": "https://pubmed.ncbi.nlm.nih.gov/16277817/"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🎼 ff.49 La pandemia del 21esimo secolo",
+                        "url": "https://fortissimo.substack.com/p/ff49-la-pandemia-del-21esimo-secolo"
+                    }
+                ]
+            },
+            {
+                "title": "🍔ff.94.2 Grassi buoni e cattivi",
+                "link": "https://fortissimo.substack.com/i/142232159/ff-grassi-buoni-e-cattivi",
+                "content": "Un po’ di grasso fa bene. Ma quale?\nAlimentazione e dieta sono un intreccio di chimica, biologia e fisiologia. I valori nutrizionali sull’etichetta di un alimento non bastano. Specie per i grassi.\nCompound Interest raccoglie in breve le 5 categorie di grassi:\nIgrassi trans sono da evitare: l’aumento di malattie cardiovascolari.Grazie ai doppi legami C=C, i grassi poli-insaturi possono avere proprietà anti-ossidanti e abbassano il colesterolo.\nPokédex degli oli.L’olio semi di lino è “super-efficace” negli omega-3 (ma quelli corti, leggi sotto). Per l’alto contenuto di grassi saturi, invece, meglio evitare il “cocco-bello”.\nCome detto, però,c’è tanta chimica di mezzo. Temperature e rapporto tra reagenti vanno controllati precisamente. Se vi siete messi a panificare in casa durante il lockdown, lo sapete.\nTanto che:\nSe scaldiamo troppo l’olio “buono” (extravergine, poli-insaturo) lo trasformiamo in trans, facendoci silenziosamentemoltomale(è bastato “girare” il legame C=C della catena di carbonio).I grassi poli-insaturi fanno bene, ma troppi omega-6 rispetto agli omega-3 forse no.\nPer approfondire (è lungo, vi avviso), il blog Dynomight.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!Hqim!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Feb8136ad-1776-43da-871d-c00cf5e5a852_1323x935.png",
+                        "caption": "Classificazione dei grassi alimentari."
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!8rlJ!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F05392f75-e9d9-4169-8816-156446e523f5_650x422.png",
+                        "caption": "Distribuzione di varie tipologie di grassi negli oli più comuni in cucina."
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "grassi trans sono da evitare: l’aumento di malattie cardiovascolari",
+                        "url": "https://www.cochranelibrary.com/cdsr/doi/10.1002/14651858.CD011737.pub2/full"
+                    },
+                    {
+                        "text": "Se scaldiamo troppo l’olio “buono” (extravergine, poli-insaturo) lo trasformiamo in trans, facendoci silenziosamente",
+                        "url": "https://pubmed.ncbi.nlm.nih.gov/35406103/"
+                    },
+                    {
+                        "text": "molto",
+                        "url": "https://pubmed.ncbi.nlm.nih.gov/35406103/"
+                    },
+                    {
+                        "text": "male",
+                        "url": "https://pubmed.ncbi.nlm.nih.gov/35406103/"
+                    },
+                    {
+                        "text": "Per approfondire (è lungo, vi avviso), il blog Dynomight.",
+                        "url": "https://dynomight.substack.com/p/seed-oil"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🚬ff.94.3 Omega-3 come sigarette?",
+                "link": "https://fortissimo.substack.com/i/142232159/ff-omega-come-sigarette",
+                "content": "Ok, ho aggiunto carne al fuoco e la domanda “quali grassi?” è ancora più intricata.\nUna risposta semplice, se dovete scegliere quali grassi assumere: omega-3 “lunghi”.\nIn questo fenomenale podcast (ci torneremo), Rhonda Patrick fa notare:\nAssumere 1g al giorno di omega-3 (50g di salmone) può avere gli stessi effetti di smettere di fumare.I maggiori benefici derivano da omega-3 “lunghi”(=EPA e DPA), presenti in fonti animali (il pesce).La variante “breve” di omega-3 (=ALA) presente in semi e dieta vegetariana, anche se parzialmente “allungata” durante la digestione, non basta.Vegetariani o pescetariani? Per raggiungere in modo semplice e consistente l’obbiettivo, conviene prendereun integratore(solo uno, promesso, non come💊 ff.49.4 Il superuomo che prende 100 pillole al giorno)\nE con questo è tutto per oggi. Vado a sgrassare un po’.\n🎶archivio note fortissime\n☕caffè virtuale\n❤️cuoricino qui sotto?\n👋 A presto, damicmer\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!wBM8!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F4eae1085-77eb-402f-9fa5-4af04be9657f_696x500.jpeg",
+                        "caption": "Come le etichette e i font possono cambiare la percezione del cibo."
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "I maggiori benefici derivano da omega-3 “lunghi”",
+                        "url": "https://www.nature.com/articles/s41467-021-22370-2"
+                    },
+                    {
+                        "text": "un integratore",
+                        "url": "https://amzn.to/3UOT1N2"
+                    },
+                    {
+                        "text": "archivio note fortissime",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "caffè virtuale",
+                        "url": "https://www.paypal.com/paypalme/MicheleMerelli"
+                    },
+                    {
+                        "text": "micmer",
+                        "url": "https://linktr.ee/micmer"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "💊 ff.49.4 Il superuomo che prende 100 pillole al giorno",
+                        "url": "https://fortissimo.substack.com/i/95768941/ff-il-superuomo-che-prende-pillole-al-giorno"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff93-tesla-la-fine-di-unera",
+        "title": "🎼 ff.93 Tesla: la fine di un'era?",
+        "error": "HTTP 404"
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff92-la-dieta-dei-centenari",
+        "title": "🎼 ff.92 La dieta dei centenari?",
+        "subtitle": "Sfamare il microbioma con fagioli, tè e caffè",
+        "keypoints": [
+            "Fagioli: il prossimo super-food?",
+            "Perché il caffè può prevenire il diabete?",
+            "Siamo i microbi del nostro intestino?"
+        ],
+        "subchapters": [
+            {
+                "title": "🫘ff.92.1 Fagioli di bazar",
+                "link": "https://fortissimo.substack.com/i/137958307/ff-fagioli-di-bazar",
+                "content": "In questa newsletter non troverete super cibi. Ma fagioli.\nDan Buettner è l’esperto quando si parla diregioni con più centenari (tra cui la Sardegna), leblue zones.Il suo bestseller ha ispirato il documentario Netflix sul tema.\n93 anni.L’età media dei 9 fratelli dellafamiglia Melis quando è entrata nel Guinness dei Primati.\nIl segreto?\nIl minestrone centenario.Ogni giorno, a pranzo,zuppa (ricetta qui): tris di fagioli, carote, cipolle, origano, patate, sedano, peperoni rossi e un filo d’olio (e pecorino) a guarnire.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!EZmc!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Faf8a9704-87f2-48d5-8757-4bc17e0a1a04_2400x1200.jpeg",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "regioni con più centenari (tra cui la Sardegna), le",
+                        "url": "https://amzn.to/3V3ybtM"
+                    },
+                    {
+                        "text": "blue zones",
+                        "url": "https://amzn.to/3V3ybtM"
+                    },
+                    {
+                        "text": "famiglia Melis quando è entrata nel Guinness dei Primati",
+                        "url": "https://www.youtube.com/watch?v=391J_zPKUIo"
+                    },
+                    {
+                        "text": "zuppa (ricetta qui)",
+                        "url": "https://www.lacucinaitaliana.it/storie/piatti-tipici/minestrone-lunga-vita-sardegna-ricetta/"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🦠ff.92.2 Un organo in più: il microbioma",
+                "link": "https://fortissimo.substack.com/i/137958307/ff-un-organo-in-piu-il-microbioma",
+                "content": "Il microbioma (strato di microbi che riveste l’intestino) è sempre più connesso con umore, glicemia e malattie.\nD’altronde, se ci pensate, l’intestino è dove il cibo passa la maggior parte del tempo nel nostro corpo. I microbi controllano quindi la velocità con cui molecole, come gli zuccheri, entrano in circolo (e quindi la risposta glicemica).\nTanto che analizzare (no pun intended) la cacca può far vincere le olimpiadi (Blummenfelt, iridato triatleta:🇳🇴 ff.17.1 La Norvegia è maniacale).\nContengo moltitudinidel Pulitzer Ed Yong innalza microbi dell’intestino al pari di altre “nostre” cellule. Tanto che crescere senza microbi è impossibile (ad esempio,regolano la pressione cardiaca).\nE i fagioli?Come altri cibi non processati, sono ricchi di fibre. Ele fibre favoriscono un microbioma sano e vario (e conseguentemente minori infiammazioni).\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!W-bm!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F286c9b3c-6a18-430e-8f1d-a39f5a504446_463x679.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Contengo moltitudini",
+                        "url": "https://amzn.to/47MBGrm"
+                    },
+                    {
+                        "text": "regolano la pressione cardiaca",
+                        "url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7666075/"
+                    },
+                    {
+                        "text": "le fibre favoriscono un microbioma sano e vario (e conseguentemente minori infiammazioni)",
+                        "url": "https://www.sciencedirect.com/science/article/pii/S2590097822000209#:~:text=High%2Dfiber%20dietary%20regime%20has,bacteria%20in%20the%20human%20gut."
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🇳🇴 ff.17.1 La Norvegia è maniacale",
+                        "url": "https://fortissimo.substack.com/i/48254558/ff-la-norvegia-e-maniacale"
+                    }
+                ]
+            },
+            {
+                "title": "☕ff.92.3 Tè o caffè? Benzina del microbioma",
+                "link": "https://fortissimo.substack.com/i/137958307/ff-te-o-caffe-benzina-del-microbioma",
+                "content": "Il microbioma è ghiotto anche di polifenoli.\nCaffè e tè ne sono ricchi. Un’altra arma contro picchi glicemici e diabete?\nLa caffeina prende in prestito energia del futuro. Si lega ai ricettori dell’adenosina (molecola della stanchezza). Quando poi se ne va, però, tutta l’adenosina accumulata nel frattempo “ci colpisce ancora più fortemente”.Andrew Huberman,Using Caffeine to Optimize Mental & Physical Performance\nE’ bene non assumere più di 400mg di caffeina (guida sulla caffeina in Starbucks). Bilanciate piuttosto con iltè, che può ridurre l’ansia,grazie alla L-teanina.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!t-nA!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fbucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com%2Fpublic%2Fimages%2F04c59710-fd92-4ac4-be00-48de0f65c96a_828x241.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!sIEv!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fbucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com%2Fpublic%2Fimages%2F64fa242d-1035-404c-b5f9-dd9766c95e4f_810x387.png",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!-5Lh!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fd7cc357d-b824-4bfc-96b7-0e2ca38edbff_752x265.png",
+                        "caption": "La caffeina in tazze da 8 once (237 ml, grazie sistema americano) per varie bevande."
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Il microbioma è ghiotto anche di polifenoli",
+                        "url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6160559/"
+                    },
+                    {
+                        "text": "Using Caffeine to Optimize Mental & Physical Performance",
+                        "url": "https://www.youtube.com/watch?v=iw97uvIge7c"
+                    },
+                    {
+                        "text": "guida sulla caffeina in Starbucks",
+                        "url": "https://www.caffeineinformer.com/the-complete-guide-to-starbucks-caffeine"
+                    },
+                    {
+                        "text": "tè, che può ridurre l’ansia",
+                        "url": "https://pubmed.ncbi.nlm.nih.gov/28899506/"
+                    },
+                    {
+                        "text": "grazie alla L-teanina",
+                        "url": "https://examine.com/supplements/theanine/?itid=lk_inline_enhanced-template"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "👌ff.92.4 La dieta perfetta (secondo GPT)",
+                "link": "https://fortissimo.substack.com/i/137958307/ff-la-dieta-perfetta-secondo-gpt",
+                "content": "Quindi, per riassumere, cosa mangiare per arrivare a 100 anni? Non dovete spingervi fino al metodo Blueprint di Bryan Johnson (💊 ff.49.4 Il superuomo che prende 100 pillole al giorno).\nHo chiesto a GPT di sviluppare la dieta perfetta, (con 100g di proteine, 40g di fibre e micronutrienti essenziali, stando in circa 2200 kcal).\nNon solo fagioli, quindi.Meglio, altrimenti va a finire come per questa coppia, con inspiegabiliperiodiche flatulenze dopo una visita dai parenti di lei.\n🎶archivio note\n☕caffè virtuale\n❤️metti un cuoricino qui sotto?\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!nwMl!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fd182f1d3-8100-40d4-97fd-b56268e41f02_443x344.png",
+                        "caption": "La dieta perfetta secondo ChatGPT (via futuro fortissimo, michele merelli)"
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!vcJs!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F42418bf1-3b60-4af9-93a6-af6bfd85cfa9_1056x1462.bin",
+                        "caption": "Il nuovo show di Gordon Ramsay, Idiot Sandwich"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Ho chiesto a GPT di sviluppare la dieta perfetta",
+                        "url": "https://chat.openai.com/share/d3990a4e-d13a-4efe-b28b-17a3f7f6a1c1"
+                    },
+                    {
+                        "text": "periodiche flatulenze dopo una visita dai parenti di lei",
+                        "url": "https://www.reddit.com/r/NoStupidQuestions/comments/1anr8w5/why_do_my_husband_and_i_experience_severe/?utm_source=share&utm_medium=android_app&utm_name=androidcss&utm_term=1&utm_content=1"
+                    },
+                    {
+                        "text": "archivio note",
+                        "url": "https://futurofortissimo.github.io/note.html"
+                    },
+                    {
+                        "text": "caffè virtuale",
+                        "url": "https://www.paypal.com/paypalme/MicheleMerelli"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "💊 ff.49.4 Il superuomo che prende 100 pillole al giorno",
+                        "url": "https://fortissimo.substack.com/i/95768941/ff-il-superuomo-che-prende-pillole-al-giorno"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff91-i-sassi-le-luci-il-sale",
+        "title": "🎼 ff.91 I sassi, le luci, il sale",
+        "error": "HTTP 404"
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff90-lepidemia-di-stress",
+        "title": "🎼 ff.90 L'epidemia di stress",
+        "error": "HTTP 404"
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff89-meno-tinder-piu-relazioni",
+        "title": "🎼 ff.89 Meno Tinder, più relazioni",
+        "subtitle": "Piccolo principe, Conad e persone oltre le cose.",
+        "keypoints": [
+            "Persone oltre le cose?",
+            "La Piramide di Maslow va rivista?",
+            "Siete essenzialisti o non-essenzialisti?"
+        ],
+        "subchapters": [
+            {
+                "title": "1️⃣ff.89.1 Un podcast da ascoltare",
+                "link": "https://fortissimo.substack.com/i/141331290/ff-un-podcast-da-ascoltare",
+                "content": "Siamo a 3 mesi di 2024. Come vanno i buoni propositi? Obbiettivi raggiunti?\nInterrogato sui suoi buoni propositi per il 2024,Greg McKeown, MBA di Stanford e vescovo mormone(un personaggino non banale, insomma) ha risposto a Tim: più che obbiettivi, persone.\nGreg tiene un diario, rigorosamente cartaceo, con i nomi delle persone più intime. Costruisce le sue azioni, i suoi obbiettivi, partendo da loro.\nChe ribaltone!Inverte così in modo affascinante il mondo di buoni propositi, obbiettivi eto-do-listdella nostra iper-individualistica società.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!31ck!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fdd186f90-28dd-4cca-a7c8-610f05db6c06_842x277.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Greg McKeown, MBA di Stanford e vescovo mormone",
+                        "url": "https://en.wikipedia.org/wiki/Greg_McKeown_(author)"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🔺ff.89.2 Piramide di Maslow 2.0",
+                "link": "https://fortissimo.substack.com/i/141331290/ff-piramide-di-maslow",
+                "content": "In🔺 ff.62.4 La piramide che c’è in tutti noiavevamo visto che, al crescere della sicurezza alimentare ed economica, gli individui tendono a valori più alti per essere felici. Uno su tutti, la realizzazione del sé.\nPerò, però, però.Greg fa notare, spiazzando anche l’esperto Ferris, cheMaslow ha rivisitato nella sua ultima fase di vita la Piramide, aggiungendo la trascendenza del sé, laself-trascendence.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!9HjO!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Ffae0ca0d-597c-42d3-ab79-bc2721d47e6d_1604x1127.jpeg",
+                        "caption": "La teoria finale di Maslow: la Z e la trascendenza del sé (1969)."
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Maslow ha rivisitato nella sua ultima fase di vita la Piramide, aggiungendo la trascendenza del sé",
+                        "url": "https://agile-od.com/mmdojo/8287/maslows-final-theory-z"
+                    }
+                ],
+                "connections": [
+                    {
+                        "text": "🔺 ff.62.4 La piramide che c’è in tutti noi",
+                        "url": "https://fortissimo.substack.com/i/118479393/ff-la-piramide-che-ce-in-tutti-noi"
+                    }
+                ]
+            },
+            {
+                "title": "🤴ff.89.3 L’essenziale è invisibile agli occhi",
+                "link": "https://fortissimo.substack.com/i/141331290/ff-lessenziale-e-invisibile-agli-occhi",
+                "content": "Come si trascende il sé?\nFermando il flusso di infinite alternative,side-hustlee relazioni che il mondo digitale propone, veloci comeswipessu Tinder (♾️ ff.44.2 L’infinitudine là fuori).\nInsomma, diventando essenzialisti.\nI grandi amano le cifre. Quando parlate di un nuovo amico, non interessano alle cose essenziali [sic!].Non si domandano mai: “Qual è il tono della sua voce? Quali sono i suoi giochi preferiti? Fa collezione di farfalle?”Ma vi domandano: “Che età ha? Quanti fratelli? Quanto pesa? Quanto guadagna suo padre?”.Allora soltanto credono di conoscerlo.Antoine de Saint-Exupéry,Il piccolo principe.\nE dal 1943 è tutto.\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!KvUb!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F0aab98b4-9ad2-4164-9f2c-91036dcf5a7b_550x399.png",
+                        "caption": "La differenza tra essenzialisti e non-essenzialisti, dal libroEssenzialismo."
+                    }
+                ],
+                "references": [],
+                "connections": [
+                    {
+                        "text": "♾️ ff.44.2 L’infinitudine là fuori",
+                        "url": "https://fortissimo.substack.com/i/82346421/ff-linfinitudine-la-fuori"
+                    }
+                ]
+            },
+            {
+                "title": "🧭ff.89.4 Continui riaggiustamenti",
+                "link": "https://fortissimo.substack.com/i/141331290/ff-continui-riaggiustamenti",
+                "content": "Contro l’ennesimo trend proposto dalla società (qualcuno ha detto padel?), una consapevolezza: la necessità incessante di controllare la mappa e tornare sul proprio percorso.\nIn una bella analogia, Greg dice che un aereo è fuori rotta il 99% del tempo. Ma è un sistema dinamicamente stabile: con piccoli aggiustamenti, arriva a destinazione.\nCosì, diario alla mano, ogni fine settimana, di domenica, Greg fa un check sulle azioni compiute, verificando se siano in linea con le sue relazioni, i suoi valori.\nChe dite, riaggiustiamo la rotta dell’anno da qui?\nHai visto ilnuovo sito di futuro fortissimo?Se vuoi fare del bene:☕un caffè virtuale❤️un cuoricino qui sotto\n",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!D6q0!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F1ad34755-3ccf-45c0-8059-50d9a8350206_1440x2763.bin",
+                        "caption": "Lucile Ourvouai"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "nuovo sito di futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/"
+                    },
+                    {
+                        "text": "un caffè virtuale",
+                        "url": "https://www.paypal.com/paypalme/MicheleMerelli"
+                    }
+                ],
+                "connections": []
+            }
+        ]
+    },
+    {
         "url": "https://fortissimo.substack.com/p/ff88-singolarita-nel-2029",
         "title": "🎼 ff.88 Singolarità nel 2029?",
         "subtitle": "L'accelerazione robotica grazie a ChatGPT e FigureAI",


### PR DESCRIPTION
## Summary
- add newsletter entries ff.139 through ff.89 from the full data export to `data.js`
- ensure the data export remains properly formatted for the site data loader

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694285db09608320bbae2fe116840602)