### PR TITLE
Integrate Themes/Connections/Book outline into main UI (modals)

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,6 +9,9 @@ import SearchResultsModal from './components/SearchResultsModal.js';
 import BooksPopup from './components/BooksPopup.js';
 import { NavigationProvider, useNavigation } from './NavigationContext.js';
 import IndexChapter from './components/IndexChapter.js';
+import ThemesPopup from './components/ThemesPopup.js';
+import ConnectionsPopup from './components/ConnectionsPopup.js';
+import BookOutlinePopup from './components/BookOutlinePopup.js';
 
 const headerBackgroundDataUri =
   'data:image/svg+xml;utf8,' +
@@ -80,6 +83,9 @@ const InnerApp = () => {
   const [isSearchOverlayOpen, setIsSearchOverlayOpen] = React.useState(false);
   const [hasManuallyClosedSearch, setHasManuallyClosedSearch] = React.useState(false);
   const [isFilterMenuOpen, setIsFilterMenuOpen] = React.useState(false);
+  const [isThemesOpen, setIsThemesOpen] = React.useState(false);
+  const [isConnectionsOpen, setIsConnectionsOpen] = React.useState(false);
+  const [isBookOpen, setIsBookOpen] = React.useState(false);
   const { incrementInteraction, searchQuery, setSearchQuery, debouncedSearchQuery } = useNavigation();
 
   React.useEffect(() => {
@@ -287,20 +293,27 @@ const InnerApp = () => {
               >
                 📚 Libri
               </button>
-              <a
-                href="./themes.html"
-                data-nav="1"
+              <button
+                type="button"
+                onClick=${() => setIsBookOpen(true)}
+                className="px-4 py-3 border-3 border-black bg-white brutal-shadow ff-button hover:-translate-y-1 transition-transform"
+              >
+                📖 Libro
+              </button>
+              <button
+                type="button"
+                onClick=${() => setIsThemesOpen(true)}
                 className="px-4 py-3 border-3 border-black bg-white brutal-shadow ff-button hover:-translate-y-1 transition-transform"
               >
                 🧭 Temi
-              </a>
-              <a
-                href="./connections.html"
-                data-nav="1"
+              </button>
+              <button
+                type="button"
+                onClick=${() => setIsConnectionsOpen(true)}
                 className="px-4 py-3 border-3 border-black bg-white brutal-shadow ff-button hover:-translate-y-1 transition-transform"
               >
                 🕸️ Connessioni
-              </a>
+              </button>
               <a
                 href="https://www.paypal.com/paypalme/MicheleMerelli"
                 target="_blank"
@@ -382,6 +395,10 @@ const InnerApp = () => {
           </div>
         </div>`
       : null}
+
+    ${isThemesOpen ? html`<${ThemesPopup} onClose=${() => setIsThemesOpen(false)} />` : null}
+    ${isConnectionsOpen ? html`<${ConnectionsPopup} onClose=${() => setIsConnectionsOpen(false)} />` : null}
+    ${isBookOpen ? html`<${BookOutlinePopup} onClose=${() => setIsBookOpen(false)} />` : null}
 
     ${isFilterMenuOpen
       ? html`<div className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm flex justify-end lg:hidden">

--- a/analytics.js
+++ b/analytics.js
@@ -1,4 +1,5 @@
 // Lightweight analytics + interaction tracking.
+// Note: this file is loaded as type=module (see index.html).
 // This file is safe even if no analytics provider is configured.
 //
 // To enable Plausible:

--- a/components/BookOutlinePopup.js
+++ b/components/BookOutlinePopup.js
@@ -1,0 +1,47 @@
+import { React, html } from '../runtime.js';
+
+const BookOutlinePopup = ({ onClose }) => {
+  const [data, setData] = React.useState(null);
+
+  React.useEffect(() => {
+    fetch(`./generated/book/outline.json?ts=${Date.now()}`)
+      .then((r) => r.json())
+      .then(setData)
+      .catch(() => setData({ error: true }));
+  }, []);
+
+  return html`<div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
+    <div role="dialog" aria-modal="true" aria-label="Outline libro" className="relative max-w-5xl w-full">
+      <div className="absolute right-4 top-4 z-10">
+        <button onClick=${onClose} className="px-4 py-2 border-3 border-black bg-white ff-button hover:-translate-y-0.5 transition-transform">
+          Chiudi
+        </button>
+      </div>
+
+      <div className="border-3 border-black bg-white brutal-shadow p-6 max-h-[80vh] overflow-auto">
+        <div className="ff-eyebrow-md text-black/80">Libro / mini‑saggi</div>
+        <h2 className="ff-heading-xl mt-2">14 capitoli (outline)</h2>
+        <p className="ff-body text-black/70 mt-2">Struttura consequenziale: tech → cultura/simulazione → attenzione/salute → materiale/politico.</p>
+
+        ${!data
+          ? html`<p className="mt-6">Caricamento…</p>`
+          : data.error
+            ? html`<p className="mt-6">Errore caricamento outline.</p>`
+            : html`<ol className="mt-6 space-y-5">
+                ${(data.chapters || []).map((c) => html`
+                  <li className="border-3 border-black p-4 brutal-shadow">
+                    <div className="ff-caption text-black/70">Capitolo ${c.n}</div>
+                    <div className="text-lg font-bold mt-1">${c.title}</div>
+                    <div className="ff-body mt-2 text-black/80">${c.thesis}</div>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      ${(c.refs || []).map((r) => html`<span className="px-2 py-1 border-3 border-black text-xs ff-button bg-white">${r}</span>`)}
+                    </div>
+                  </li>
+                `)}
+              </ol>`}
+      </div>
+    </div>
+  </div>`;
+};
+
+export default BookOutlinePopup;

--- a/components/ConnectionsPopup.js
+++ b/components/ConnectionsPopup.js
@@ -1,0 +1,48 @@
+import { React, html } from '../runtime.js';
+
+const ConnectionsPopup = ({ onClose }) => {
+  const [data, setData] = React.useState(null);
+
+  React.useEffect(() => {
+    fetch(`./generated/connections.json?ts=${Date.now()}`)
+      .then((r) => r.json())
+      .then(setData)
+      .catch(() => setData({ error: true }));
+  }, []);
+
+  const hubs = data?.topHubs ? data.topHubs.slice(0, 25) : [];
+
+  return html`<div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
+    <div role="dialog" aria-modal="true" aria-label="Connessioni" className="relative max-w-5xl w-full">
+      <div className="absolute right-4 top-4 z-10">
+        <button onClick=${onClose} className="px-4 py-2 border-3 border-black bg-white ff-button hover:-translate-y-0.5 transition-transform">
+          Chiudi
+        </button>
+      </div>
+
+      <div className="border-3 border-black bg-white brutal-shadow p-6 max-h-[80vh] overflow-auto">
+        <div className="ff-eyebrow-md text-black/80">Connessioni</div>
+        <h2 className="ff-heading-xl mt-2">Connessioni fortissime</h2>
+        <p className="ff-body text-black/70 mt-2">Hub più citati nel grafo <span className="ff-caption">connections</span> dei subcapitoli.</p>
+
+        ${!data
+          ? html`<p className="mt-6">Caricamento…</p>`
+          : data.error
+            ? html`<p className="mt-6">Errore caricamento connessioni.</p>`
+            : html`<ol className="mt-6 space-y-4">
+                ${hubs.map((h) => html`
+                  <li className="border-3 border-black p-4 brutal-shadow">
+                    <div className="ff-caption text-black/70">${h.id} · score ${h.score}</div>
+                    <div className="text-lg font-bold mt-1">${(h.label || h.id).replace(/\s+/g, ' ')}</div>
+                    ${h.url
+                      ? html`<div className="mt-2"><a className="underline" href=${h.url} target="_blank" rel="noopener noreferrer">Apri</a></div>`
+                      : null}
+                  </li>
+                `)}
+              </ol>`}
+      </div>
+    </div>
+  </div>`;
+};
+
+export default ConnectionsPopup;

--- a/components/ThemesPopup.js
+++ b/components/ThemesPopup.js
@@ -1,0 +1,56 @@
+import { React, html } from '../runtime.js';
+
+const ThemesPopup = ({ onClose }) => {
+  const [data, setData] = React.useState(null);
+
+  React.useEffect(() => {
+    fetch(`./generated/themes.json?ts=${Date.now()}`)
+      .then((r) => r.json())
+      .then(setData)
+      .catch(() => setData({ error: true }));
+  }, []);
+
+  const themes = data?.themes ? [...data.themes].sort((a, b) => b.count - a.count) : [];
+
+  return html`<div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
+    <div role="dialog" aria-modal="true" aria-label="Macro-temi" className="relative max-w-5xl w-full">
+      <div className="absolute right-4 top-4 z-10">
+        <button onClick=${onClose} className="px-4 py-2 border-3 border-black bg-white ff-button hover:-translate-y-0.5 transition-transform">
+          Chiudi
+        </button>
+      </div>
+
+      <div className="border-3 border-black bg-white brutal-shadow p-6 max-h-[80vh] overflow-auto">
+        <div className="ff-eyebrow-md text-black/80">Macro‑temi</div>
+        <h2 className="ff-heading-xl mt-2">Indice dei temi ricorrenti</h2>
+        <p className="ff-body text-black/70 mt-2">Classificazione automatica (keyword) per navigare il corpus.</p>
+
+        ${!data
+          ? html`<p className="mt-6">Caricamento…</p>`
+          : data.error
+            ? html`<p className="mt-6">Errore caricamento macro‑temi.</p>`
+            : html`<div className="mt-6 space-y-5">
+                ${themes.map((t) => html`
+                  <article className="border-3 border-black p-4 brutal-shadow">
+                    <div className="ff-caption text-black/70">${t.key} · occorrenze: ${t.count}</div>
+                    <div className="text-lg font-bold mt-1">${t.name}</div>
+                    <div className="mt-3">
+                      <div className="ff-caption text-black/60">Esempi</div>
+                      <ul className="mt-2 space-y-1">
+                        ${(t.samples || []).slice(0, 6).map((s) => html`
+                          <li>
+                            <a className="underline" href=${s.url} target="_blank" rel="noopener noreferrer">${s.title}</a>
+                            <span className="text-black/60 ff-caption"> ${s.id || ''}</span>
+                          </li>
+                        `)}
+                      </ul>
+                    </div>
+                  </article>
+                `)}
+              </div>`}
+      </div>
+    </div>
+  </div>`;
+};
+
+export default ThemesPopup;

--- a/generated/book/outline.json
+++ b/generated/book/outline.json
@@ -1,0 +1,20 @@
+{
+  "generatedAt": "2026-01-27",
+  "title": "Futuro Fortissimo — 14 capitoli (outline)",
+  "chapters": [
+    {"n":1,"title":"La nuova unità di misura: l’AI come metrica del valore","thesis":"L’AI non è solo una tecnologia: è una nuova unità di misura che ridisegna valore, produttività e potere.","refs":["ff.139.1","ff.139.2","ff.135.1","ff.123.1","ff.102.3"]},
+    {"n":2,"title":"Il conto dell’intelligenza: costi, energia, compute, infrastrutture","thesis":"Ogni salto cognitivo artificiale è anche un salto infrastrutturale: paghiamo l’intelligenza in energia, supply chain e vincoli fisici.","refs":["ff.135.1","ff.135.2","ff.139.1","ff.126.1","ff.125.2"]},
+    {"n":3,"title":"Siamo già nella singolarità? (o nella sua versione gentile)","thesis":"La singolarità come cambio di regime: feedback economici/cognitivi che alterano aspettative e istituzioni.","refs":["ff.135.3","ff.129.1","ff.139.2","ff.124.4","ff.117.4"]},
+    {"n":4,"title":"Il coltellino svizzero cognitivo: dal tool all’agente","thesis":"L’AI utile non è quella che sa, ma quella che fa: integra strumenti, contesto e obiettivi e riscrive i workflow.","refs":["ff.123.1","ff.123.2","ff.123.3","ff.123.4","ff.124.3","ff.124.4","ff.119.3"]},
+    {"n":5,"title":"Creatività post-umana: arte, stile, autenticità nell’era dei modelli","thesis":"La creatività si sposta dal fare al dirigere: conta intenzione, gusto e firma in un mondo dove lo stile è commodity.","refs":["ff.106.1","ff.106.2","ff.119.4","ff.123.4","ff.130.2","ff.124.1","ff.124.2"]},
+    {"n":6,"title":"Simulare il mondo: modelli, videogiochi e verità operativa","thesis":"La simulazione è un modo di conoscere: quando il modello diventa più pratico del reale, cambia la nostra idea di verità.","refs":["ff.117.3","ff.117.4","ff.98.1","ff.98.4","ff.132.2","ff.132.3","ff.132.4"]},
+    {"n":7,"title":"Attenzione: la crisi non è (solo) distrazione, è governance interiore","thesis":"Difendere l’attenzione significa progettare ambienti e tecnologie che non colonizzino la mente: è una questione di libertà.","refs":["ff.132.1","ff.109.2","ff.121.1","ff.121.2","ff.134.1"]},
+    {"n":8,"title":"Flow e vita ben vissuta: performance, felicità, significato","thesis":"Il benessere è una tecnologia della vita: flow, esperienze e investimenti personali formano un portafoglio esistenziale.","refs":["ff.121.1","ff.121.2","ff.111.4","ff.108.1","ff.108.3","ff.137.4"]},
+    {"n":9,"title":"Solitudine, contatto, stress: il corpo sociale come infrastruttura","thesis":"La crisi contemporanea è anche di contatto: salute mentale e relazione sono un problema di design sociale.","refs":["ff.97.1","ff.97.2","ff.97.3","ff.97.4","ff.119.2"]},
+    {"n":10,"title":"Mangiare il futuro: dieta, microbioma, longevità (senza culto)","thesis":"La via d’uscita dal caos nutrizionale è unire scienza, contesto personale e umiltà epistemica.","refs":["ff.92.2","ff.92.3","ff.92.4","ff.94.2","ff.99.1","ff.113.2","ff.113.4","ff.104.4"]},
+    {"n":11,"title":"Corpo, performance e rischio: allenarsi contro la mortalità (davvero?)","thesis":"Salute e performance sono scelte di rischio: robustezza > ottimizzazione fragile.","refs":["ff.120.1","ff.120.2","ff.120.3","ff.120.4","ff.120.5","ff.112.3"]},
+    {"n":12,"title":"Plastica e modernità: il costo invisibile del comfort","thesis":"Le microplastiche rendono i costi esterni improvvisamente interni: corpo, arterie, ecosistemi.","refs":["ff.130.1","ff.130.2","ff.130.3","ff.130.4","ff.130.5"]},
+    {"n":13,"title":"Imperi, dollaro, Internet: geopolitica nell’era delle reti","thesis":"La geopolitica torna imperiale, ma con reti digitali e standard tecnologici al centro.","refs":["ff.125.1","ff.125.2","ff.125.3","ff.125.4","ff.135.5","ff.102.2"]},
+    {"n":14,"title":"Sovranità digitale, proprietà e crypto: uscire (o entrare) nello Stato","thesis":"Crypto non sono soldi magici: sono strumenti per ripensare proprietà, fiducia e istituzioni, con costi politici.","refs":["ff.95.1","ff.95.3","ff.95.5","ff.110.3","ff.135.4"]}
+  ]
+}


### PR DESCRIPTION
## What\n- Replace Temi/Connessioni header links with in-app **modals** styled like main UI.\n- Add **📖 Libro** modal with 14-chapter outline (generated/book/outline.json).\n\n## Why\n- Matches main design; keeps users inside the app and improves engagement.\n\n## Checks\n- npm run build (ok)\n\nNext\n- When you provide GA4 Measurement ID, I’ll add GA4 + event taxonomy and schedule weekly Sunday report.