### PR TITLE
Handle missing chapter keypoints

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -206,11 +206,13 @@ export const processChapter = (chapter) => {
   }
 
   const { emoji, cleanTitle } = extractEmojiAndTitle(chapter.title || '');
+  const keypoints = Array.isArray(chapter.keypoints) ? chapter.keypoints : [];
   const processedSubchapters = (chapter.subchapters || []).map(processSubchapter);
   const fallbackEmoji = emoji || '🎼';
 
   return {
     ...chapter,
+    keypoints,
     cleanTitle,
     originalEmoji: fallbackEmoji,
     primaryEmoji: determineChapterEmoji(chapter, processedSubchapters, fallbackEmoji),


### PR DESCRIPTION
## Summary
- default chapter keypoints to an empty array during processing
- prevent rendering errors when keypoints are missing from data

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694296c5721083209fa67b4a647c7d77)