### PR TITLE
Refine typography hierarchy and UI readability

### DIFF
--- a/App.js
+++ b/App.js
@@ -233,7 +233,7 @@ const InnerApp = () => {
         }}
       >
         <div className="w-full">
-          <h1 className="pixel-title text-2xl md:text-3xl lg:text-4xl leading-tight text-center">FUTURO FORTISSIMO</h1>
+          <h1 className="pixel-title ff-hero text-center">FUTURO FORTISSIMO</h1>
         </div>
       </header>
 
@@ -247,7 +247,7 @@ const InnerApp = () => {
                   value=${searchQuery}
                   onInput=${handleSearchChange}
                   placeholder="Cerca storie..."
-                  className="w-full px-4 py-3 pr-20 bg-white border-3 border-black font-heading uppercase tracking-[0.15em] placeholder:text-gray-400 focus:outline-none focus:ring-0"
+                  className="w-full px-4 py-3 pr-20 bg-white border-3 border-black ff-input placeholder:text-gray-400 focus:outline-none focus:ring-0"
                   aria-label="Cerca storie"
                 />
                 <div className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-2">
@@ -275,7 +275,7 @@ const InnerApp = () => {
               <button
                 type="button"
                 onClick=${handleOpenMedia}
-                className="px-4 py-3 border-3 border-black bg-white brutal-shadow font-heading text-xs uppercase tracking-[0.2em] hover:-translate-y-1 transition-transform"
+                className="px-4 py-3 border-3 border-black bg-white brutal-shadow ff-button hover:-translate-y-1 transition-transform"
               >
                 🎥 Media
               </button>
@@ -283,7 +283,7 @@ const InnerApp = () => {
                 type="button"
                 onClick=${handleOpenBooks}
                 disabled=${bookSuggestions.length === 0}
-                className="px-4 py-3 border-3 border-black bg-white brutal-shadow font-heading text-xs uppercase tracking-[0.2em] hover:-translate-y-1 transition-transform disabled:opacity-60 disabled:cursor-not-allowed"
+                className="px-4 py-3 border-3 border-black bg-white brutal-shadow ff-button hover:-translate-y-1 transition-transform disabled:opacity-60 disabled:cursor-not-allowed"
               >
                 📚 Libri
               </button>
@@ -292,7 +292,7 @@ const InnerApp = () => {
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="Supporto PayPal"
-                className="px-4 py-3 border-3 border-black bg-[var(--ff-blue)] text-black brutal-shadow font-heading text-xs uppercase tracking-[0.2em] hover:-translate-y-1 transition-transform"
+                className="px-4 py-3 border-3 border-black bg-[var(--ff-blue)] text-black brutal-shadow ff-button hover:-translate-y-1 transition-transform"
               >
                 ☕
               </a>
@@ -301,7 +301,7 @@ const InnerApp = () => {
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="Progetti micmer"
-                className="px-4 py-3 border-3 border-black bg-[var(--ff-blue)] text-black brutal-shadow font-heading text-xs uppercase tracking-[0.2em] hover:-translate-y-1 transition-transform"
+                className="px-4 py-3 border-3 border-black bg-[var(--ff-blue)] text-black brutal-shadow ff-button hover:-translate-y-1 transition-transform"
               >
                 M
               </a>
@@ -317,16 +317,16 @@ const InnerApp = () => {
       <section id="indice" className="compact-index space-y-6">
         <div className="flex flex-col gap-6">
           <div className="flex items-center gap-2 flex-wrap">
-            <div className="font-heading text-sm">Indice</div>
+            <div className="ff-eyebrow-md text-black/80">Indice</div>
             <span aria-hidden="true" className="text-black/60">·</span>
             ${selectedEmoji
               ? html`<button
-                  className="font-heading text-xs uppercase tracking-[0.2em] border-3 border-black px-3 py-2 bg-[var(--ff-yellow)] brutal-shadow"
+                  className="ff-button border-3 border-black px-3 py-2 bg-[var(--ff-yellow)] brutal-shadow"
                   onClick=${() => handleTopicSelect(null)}
                 >
                   Clear ${selectedEmoji}
                 </button>`
-              : html`<span className="font-heading text-xs uppercase tracking-[0.2em]">Tutti i temi</span>`}
+              : html`<span className="ff-eyebrow-md text-black/70">Tutti i temi</span>`}
           </div>
 
           <div className="space-y-6">
@@ -340,10 +340,10 @@ const InnerApp = () => {
                 )
               : html`<div className="border-3 border-black p-10 text-center brutal-shadow">
                   <span className="text-5xl block mb-4">🔍</span>
-                  <p className="text-lg mb-4">Nessun risultato per questo filtro.</p>
+                  <p className="ff-body mb-4">Nessun risultato per questo filtro.</p>
                   <button
                     onClick=${() => handleTopicSelect(null)}
-                    className="px-4 py-3 border-3 border-black bg-white brutal-shadow font-heading text-xs uppercase tracking-[0.2em] hover:-translate-y-1 transition-transform"
+                    className="px-4 py-3 border-3 border-black bg-white brutal-shadow ff-button hover:-translate-y-1 transition-transform"
                   >
                     Azzera filtri
                   </button>
@@ -359,7 +359,7 @@ const InnerApp = () => {
             <div className="absolute right-4 top-4 z-10">
               <button
                 onClick=${handleCloseMedia}
-                className="px-4 py-2 border-3 border-black bg-white font-heading text-xs uppercase tracking-[0.2em] hover:-translate-y-0.5 transition-transform"
+                className="px-4 py-2 border-3 border-black bg-white ff-button hover:-translate-y-0.5 transition-transform"
               >
                 Chiudi media
               </button>
@@ -373,7 +373,7 @@ const InnerApp = () => {
       ? html`<div className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm flex justify-end lg:hidden">
           <div className="w-72 max-w-full bg-white border-l-4 border-black p-4 flex flex-col gap-4">
             <div className="flex items-center justify-between">
-              <div className="font-heading text-xs uppercase tracking-[0.2em]">Filtri</div>
+              <div className="ff-eyebrow text-black/80">Filtri</div>
               <button
                 type="button"
                 aria-label="Chiudi filtri"

--- a/components/BooksModal.js
+++ b/components/BooksModal.js
@@ -98,13 +98,13 @@ const BooksModal = ({ sections, onClose }) => {
       <div className="p-5 sm:p-6 flex flex-col gap-5 overflow-y-auto max-h-[calc(100vh-3.5rem)]">
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
           <div>
-            <div className="text-[11px] font-heading uppercase tracking-[0.3em] text-black">Biblioteca</div>
-            <h3 className="text-2xl font-heading font-black leading-tight">Tutte le sezioni libro</h3>
-            <p className="text-sm text-black/70 max-w-2xl">Scorri le citazioni dei libri presenti nei capitoli e apri subito la fonte su Amazon.</p>
+            <div className="ff-eyebrow text-black">Biblioteca</div>
+            <h3 className="ff-heading-xl font-heading text-black">Tutte le sezioni libro</h3>
+            <p className="ff-body-sm text-black/70 max-w-2xl">Scorri le citazioni dei libri presenti nei capitoli e apri subito la fonte su Amazon.</p>
           </div>
           <button
             onClick=${onClose}
-            className="px-3 py-2 border-3 border-black bg-white font-heading text-[11px] uppercase tracking-[0.2em] brutal-shadow hover:-translate-y-0.5 transition-transform"
+            className="px-3 py-2 border-3 border-black bg-white ff-button brutal-shadow hover:-translate-y-0.5 transition-transform"
           >
             Chiudi
           </button>
@@ -113,10 +113,10 @@ const BooksModal = ({ sections, onClose }) => {
         ${hasSections
           ? html`<div className="space-y-3">
               <div className="flex flex-wrap gap-2 items-center">
-                <span className="text-[11px] font-heading uppercase tracking-[0.3em] text-black">Filtra per emoji</span>
+                <span className="ff-eyebrow text-black">Filtra per emoji</span>
                 <div className="flex flex-wrap gap-2">
                   <button
-                    className=${`px-3 py-1 border-2 border-black font-heading text-[11px] uppercase tracking-[0.2em] transition-transform brutal-shadow ${
+                    className=${`px-3 py-1 border-2 border-black ff-caption transition-transform brutal-shadow ${
                       selectedFilter === null ? 'bg-[var(--ff-blue)]' : 'bg-white'
                     }`}
                     onClick=${() => setSelectedFilter(null)}
@@ -126,7 +126,7 @@ const BooksModal = ({ sections, onClose }) => {
                   ${filters.map(
                     (emoji) => html`<button
                       key=${emoji}
-                      className=${`px-3 py-1 border-2 border-black font-heading text-[11px] uppercase tracking-[0.2em] transition-transform brutal-shadow flex items-center gap-2 ${
+                      className=${`px-3 py-1 border-2 border-black ff-caption transition-transform brutal-shadow flex items-center gap-2 ${
                         selectedFilter === emoji ? 'bg-[var(--ff-yellow)]' : 'bg-white'
                       }`}
                       onClick=${() => setSelectedFilter(emoji)}
@@ -142,10 +142,10 @@ const BooksModal = ({ sections, onClose }) => {
 
               ${bookFilters.length
                 ? html`<div className="flex flex-col gap-2">
-                    <span className="text-[11px] font-heading uppercase tracking-[0.3em] text-black">Filtra per libro 📚</span>
+                    <span className="ff-eyebrow text-black">Filtra per libro 📚</span>
                     <div className="flex flex-wrap gap-2">
                       <button
-                        className=${`px-3 py-1 border-2 border-black font-heading text-[11px] uppercase tracking-[0.2em] transition-transform brutal-shadow ${
+                        className=${`px-3 py-1 border-2 border-black ff-caption transition-transform brutal-shadow ${
                           selectedBookTitle === 'all' ? 'bg-[var(--ff-blue)]' : 'bg-white'
                         }`}
                         onClick=${() => setSelectedBookTitle('all')}
@@ -155,7 +155,7 @@ const BooksModal = ({ sections, onClose }) => {
                       ${bookFilters.map(
                         ({ title, author }) => html`<button
                           key=${title}
-                          className=${`px-3 py-1 border-2 border-black font-heading text-[11px] uppercase tracking-[0.15em] transition-transform brutal-shadow flex items-center gap-2 text-left ${
+                          className=${`px-3 py-1 border-2 border-black ff-caption transition-transform brutal-shadow flex items-center gap-2 text-left ${
                             selectedBookTitle === title ? 'bg-[var(--ff-yellow)]' : 'bg-white'
                           }`}
                           onClick=${() => setSelectedBookTitle(title)}
@@ -173,19 +173,19 @@ const BooksModal = ({ sections, onClose }) => {
 
         ${!hasSections
           ? html`<div className="border-3 border-black p-6 text-center brutal-shadow bg-white">
-              <p className="font-heading text-base">Nessuna sezione libro trovata.</p>
+              <p className="font-heading ff-body">Nessuna sezione libro trovata.</p>
             </div>`
           : html`<div className="grid gap-4 sm:grid-cols-2">
               ${filteredSections.map((section, idx) =>
                 html`<article key=${idx} className="border-3 border-black bg-white brutal-shadow p-4 flex flex-col gap-3 h-full">
                   <div className="flex items-start justify-between gap-2">
                     <div className="space-y-1">
-                      <div className="font-heading font-bold text-base leading-tight">${section.bookTitle}</div>
-                      <div className="text-[11px] uppercase tracking-[0.2em] text-black/70">${section.bookAuthor}</div>
+                      <div className="font-heading ff-heading-md text-black">${section.bookTitle}</div>
+                      <div className="ff-eyebrow text-black/70">${section.bookAuthor}</div>
                     </div>
                     <div className="flex flex-col items-end gap-1">
                       <span className="text-xl" aria-hidden="true">📚</span>
-                      <span className="px-2 py-1 border-2 border-black text-[10px] font-heading uppercase tracking-[0.2em] bg-[var(--ff-yellow)]">${section.referenceLabel}</span>
+                      <span className="px-2 py-1 border-2 border-black ff-caption bg-[var(--ff-yellow)]">${section.referenceLabel}</span>
                     </div>
                   </div>
 
@@ -193,10 +193,10 @@ const BooksModal = ({ sections, onClose }) => {
                     ? html`<figure className="space-y-1">
                         <img src=${section.previewImage.src} alt=${section.previewImage.caption || 'Anteprima libro'} className="w-full h-auto border-3 border-black bg-white" loading="lazy" />
                         ${section.previewImage.caption
-                          ? html`<figcaption className="text-[10px] font-heading uppercase tracking-widest text-black font-bold pl-1">${section.previewImage.caption}</figcaption>`
+                          ? html`<figcaption className="ff-caption text-black font-bold pl-1">${section.previewImage.caption}</figcaption>`
                           : null}
                       </figure>`
-                    : html`<blockquote className="border-l-4 border-black pl-3 text-sm leading-snug text-black/80">
+                    : html`<blockquote className="border-l-4 border-black pl-3 ff-body-sm leading-snug text-black/80">
                         “${section.quote.length > 220 ? `${section.quote.slice(0, 220)}…` : section.quote}”
                       </blockquote>`}
 
@@ -206,7 +206,7 @@ const BooksModal = ({ sections, onClose }) => {
                           href=${section.amazonRef.url}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="px-3 py-2 border-2 border-black bg-[var(--ff-yellow)] font-heading text-[11px] uppercase tracking-[0.2em] hover:-translate-y-0.5 transition-transform"
+                          className="px-3 py-2 border-2 border-black bg-[var(--ff-yellow)] ff-button hover:-translate-y-0.5 transition-transform"
                         >
                           Leggi su Amazon ↗
                         </a>`
@@ -215,7 +215,7 @@ const BooksModal = ({ sections, onClose }) => {
                       href=${section.subchapterLink}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="px-3 py-2 border-2 border-black bg-white font-heading text-[11px] uppercase tracking-[0.2em] hover:-translate-y-0.5 transition-transform"
+                      className="px-3 py-2 border-2 border-black bg-white ff-button hover:-translate-y-0.5 transition-transform"
                     >
                       Apri ${section.referenceLabel}
                     </a>

--- a/components/BooksPopup.js
+++ b/components/BooksPopup.js
@@ -65,9 +65,9 @@ const BooksPopup = ({ isOpen, onClose, books }) => {
         <div className="relative space-y-5">
           <div className="flex justify-between items-start gap-4">
             <div className="space-y-1">
-              <div className="text-[11px] font-heading uppercase tracking-[0.3em] text-black mb-1">Consigli di lettura</div>
-              <h3 className="text-2xl font-heading font-black text-black leading-tight">${current.title}</h3>
-              <p className="text-xs md:text-sm text-black/70">${chapterLabel}</p>
+              <div className="ff-eyebrow text-black mb-1">Consigli di lettura</div>
+              <h3 className="ff-heading-xl font-heading text-black">${current.title}</h3>
+              <p className="ff-body-xs text-black/70">${chapterLabel}</p>
             </div>
             <div className="flex gap-2">
               <button aria-label="Libro casuale precedente" onClick=${goRandom} className="h-12 w-12 border-3 border-black bg-white brutal-shadow hover:-translate-y-1 transition-transform">⟵</button>
@@ -84,14 +84,14 @@ const BooksPopup = ({ isOpen, onClose, books }) => {
               : null}
             <div className="border-3 border-black bg-white brutal-shadow p-4 flex flex-col gap-3">
               ${quoteText
-                ? html`<p className="text-sm text-black leading-relaxed">“${quoteText}”</p>`
-                : html`<p className="text-sm text-black leading-relaxed">Scopri perché è in archivio: clicca per il capitolo completo.</p>`}
+                ? html`<p className="ff-body-sm text-black leading-relaxed">“${quoteText}”</p>`
+                : html`<p className="ff-body-sm text-black leading-relaxed">Scopri perché è in archivio: clicca per il capitolo completo.</p>`}
 
               <a
                 href=${current.link}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="px-4 py-3 border-3 border-black bg-[var(--ff-yellow)] text-black brutal-shadow font-heading text-xs uppercase tracking-[0.2em] w-fit hover:-translate-y-1 transition-transform"
+                className="px-4 py-3 border-3 border-black bg-[var(--ff-yellow)] text-black brutal-shadow ff-button w-fit hover:-translate-y-1 transition-transform"
               >
                 Compra su Amazon
               </a>
@@ -99,7 +99,7 @@ const BooksPopup = ({ isOpen, onClose, books }) => {
                 href=${current.subLink || current.chapterUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="px-4 py-3 border-3 border-black bg-white text-black brutal-shadow font-heading text-xs uppercase tracking-[0.2em] w-fit hover:-translate-y-1 transition-transform"
+                className="px-4 py-3 border-3 border-black bg-white text-black brutal-shadow ff-button w-fit hover:-translate-y-1 transition-transform"
               >
                 ${chapterCode}
               </a>

--- a/components/ChapterItem.js
+++ b/components/ChapterItem.js
@@ -6,12 +6,12 @@ const ChapterItem = ({ chapter }) => {
     <div className="mb-4 border-b-4 border-black pb-3 flex items-start gap-3">
       <span className="text-2xl select-none leading-none">${chapter.primaryEmoji || chapter.originalEmoji}</span>
       <div>
-        <h2 className="font-heading text-lg md:text-xl font-bold text-black leading-none">
+        <h2 className="font-heading ff-heading-lg text-black leading-none">
           <a href=${chapter.url} target="_blank" rel="noopener noreferrer" className="hover:underline decoration-4">
             ${chapter.cleanTitle}
           </a>
         </h2>
-        <p className="inline-block bg-[var(--ff-yellow)] px-2 py-1 text-[11px] md:text-sm text-black font-heading uppercase tracking-[0.18em] mt-2">
+        <p className="inline-block bg-[var(--ff-yellow)] px-2 py-1 ff-eyebrow text-black mt-2">
           ${chapter.subtitle}
         </p>
       </div>
@@ -21,7 +21,7 @@ const ChapterItem = ({ chapter }) => {
       ? html`<div className="mb-4">
           <ul className="space-y-2">
             ${chapter.keypoints.map(
-              (point, idx) => html`<li key=${idx} className="text-sm md:text-base text-black font-medium flex items-start gap-2 leading-snug">
+              (point, idx) => html`<li key=${idx} className="ff-body-sm text-black font-medium flex items-start gap-2 leading-snug">
                   <span className="mt-1 w-2 h-2 bg-black shrink-0"></span>
                   <span>${point}</span>
                 </li>`

--- a/components/IndexChapter.js
+++ b/components/IndexChapter.js
@@ -24,18 +24,18 @@ const IndexChapter = ({ chapter, highlight }) => {
     <div className="flex items-start gap-3">
       <span className="text-xl select-none leading-none">${chapter.primaryEmoji || chapter.originalEmoji}</span>
       <div className="flex-1">
-        <h2 className="font-heading text-lg md:text-xl font-bold text-black leading-tight chapter-title">
+        <h2 className="font-heading ff-heading-lg text-black chapter-title">
           <a href=${chapter.url} target="_blank" rel="noopener noreferrer" className="hover:underline decoration-4">
             <${HighlightText} text=${chapter.cleanTitle} highlight=${highlight} />
           </a>
         </h2>
         ${chapter.subtitle
-          ? html`<p className="inline-block px-0 py-1 text-sm md:text-base text-black font-heading uppercase tracking-[0.18em] mt-2 sub-title">
+          ? html`<p className="inline-block px-0 py-1 ff-eyebrow-md text-black/80 mt-2 sub-title">
               <${HighlightText} text=${chapter.subtitle} highlight=${highlight} />
             </p>`
           : null}
         ${chapter.keypoints.length
-          ? html`<ul className="mt-3 space-y-2 text-base md:text-lg text-black font-medium">
+          ? html`<ul className="mt-3 space-y-2 ff-body text-black font-medium">
               ${chapter.keypoints.map((point, idx) =>
                 html`<li key=${idx} className="leading-snug flex gap-2 items-start">
                   <span className="text-lg leading-none mt-0.5">•</span>
@@ -56,12 +56,12 @@ const IndexChapter = ({ chapter, highlight }) => {
               href=${sub.link}
               target="_blank"
               rel="noopener noreferrer"
-              className="font-heading text-lg md:text-xl font-bold text-black hover:underline decoration-2 break-words"
+              className="font-heading ff-heading-md text-black hover:underline decoration-2 break-words"
             >
               <${HighlightText} text=${sub.cleanTitle} highlight=${highlight} />
             </a>
             ${sub.summary
-              ? html`<p className="text-sm md:text-base text-gray-700 leading-snug mt-1">
+              ? html`<p className="ff-body-sm text-black/70 leading-snug mt-1">
                   <${HighlightText} text=${sub.summary} highlight=${highlight} />
                 </p>`
               : null}
@@ -74,7 +74,7 @@ const IndexChapter = ({ chapter, highlight }) => {
       ? html`<div className="mt-5 border-t border-black/10 pt-3">
           <button
             type="button"
-            className="links-toggle inline-flex items-center gap-2 border-3 border-black bg-white brutal-shadow font-heading uppercase tracking-[0.18em] px-3 py-2"
+            className="links-toggle inline-flex items-center gap-2 border-3 border-black bg-white brutal-shadow ff-button px-3 py-2"
             onClick=${() => setShowCitations((prev) => !prev)}
             aria-expanded=${showCitations}
           >
@@ -89,7 +89,7 @@ const IndexChapter = ({ chapter, highlight }) => {
                     href=${ref.url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="inline-flex items-center bg-[var(--ff-yellow)] text-[11px] font-heading uppercase tracking-[0.18em] px-2 py-1 text-black hover:underline decoration-2 brutal-shadow"
+                    className="inline-flex items-center bg-[var(--ff-yellow)] ff-caption px-2 py-1 text-black hover:underline decoration-2 brutal-shadow"
                   >
                     <${HighlightText} text=${ref.text} highlight=${highlight} />
                   </a>`

--- a/components/MediaSlider.js
+++ b/components/MediaSlider.js
@@ -56,7 +56,7 @@ const MediaSlider = ({ chapters }) => {
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_1px_1px,#000_1px,transparent_0)] [background-size:22px_22px] opacity-10 pointer-events-none"></div>
       <div className="relative p-5 md:p-8 flex flex-col gap-6">
         <div className="flex items-center justify-between gap-4">
-          <h2 className="font-heading font-black text-xl md:text-2xl tracking-tight text-black">Media dall'archivio</h2>
+          <h2 className="font-heading ff-heading-lg text-black tracking-tight">Media dall'archivio</h2>
           <div className="flex gap-2">
             <button aria-label="Previous media" onClick=${goToPrev} className="h-10 w-10 border-3 border-black bg-white brutal-shadow hover:-translate-y-1 transition-transform">⟵</button>
             <button aria-label="Next media" onClick=${goToNext} className="h-10 w-10 border-3 border-black bg-white brutal-shadow hover:-translate-y-1 transition-transform">⟶</button>
@@ -76,16 +76,16 @@ const MediaSlider = ({ chapters }) => {
           </figure>
 
           <div className="flex flex-col gap-3 bg-white border-4 border-black brutal-shadow p-4 md:p-6">
-            <h3 className="font-heading text-xl md:text-2xl font-black text-black leading-tight">${currentItem.subTitle}</h3>
-            <p className="text-xs md:text-sm text-black/80">${currentItem.chapterTitle}</p>
+            <h3 className="font-heading ff-heading-xl text-black">${currentItem.subTitle}</h3>
+            <p className="ff-body-xs text-black/80">${currentItem.chapterTitle}</p>
             ${captionText
-              ? html`<p className="text-sm md:text-base text-black leading-relaxed">${captionText}</p>`
+              ? html`<p className="ff-body-sm text-black leading-relaxed">${captionText}</p>`
               : null}
             <a
               href=${currentItem.link || currentItem.chapterUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="px-3 py-1 border-3 border-black bg-yellow-100 text-[10px] md:text-xs font-heading uppercase tracking-[0.18em] inline-flex w-fit hover:-translate-y-0.5 transition-transform"
+              className="px-3 py-1 border-3 border-black bg-yellow-100 ff-caption inline-flex w-fit hover:-translate-y-0.5 transition-transform"
             >
               ${currentItem.reference}
             </a>

--- a/components/RightSidebar.js
+++ b/components/RightSidebar.js
@@ -37,7 +37,7 @@ const RightSidebar = ({ chapters, isMobileMode = false }) => {
   }).filter(Boolean);
 
   return html`<div className="space-y-4">
-    <div className="font-heading text-[11px] uppercase tracking-[0.18em] text-black">
+    <div className="ff-eyebrow text-black">
       ${searchQuery ? `Risultati per “${searchQuery}”` : 'Naviga tra i capitoli'}
     </div>
 
@@ -51,7 +51,7 @@ const RightSidebar = ({ chapters, isMobileMode = false }) => {
             }}
           >
             <span className="text-lg">${chapter.primaryEmoji || chapter.originalEmoji}</span>
-            <span className="font-heading font-bold text-sm text-black group-hover:underline break-words">${chapter.cleanTitle}</span>
+            <span className="font-heading ff-body-xs text-black group-hover:underline break-words">${chapter.cleanTitle}</span>
           </button>
 
           <div className="pl-4 space-y-2 border-l-4 border-black">
@@ -68,7 +68,7 @@ const RightSidebar = ({ chapters, isMobileMode = false }) => {
                 <div className="flex items-start gap-2">
                   <span className="text-base leading-none mt-0.5">${sub.originalEmoji}</span>
                   <div>
-                    <div className="font-heading text-[12px] font-semibold text-black group-hover:underline break-words">${sub.cleanTitle}</div>
+                    <div className="font-heading ff-body-xs text-black group-hover:underline break-words">${sub.cleanTitle}</div>
                   </div>
                 </div>
               </button>`;

--- a/components/SearchResultsModal.js
+++ b/components/SearchResultsModal.js
@@ -97,13 +97,13 @@ const SearchResultsModal = ({ chapters, isOpen, onHide, onClear, onNavigate }) =
         <div className="flex flex-col gap-3">
           <div className="flex items-start justify-between gap-3">
             <div>
-              <div className="text-[11px] font-heading uppercase tracking-[0.3em] text-black">Ricerca</div>
-              <h3 className="text-2xl font-heading font-black leading-tight">Risultati per “${searchQuery}”</h3>
-              <p className="text-sm text-black/70 max-w-2xl">Apri il risultato per scorrere alla card corrispondente. I testi coincidono con l’evidenziazione già visibile nelle schede.</p>
+              <div className="ff-eyebrow text-black">Ricerca</div>
+              <h3 className="ff-heading-xl font-heading text-black">Risultati per “${searchQuery}”</h3>
+              <p className="ff-body-sm text-black/70 max-w-2xl">Apri il risultato per scorrere alla card corrispondente. I testi coincidono con l’evidenziazione già visibile nelle schede.</p>
             </div>
             <button
               onClick=${handleClose}
-              className="px-3 py-2 border-3 border-black bg-white font-heading text-[11px] uppercase tracking-[0.2em] brutal-shadow hover:-translate-y-0.5 transition-transform"
+              className="px-3 py-2 border-3 border-black bg-white ff-button brutal-shadow hover:-translate-y-0.5 transition-transform"
               aria-label="Chiudi e cancella ricerca"
             >
               ✕
@@ -113,7 +113,7 @@ const SearchResultsModal = ({ chapters, isOpen, onHide, onClear, onNavigate }) =
 
         ${results.length === 0
           ? html`<div className="border-3 border-black p-6 text-center brutal-shadow bg-white">
-              <p className="font-heading text-base">Nessun contenuto corrisponde alla ricerca.</p>
+              <p className="font-heading ff-body">Nessun contenuto corrisponde alla ricerca.</p>
             </div>`
           : html`<ol className="space-y-3">
               ${results.map(
@@ -126,18 +126,18 @@ const SearchResultsModal = ({ chapters, isOpen, onHide, onClear, onNavigate }) =
                       <div className="flex items-start gap-2">
                         <span className="text-lg leading-none">${item.emoji}</span>
                         <div>
-                          <div className="font-heading font-bold text-base sm:text-lg text-black">
+                          <div className="font-heading ff-heading-md text-black">
                             <${HighlightText} text=${item.title} highlight=${debouncedSearchQuery} />
                           </div>
-                          <div className="text-[11px] uppercase tracking-[0.2em] text-black/70">${item.type === 'chapter'
+                          <div className="ff-eyebrow text-black/70">${item.type === 'chapter'
                             ? 'Capitolo'
                             : `Sottocapitolo · ${item.chapterTitle}`}</div>
                         </div>
                       </div>
-                      <span className="text-xs font-heading px-2 py-1 border-2 border-black bg-white">Apri</span>
+                      <span className="ff-caption px-2 py-1 border-2 border-black bg-white">Apri</span>
                     </div>
                     ${item.snippet
-                      ? html`<p className="mt-3 text-sm text-black/80 leading-snug">
+                      ? html`<p className="mt-3 ff-body-sm text-black/80 leading-snug">
                           <${HighlightText} text=${item.snippet} highlight=${debouncedSearchQuery} />
                         </p>`
                       : null}

--- a/components/SubChapterItem.js
+++ b/components/SubChapterItem.js
@@ -49,7 +49,7 @@ const SubChapterItem = ({ subchapter, parentId }) => {
           href=${subchapter.link}
           target="_blank"
           rel="noopener noreferrer"
-          className="font-heading text-lg md:text-xl font-bold text-black mr-2 break-words hover:underline decoration-4"
+          className="font-heading ff-heading-md text-black mr-2 break-words hover:underline decoration-4"
           onClick=${(e) => {
             e.stopPropagation();
             incrementInteraction();
@@ -58,7 +58,7 @@ const SubChapterItem = ({ subchapter, parentId }) => {
           <${HighlightText} text=${subchapter.cleanTitle} highlight=${debouncedSearchQuery} />
         </a>
         ${subchapter.summary
-          ? html`<p className="mt-1 text-[12px] md:text-[13px] text-gray-700 font-medium leading-snug pr-8">
+          ? html`<p className="mt-1 ff-body-xs text-black/70 font-medium leading-snug pr-8">
               ${subchapter.summary}
             </p>`
           : null}
@@ -94,7 +94,7 @@ const SubChapterItem = ({ subchapter, parentId }) => {
                 const isCross = isCrossReference(ref.text);
                 const displayText = isCross ? ref.text : capitalizeFirstLetter(ref.text);
                 const linkClasses =
-                  'inline-flex items-center gap-1 bg-[var(--ff-yellow)] text-[11px] font-heading uppercase tracking-[0.18em] px-2 py-1 text-black w-fit hover:underline decoration-2';
+                  'inline-flex items-center gap-1 bg-[var(--ff-yellow)] ff-caption px-2 py-1 text-black w-fit hover:underline decoration-2';
 
                 return html`<a
                   key=${idx}
@@ -113,7 +113,7 @@ const SubChapterItem = ({ subchapter, parentId }) => {
               })}
             </div>`
           : null}
-        <div className="prose prose-sm max-w-none text-black leading-relaxed font-medium break-words text-[12px] md:text-[13px]">
+        <div className="prose prose-sm max-w-none text-black leading-relaxed font-medium break-words ff-body-xs">
           ${subchapter.content
             .split('\n')
             .map((paragraph, idx) => (paragraph.trim() ? html`<p key=${idx} className="mb-2 last:mb-0">
@@ -134,7 +134,7 @@ const SubChapterItem = ({ subchapter, parentId }) => {
                     loading="lazy"
                   />
                   ${img.caption
-                    ? html`<figcaption className="text-[10px] font-heading uppercase tracking-widest text-black font-bold pl-1">
+                    ? html`<figcaption className="ff-caption text-black font-bold pl-1">
                         ${img.caption}
                       </figcaption>`
                     : null}

--- a/components/SupportPopup.js
+++ b/components/SupportPopup.js
@@ -24,9 +24,9 @@ const SupportPopup = () => {
         <div className="relative space-y-5">
           <div className="flex justify-between items-start gap-4">
             <div>
-              <div className="text-[11px] font-heading uppercase tracking-[0.3em] text-black mb-2">Supporto</div>
-              <h3 className="text-3xl font-heading font-black text-black leading-tight">Sostieni Futuro Fortissimo</h3>
-              <p className="text-black mt-2 text-sm md:text-base max-w-xl">Se ti piace l’archivio, puoi dargli energia con un contributo via PayPal. Ogni gesto aiuta a mantenere aggiornate le storie e i media.</p>
+              <div className="ff-eyebrow text-black mb-2">Supporto</div>
+              <h3 className="ff-heading-xl font-heading text-black">Sostieni Futuro Fortissimo</h3>
+              <p className="text-black mt-2 ff-body-sm max-w-xl">Se ti piace l’archivio, puoi dargli energia con un contributo via PayPal. Ogni gesto aiuta a mantenere aggiornate le storie e i media.</p>
             </div>
             <button onClick=${closeSupportPopup} className="h-12 w-12 border-3 border-black bg-white brutal-shadow hover:-translate-y-1 transition-transform">✕</button>
           </div>
@@ -41,11 +41,11 @@ const SupportPopup = () => {
             <div className="relative flex items-center gap-3">
               <span className="text-3xl">💙</span>
               <div>
-                <div className="font-heading font-black text-black text-lg">PayPal</div>
-                <p className="text-sm text-black/80">Il modo più rapido per mandare un grazie e supportare l’archivio.</p>
+                <div className="font-heading ff-heading-md text-black">PayPal</div>
+                <p className="ff-body-sm text-black/80">Il modo più rapido per mandare un grazie e supportare l’archivio.</p>
               </div>
             </div>
-            <div className="relative mt-auto text-sm font-heading uppercase tracking-[0.2em] text-black">paypal.me/MicheleMerelli</div>
+            <div className="relative mt-auto ff-eyebrow-md text-black">paypal.me/MicheleMerelli</div>
           </a>
 
           <div className="flex flex-wrap gap-3">

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
         color: var(--ff-black);
         position: relative;
         min-height: 100vh;
+        line-height: 1.6;
       }
 
       body::before {
@@ -78,12 +79,12 @@
       }
 
       .compact-index .chapter-title {
-        font-size: 15px;
+        font-size: 1.1rem;
       }
 
       .compact-index .sub-title,
       .compact-index .links-toggle {
-        font-size: 12px;
+        font-size: 0.75rem;
       }
 
       .accent-bar { position: relative; }
@@ -106,6 +107,92 @@
         font-family: 'IBM Plex Mono', monospace;
         letter-spacing: 0.18em;
         font-weight: 700;
+      }
+
+      .ff-hero {
+        font-size: clamp(1.9rem, 1.4rem + 2vw, 3rem);
+        line-height: 1.1;
+      }
+
+      .ff-heading-xl {
+        font-size: clamp(1.6rem, 1.2rem + 1vw, 2.2rem);
+        line-height: 1.2;
+        font-weight: 700;
+      }
+
+      .ff-heading-lg {
+        font-size: clamp(1.25rem, 1.1rem + 0.6vw, 1.6rem);
+        line-height: 1.25;
+        font-weight: 700;
+      }
+
+      .ff-heading-md {
+        font-size: 1.125rem;
+        line-height: 1.3;
+        font-weight: 700;
+      }
+
+      .ff-body {
+        font-size: 1rem;
+        line-height: 1.65;
+      }
+
+      .ff-body-sm {
+        font-size: 0.9375rem;
+        line-height: 1.6;
+      }
+
+      .ff-body-xs {
+        font-size: 0.875rem;
+        line-height: 1.55;
+      }
+
+      .ff-eyebrow {
+        font-family: 'IBM Plex Mono', monospace;
+        font-size: 0.75rem;
+        letter-spacing: 0.24em;
+        text-transform: uppercase;
+        font-weight: 700;
+      }
+
+      .ff-eyebrow-md {
+        font-family: 'IBM Plex Mono', monospace;
+        font-size: 0.8125rem;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        font-weight: 700;
+      }
+
+      .ff-caption {
+        font-family: 'IBM Plex Mono', monospace;
+        font-size: 0.75rem;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        font-weight: 700;
+      }
+
+      .ff-button {
+        font-family: 'IBM Plex Mono', monospace;
+        font-size: 0.75rem;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        font-weight: 700;
+      }
+
+      .ff-input {
+        font-family: 'IBM Plex Mono', monospace;
+        font-size: 0.8125rem;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+      }
+
+      a:focus-visible,
+      button:focus-visible,
+      input:focus-visible,
+      textarea:focus-visible,
+      select:focus-visible {
+        outline: 3px solid var(--ff-black);
+        outline-offset: 2px;
       }
 
       .no-round, .no-round * {


### PR DESCRIPTION
### Motivation
- Establish a unified typography scale and spacing to make UI text hierarchy consistent across the site. 
- Improve readability and accessibility by normalizing line-heights, label sizes, and adding clear focus styles for keyboard users. 
- Standardize button, input and caption styles so components share a single small set of utility classes.

### Description
- Added a shared type scale and utility classes in the main stylesheet (`index.html`) such as `ff-hero`, `ff-heading-xl`, `ff-heading-lg`, `ff-heading-md`, `ff-body`, `ff-body-sm`, `ff-body-xs`, `ff-eyebrow`, `ff-caption`, `ff-button` and `ff-input`, and set `line-height` defaults and `:focus-visible` outlines. 
- Replaced ad-hoc font sizes and inline styles with the new classes in the main app (`App.js`) to standardize the hero, search input and action buttons. 
- Updated multiple components to use the unified classes for headings, captions and body copy: `components/IndexChapter.js`, `components/SubChapterItem.js`, `components/ChapterItem.js`, `components/BooksModal.js`, `components/BooksPopup.js`, `components/MediaSlider.js`, `components/RightSidebar.js`, `components/SearchResultsModal.js` and `components/SupportPopup.js`. 
- Tweaked compact index sizing and a few small copy/formatting changes to improve contrast and visual rhythm across cards and modals.

### Testing
- Started the dev server with `npm run dev` and the server reported Vite ready on the expected port, which completed successfully. 
- Executed a Playwright script to load the local site and capture a full-page screenshot, and the run produced a screenshot artifact successfully. 
- No unit or integration test suites were present or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969f2f38cbc8320b0931a4934d3107f)