### PR TITLE
SEO + tracking hooks + /book pages (post-merge follow-up)

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -1,31 +1,85 @@
-// Lightweight analytics + interaction tracking.
-// Note: this file is loaded as type=module (see index.html).
-// This file is safe even if no analytics provider is configured.
+// Provider-agnostic analytics + interaction tracking.
+// Safe to include even with no analytics provider configured.
 //
-// To enable Plausible:
-// 1) Create a Plausible site for your domain.
-// 2) Add to each page head (or here via HTML):
-//    <script defer data-domain="YOUR_DOMAIN" src="https://plausible.io/js/script.js"></script>
+// Supported providers (auto-detected if present):
+// - Plausible (window.plausible)
+// - Google Analytics / gtag (window.gtag)
+// - dataLayer push (window.dataLayer)
+// - Custom adapter (window.ffAnalyticsAdapter)
 //
-// Events tracked (if provider exists):
+// Events tracked by default (via click delegation):
 // - nav_click
 // - outbound_click
-// - topic_open
-// - connection_open
+//
+// Pages can add explicit tracking attributes:
+// - data-track="event_name" (any clickable element)
 
 (function () {
   function safe(fn) {
-    try { fn(); } catch (_) {}
+    try {
+      fn();
+    } catch (_) {
+      // no-op
+    }
   }
 
-  // unified tracker
-  window.ffTrack = function (event, props) {
+  function asPlainObject(props) {
+    if (!props || typeof props !== 'object') return {};
+    const out = {};
+    for (const [k, v] of Object.entries(props)) {
+      if (v === undefined) continue;
+      out[k] = typeof v === 'string' ? v : v;
+    }
+    return out;
+  }
+
+  function trackPlausible(event, props) {
+    if (typeof window.plausible !== 'function') return;
+    window.plausible(event, { props: props || {} });
+  }
+
+  function trackGtag(event, props) {
+    if (typeof window.gtag !== 'function') return;
+    // GA4 custom events: https://developers.google.com/analytics/devguides/collection/ga4/events
+    window.gtag('event', event, props || {});
+  }
+
+  function trackDataLayer(event, props) {
+    if (!window.dataLayer || !Array.isArray(window.dataLayer)) return;
+    window.dataLayer.push({ event, ...(props || {}) });
+  }
+
+  function trackCustomAdapter(event, props) {
+    if (typeof window.ffAnalyticsAdapter !== 'function') return;
+    window.ffAnalyticsAdapter({ type: 'event', event, props: props || {} });
+  }
+
+  // Unified tracker.
+  window.ffTrack = function ffTrack(event, props) {
+    const cleanProps = asPlainObject(props);
+    safe(() => trackPlausible(event, cleanProps));
+    safe(() => trackGtag(event, cleanProps));
+    safe(() => trackDataLayer(event, cleanProps));
+    safe(() => trackCustomAdapter(event, cleanProps));
+  };
+
+  // Page view helper (call from any page).
+  window.ffTrackPage = function ffTrackPage(extraProps) {
+    const props = asPlainObject(extraProps);
+    props.path = props.path || location.pathname;
+    props.title = props.title || document.title;
+
+    // Plausible has a dedicated pageview API; but custom event keeps it provider-agnostic.
+    window.ffTrack('page_view', props);
+
+    // Plausible: also trigger native pageview when available.
     safe(() => {
       if (typeof window.plausible === 'function') {
-        window.plausible(event, { props: props || {} });
+        window.plausible('pageview');
       }
-      // Add other providers here if needed.
     });
+
+    // GA4: page_view is automatically collected when configured; keeping custom call as backup.
   };
 
   function isOutbound(a) {
@@ -38,19 +92,49 @@
     }
   }
 
-  document.addEventListener('click', (e) => {
-    const a = e.target && (e.target.closest ? e.target.closest('a') : null);
-    if (!a) return;
+  // Click delegation: supports <a> and any element with data-track.
+  document.addEventListener(
+    'click',
+    (e) => {
+      const target = e.target;
+      if (!target || !target.closest) return;
 
-    const label = (a.getAttribute('data-track') || a.textContent || '').trim().slice(0, 80);
+      const explicit = target.closest('[data-track]');
+      if (explicit) {
+        const event = (explicit.getAttribute('data-track') || '').trim();
+        if (event) {
+          const label = (explicit.getAttribute('data-label') || explicit.textContent || '')
+            .trim()
+            .slice(0, 120);
+          const href = explicit.getAttribute('href') || undefined;
+          window.ffTrack(event, { label, href });
+          return;
+        }
+      }
 
-    if (a.getAttribute('data-nav') === '1') {
-      window.ffTrack('nav_click', { label, href: a.getAttribute('href') });
+      const a = target.closest('a');
+      if (!a) return;
+
+      const label = (a.textContent || '').trim().slice(0, 120);
+
+      if (a.getAttribute('data-nav') === '1') {
+        window.ffTrack('nav_click', { label, href: a.getAttribute('href') });
+        return;
+      }
+
+      if (isOutbound(a)) {
+        window.ffTrack('outbound_click', { label, href: a.href });
+      }
+    },
+    { capture: true }
+  );
+
+  // Fire one page view on initial load.
+  safe(() => {
+    if (document.readyState === 'complete' || document.readyState === 'interactive') {
+      window.ffTrackPage();
       return;
     }
-
-    if (isOutbound(a)) {
-      window.ffTrack('outbound_click', { label, href: a.href });
-    }
-  }, { capture: true });
+    window.addEventListener('DOMContentLoaded', () => window.ffTrackPage(), { once: true });
+  });
 })();

--- a/book/chapter-01.html
+++ b/book/chapter-01.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="it">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Capitolo 01 — La nuova unità di misura: l’AI come metrica del valore</title>
+  <meta name="description" content="L’AI non è solo una tecnologia: è una nuova unità di misura che ridisegna valore, produttività e potere." />
+
+  <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-01.html" />
+
+  <meta property="og:title" content="Capitolo 01 — La nuova unità di misura: l’AI come metrica del valore" />
+  <meta property="og:description" content="L’AI non è solo una tecnologia: è una nuova unità di misura che ridisegna valore, produttività e potere." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://futurofortissimo.github.io/book/chapter-01.html" />
+  <meta property="og:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Capitolo 01 — La nuova unità di misura: l’AI come metrica del valore" />
+  <meta name="twitter:description" content="L’AI non è solo una tecnologia: è una nuova unità di misura che ridisegna valore, produttività e potere." />
+  <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <link rel="icon" href="/favicon.ico" />
+
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=IBM+Plex+Mono:wght@600;700&display=swap" rel="stylesheet">
+
+  <style>
+    :root{--ink:#0a0a0a;}
+    body{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial; color:var(--ink);}
+    .mono{font-family:"IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; letter-spacing:.06em; text-transform:uppercase;}
+  </style>
+
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Chapter",
+  "name": "La nuova unità di misura: l’AI come metrica del valore",
+  "position": 1,
+  "isPartOf": {
+    "@type": "Book",
+    "name": "Futuro Fortissimo — 14 capitoli (outline)",
+    "url": "https://futurofortissimo.github.io/book/"
+  },
+  "url": "https://futurofortissimo.github.io/book/chapter-01.html",
+  "inLanguage": "it",
+  "description": "L’AI non è solo una tecnologia: è una nuova unità di misura che ridisegna valore, produttività e potere."
+}
+</script>
+</head>
+<body class="bg-zinc-50">
+  <header class="border-b border-zinc-200 bg-white">
+    <div class="max-w-4xl mx-auto px-4 py-5 flex items-center justify-between gap-3">
+      <div>
+        <div class="mono text-xs text-zinc-500">Futuro Fortissimo — book</div>
+        <div class="text-xl font-extrabold tracking-tight">Capitolo 01 — La nuova unità di misura: l’AI come metrica del valore</div>
+      </div>
+      <nav class="flex gap-3 text-sm">
+        <a data-nav="1" class="underline" href="/index.html">Home</a>
+        <a data-nav="1" class="underline" href="/book/">Libro</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="max-w-4xl mx-auto px-4 py-8">
+    
+    <section class="rounded-xl border border-zinc-200 bg-white p-5">
+      <div class="mono text-xs text-zinc-500">Capitolo 01 / 14</div>
+      <h1 class="text-2xl font-extrabold tracking-tight mt-1">La nuova unità di misura: l’AI come metrica del valore</h1>
+      <p class="text-sm text-zinc-700 mt-3">L’AI non è solo una tecnologia: è una nuova unità di misura che ridisegna valore, produttività e potere.</p>
+
+      
+        <div class="mt-5">
+          <div class="mono text-xs text-zinc-500">Riferimenti (placeholder)</div>
+          <ul class="mt-2 grid gap-2 text-sm">
+            <li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.139.1</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.139.2</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.135.1</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.123.1</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.102.3</code></li>
+          </ul>
+          <p class="text-xs text-zinc-500 mt-3">TODO: collegare questi refs ai subcapitoli/URL reali (ff.xx.yy) e generare estratti.</p>
+        </div>
+
+      <div class="mt-6 flex flex-wrap gap-3">
+        
+        <a class="underline" data-track="chapter_index" href="/book/">Indice capitoli</a>
+        <a class="underline" data-track="chapter_next" href="/book/chapter-02.html">Successivo →</a>
+      </div>
+    </section>
+    
+  </main>
+
+  <script src="/analytics.js"></script>
+  <script>
+    // Track page view (provider-agnostic). Implemented in analytics.js
+    if (window.ffTrackPage) window.ffTrackPage();
+  </script>
+</body>
+</html>

--- a/book/chapter-02.html
+++ b/book/chapter-02.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="it">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Capitolo 02 — Il conto dell’intelligenza: costi, energia, compute, infrastrutture</title>
+  <meta name="description" content="Ogni salto cognitivo artificiale è anche un salto infrastrutturale: paghiamo l’intelligenza in energia, supply chain e vincoli fisici." />
+
+  <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-02.html" />
+
+  <meta property="og:title" content="Capitolo 02 — Il conto dell’intelligenza: costi, energia, compute, infrastrutture" />
+  <meta property="og:description" content="Ogni salto cognitivo artificiale è anche un salto infrastrutturale: paghiamo l’intelligenza in energia, supply chain e vincoli fisici." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://futurofortissimo.github.io/book/chapter-02.html" />
+  <meta property="og:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Capitolo 02 — Il conto dell’intelligenza: costi, energia, compute, infrastrutture" />
+  <meta name="twitter:description" content="Ogni salto cognitivo artificiale è anche un salto infrastrutturale: paghiamo l’intelligenza in energia, supply chain e vincoli fisici." />
+  <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <link rel="icon" href="/favicon.ico" />
+
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=IBM+Plex+Mono:wght@600;700&display=swap" rel="stylesheet">
+
+  <style>
+    :root{--ink:#0a0a0a;}
+    body{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial; color:var(--ink);}
+    .mono{font-family:"IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; letter-spacing:.06em; text-transform:uppercase;}
+  </style>
+
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Chapter",
+  "name": "Il conto dell’intelligenza: costi, energia, compute, infrastrutture",
+  "position": 2,
+  "isPartOf": {
+    "@type": "Book",
+    "name": "Futuro Fortissimo — 14 capitoli (outline)",
+    "url": "https://futurofortissimo.github.io/book/"
+  },
+  "url": "https://futurofortissimo.github.io/book/chapter-02.html",
+  "inLanguage": "it",
+  "description": "Ogni salto cognitivo artificiale è anche un salto infrastrutturale: paghiamo l’intelligenza in energia, supply chain e vincoli fisici."
+}
+</script>
+</head>
+<body class="bg-zinc-50">
+  <header class="border-b border-zinc-200 bg-white">
+    <div class="max-w-4xl mx-auto px-4 py-5 flex items-center justify-between gap-3">
+      <div>
+        <div class="mono text-xs text-zinc-500">Futuro Fortissimo — book</div>
+        <div class="text-xl font-extrabold tracking-tight">Capitolo 02 — Il conto dell’intelligenza: costi, energia, compute, infrastrutture</div>
+      </div>
+      <nav class="flex gap-3 text-sm">
+        <a data-nav="1" class="underline" href="/index.html">Home</a>
+        <a data-nav="1" class="underline" href="/book/">Libro</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="max-w-4xl mx-auto px-4 py-8">
+    
+    <section class="rounded-xl border border-zinc-200 bg-white p-5">
+      <div class="mono text-xs text-zinc-500">Capitolo 02 / 14</div>
+      <h1 class="text-2xl font-extrabold tracking-tight mt-1">Il conto dell’intelligenza: costi, energia, compute, infrastrutture</h1>
+      <p class="text-sm text-zinc-700 mt-3">Ogni salto cognitivo artificiale è anche un salto infrastrutturale: paghiamo l’intelligenza in energia, supply chain e vincoli fisici.</p>
+
+      
+        <div class="mt-5">
+          <div class="mono text-xs text-zinc-500">Riferimenti (placeholder)</div>
+          <ul class="mt-2 grid gap-2 text-sm">
+            <li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.135.1</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.135.2</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.139.1</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.126.1</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.125.2</code></li>
+          </ul>
+          <p class="text-xs text-zinc-500 mt-3">TODO: collegare questi refs ai subcapitoli/URL reali (ff.xx.yy) e generare estratti.</p>
+        </div>
+
+      <div class="mt-6 flex flex-wrap gap-3">
+        <a class="underline" data-track="chapter_prev" href="/book/chapter-01.html">← Precedente</a>
+        <a class="underline" data-track="chapter_index" href="/book/">Indice capitoli</a>
+        <a class="underline" data-track="chapter_next" href="/book/chapter-03.html">Successivo →</a>
+      </div>
+    </section>
+    
+  </main>
+
+  <script src="/analytics.js"></script>
+  <script>
+    // Track page view (provider-agnostic). Implemented in analytics.js
+    if (window.ffTrackPage) window.ffTrackPage();
+  </script>
+</body>
+</html>

--- a/book/chapter-03.html
+++ b/book/chapter-03.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="it">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Capitolo 03 — Siamo già nella singolarità? (o nella sua versione gentile)</title>
+  <meta name="description" content="La singolarità come cambio di regime: feedback economici/cognitivi che alterano aspettative e istituzioni." />
+
+  <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-03.html" />
+
+  <meta property="og:title" content="Capitolo 03 — Siamo già nella singolarità? (o nella sua versione gentile)" />
+  <meta property="og:description" content="La singolarità come cambio di regime: feedback economici/cognitivi che alterano aspettative e istituzioni." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://futurofortissimo.github.io/book/chapter-03.html" />
+  <meta property="og:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Capitolo 03 — Siamo già nella singolarità? (o nella sua versione gentile)" />
+  <meta name="twitter:description" content="La singolarità come cambio di regime: feedback economici/cognitivi che alterano aspettative e istituzioni." />
+  <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <link rel="icon" href="/favicon.ico" />
+
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=IBM+Plex+Mono:wght@600;700&display=swap" rel="stylesheet">
+
+  <style>
+    :root{--ink:#0a0a0a;}
+    body{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial; color:var(--ink);}
+    .mono{font-family:"IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; letter-spacing:.06em; text-transform:uppercase;}
+  </style>
+
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Chapter",
+  "name": "Siamo già nella singolarità? (o nella sua versione gentile)",
+  "position": 3,
+  "isPartOf": {
+    "@type": "Book",
+    "name": "Futuro Fortissimo — 14 capitoli (outline)",
+    "url": "https://futurofortissimo.github.io/book/"
+  },
+  "url": "https://futurofortissimo.github.io/book/chapter-03.html",
+  "inLanguage": "it",
+  "description": "La singolarità come cambio di regime: feedback economici/cognitivi che alterano aspettative e istituzioni."
+}
+</script>
+</head>
+<body class="bg-zinc-50">
+  <header class="border-b border-zinc-200 bg-white">
+    <div class="max-w-4xl mx-auto px-4 py-5 flex items-center justify-between gap-3">
+      <div>
+        <div class="mono text-xs text-zinc-500">Futuro Fortissimo — book</div>
+        <div class="text-xl font-extrabold tracking-tight">Capitolo 03 — Siamo già nella singolarità? (o nella sua versione gentile)</div>
+      </div>
+      <nav class="flex gap-3 text-sm">
+        <a data-nav="1" class="underline" href="/index.html">Home</a>
+        <a data-nav="1" class="underline" href="/book/">Libro</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="max-w-4xl mx-auto px-4 py-8">
+    
+    <section class="rounded-xl border border-zinc-200 bg-white p-5">
+      <div class="mono text-xs text-zinc-500">Capitolo 03 / 14</div>
+      <h1 class="text-2xl font-extrabold tracking-tight mt-1">Siamo già nella singolarità? (o nella sua versione gentile)</h1>
+      <p class="text-sm text-zinc-700 mt-3">La singolarità come cambio di regime: feedback economici/cognitivi che alterano aspettative e istituzioni.</p>
+
+      
+        <div class="mt-5">
+          <div class="mono text-xs text-zinc-500">Riferimenti (placeholder)</div>
+          <ul class="mt-2 grid gap-2 text-sm">
+            <li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.135.3</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.129.1</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.139.2</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.124.4</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.117.4</code></li>
+          </ul>
+          <p class="text-xs text-zinc-500 mt-3">TODO: collegare questi refs ai subcapitoli/URL reali (ff.xx.yy) e generare estratti.</p>
+        </div>
+
+      <div class="mt-6 flex flex-wrap gap-3">
+        <a class="underline" data-track="chapter_prev" href="/book/chapter-02.html">← Precedente</a>
+        <a class="underline" data-track="chapter_index" href="/book/">Indice capitoli</a>
+        <a class="underline" data-track="chapter_next" href="/book/chapter-04.html">Successivo →</a>
+      </div>
+    </section>
+    
+  </main>
+
+  <script src="/analytics.js"></script>
+  <script>
+    // Track page view (provider-agnostic). Implemented in analytics.js
+    if (window.ffTrackPage) window.ffTrackPage();
+  </script>
+</body>
+</html>

--- a/book/chapter-04.html
+++ b/book/chapter-04.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="it">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Capitolo 04 — Il coltellino svizzero cognitivo: dal tool all’agente</title>
+  <meta name="description" content="L’AI utile non è quella che sa, ma quella che fa: integra strumenti, contesto e obiettivi e riscrive i workflow." />
+
+  <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-04.html" />
+
+  <meta property="og:title" content="Capitolo 04 — Il coltellino svizzero cognitivo: dal tool all’agente" />
+  <meta property="og:description" content="L’AI utile non è quella che sa, ma quella che fa: integra strumenti, contesto e obiettivi e riscrive i workflow." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://futurofortissimo.github.io/book/chapter-04.html" />
+  <meta property="og:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Capitolo 04 — Il coltellino svizzero cognitivo: dal tool all’agente" />
+  <meta name="twitter:description" content="L’AI utile non è quella che sa, ma quella che fa: integra strumenti, contesto e obiettivi e riscrive i workflow." />
+  <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <link rel="icon" href="/favicon.ico" />
+
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=IBM+Plex+Mono:wght@600;700&display=swap" rel="stylesheet">
+
+  <style>
+    :root{--ink:#0a0a0a;}
+    body{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial; color:var(--ink);}
+    .mono{font-family:"IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; letter-spacing:.06em; text-transform:uppercase;}
+  </style>
+
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Chapter",
+  "name": "Il coltellino svizzero cognitivo: dal tool all’agente",
+  "position": 4,
+  "isPartOf": {
+    "@type": "Book",
+    "name": "Futuro Fortissimo — 14 capitoli (outline)",
+    "url": "https://futurofortissimo.github.io/book/"
+  },
+  "url": "https://futurofortissimo.github.io/book/chapter-04.html",
+  "inLanguage": "it",
+  "description": "L’AI utile non è quella che sa, ma quella che fa: integra strumenti, contesto e obiettivi e riscrive i workflow."
+}
+</script>
+</head>
+<body class="bg-zinc-50">
+  <header class="border-b border-zinc-200 bg-white">
+    <div class="max-w-4xl mx-auto px-4 py-5 flex items-center justify-between gap-3">
+      <div>
+        <div class="mono text-xs text-zinc-500">Futuro Fortissimo — book</div>
+        <div class="text-xl font-extrabold tracking-tight">Capitolo 04 — Il coltellino svizzero cognitivo: dal tool all’agente</div>
+      </div>
+      <nav class="flex gap-3 text-sm">
+        <a data-nav="1" class="underline" href="/index.html">Home</a>
+        <a data-nav="1" class="underline" href="/book/">Libro</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="max-w-4xl mx-auto px-4 py-8">
+    
+    <section class="rounded-xl border border-zinc-200 bg-white p-5">
+      <div class="mono text-xs text-zinc-500">Capitolo 04 / 14</div>
+      <h1 class="text-2xl font-extrabold tracking-tight mt-1">Il coltellino svizzero cognitivo: dal tool all’agente</h1>
+      <p class="text-sm text-zinc-700 mt-3">L’AI utile non è quella che sa, ma quella che fa: integra strumenti, contesto e obiettivi e riscrive i workflow.</p>
+
+      
+        <div class="mt-5">
+          <div class="mono text-xs text-zinc-500">Riferimenti (placeholder)</div>
+          <ul class="mt-2 grid gap-2 text-sm">
+            <li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.123.1</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.123.2</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.123.3</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.123.4</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.124.3</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.124.4</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.119.3</code></li>
+          </ul>
+          <p class="text-xs text-zinc-500 mt-3">TODO: collegare questi refs ai subcapitoli/URL reali (ff.xx.yy) e generare estratti.</p>
+        </div>
+
+      <div class="mt-6 flex flex-wrap gap-3">
+        <a class="underline" data-track="chapter_prev" href="/book/chapter-03.html">← Precedente</a>
+        <a class="underline" data-track="chapter_index" href="/book/">Indice capitoli</a>
+        <a class="underline" data-track="chapter_next" href="/book/chapter-05.html">Successivo →</a>
+      </div>
+    </section>
+    
+  </main>
+
+  <script src="/analytics.js"></script>
+  <script>
+    // Track page view (provider-agnostic). Implemented in analytics.js
+    if (window.ffTrackPage) window.ffTrackPage();
+  </script>
+</body>
+</html>

--- a/book/chapter-05.html
+++ b/book/chapter-05.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="it">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Capitolo 05 — Creatività post-umana: arte, stile, autenticità nell’era dei modelli</title>
+  <meta name="description" content="La creatività si sposta dal fare al dirigere: conta intenzione, gusto e firma in un mondo dove lo stile è commodity." />
+
+  <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-05.html" />
+
+  <meta property="og:title" content="Capitolo 05 — Creatività post-umana: arte, stile, autenticità nell’era dei modelli" />
+  <meta property="og:description" content="La creatività si sposta dal fare al dirigere: conta intenzione, gusto e firma in un mondo dove lo stile è commodity." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://futurofortissimo.github.io/book/chapter-05.html" />
+  <meta property="og:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Capitolo 05 — Creatività post-umana: arte, stile, autenticità nell’era dei modelli" />
+  <meta name="twitter:description" content="La creatività si sposta dal fare al dirigere: conta intenzione, gusto e firma in un mondo dove lo stile è commodity." />
+  <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <link rel="icon" href="/favicon.ico" />
+
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=IBM+Plex+Mono:wght@600;700&display=swap" rel="stylesheet">
+
+  <style>
+    :root{--ink:#0a0a0a;}
+    body{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial; color:var(--ink);}
+    .mono{font-family:"IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; letter-spacing:.06em; text-transform:uppercase;}
+  </style>
+
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Chapter",
+  "name": "Creatività post-umana: arte, stile, autenticità nell’era dei modelli",
+  "position": 5,
+  "isPartOf": {
+    "@type": "Book",
+    "name": "Futuro Fortissimo — 14 capitoli (outline)",
+    "url": "https://futurofortissimo.github.io/book/"
+  },
+  "url": "https://futurofortissimo.github.io/book/chapter-05.html",
+  "inLanguage": "it",
+  "description": "La creatività si sposta dal fare al dirigere: conta intenzione, gusto e firma in un mondo dove lo stile è commodity."
+}
+</script>
+</head>
+<body class="bg-zinc-50">
+  <header class="border-b border-zinc-200 bg-white">
+    <div class="max-w-4xl mx-auto px-4 py-5 flex items-center justify-between gap-3">
+      <div>
+        <div class="mono text-xs text-zinc-500">Futuro Fortissimo — book</div>
+        <div class="text-xl font-extrabold tracking-tight">Capitolo 05 — Creatività post-umana: arte, stile, autenticità nell’era dei modelli</div>
+      </div>
+      <nav class="flex gap-3 text-sm">
+        <a data-nav="1" class="underline" href="/index.html">Home</a>
+        <a data-nav="1" class="underline" href="/book/">Libro</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="max-w-4xl mx-auto px-4 py-8">
+    
+    <section class="rounded-xl border border-zinc-200 bg-white p-5">
+      <div class="mono text-xs text-zinc-500">Capitolo 05 / 14</div>
+      <h1 class="text-2xl font-extrabold tracking-tight mt-1">Creatività post-umana: arte, stile, autenticità nell’era dei modelli</h1>
+      <p class="text-sm text-zinc-700 mt-3">La creatività si sposta dal fare al dirigere: conta intenzione, gusto e firma in un mondo dove lo stile è commodity.</p>
+
+      
+        <div class="mt-5">
+          <div class="mono text-xs text-zinc-500">Riferimenti (placeholder)</div>
+          <ul class="mt-2 grid gap-2 text-sm">
+            <li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.106.1</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.106.2</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.119.4</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.123.4</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.130.2</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.124.1</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.124.2</code></li>
+          </ul>
+          <p class="text-xs text-zinc-500 mt-3">TODO: collegare questi refs ai subcapitoli/URL reali (ff.xx.yy) e generare estratti.</p>
+        </div>
+
+      <div class="mt-6 flex flex-wrap gap-3">
+        <a class="underline" data-track="chapter_prev" href="/book/chapter-04.html">← Precedente</a>
+        <a class="underline" data-track="chapter_index" href="/book/">Indice capitoli</a>
+        <a class="underline" data-track="chapter_next" href="/book/chapter-06.html">Successivo →</a>
+      </div>
+    </section>
+    
+  </main>
+
+  <script src="/analytics.js"></script>
+  <script>
+    // Track page view (provider-agnostic). Implemented in analytics.js
+    if (window.ffTrackPage) window.ffTrackPage();
+  </script>
+</body>
+</html>

--- a/book/chapter-06.html
+++ b/book/chapter-06.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="it">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Capitolo 06 — Simulare il mondo: modelli, videogiochi e verità operativa</title>
+  <meta name="description" content="La simulazione è un modo di conoscere: quando il modello diventa più pratico del reale, cambia la nostra idea di verità." />
+
+  <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-06.html" />
+
+  <meta property="og:title" content="Capitolo 06 — Simulare il mondo: modelli, videogiochi e verità operativa" />
+  <meta property="og:description" content="La simulazione è un modo di conoscere: quando il modello diventa più pratico del reale, cambia la nostra idea di verità." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://futurofortissimo.github.io/book/chapter-06.html" />
+  <meta property="og:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Capitolo 06 — Simulare il mondo: modelli, videogiochi e verità operativa" />
+  <meta name="twitter:description" content="La simulazione è un modo di conoscere: quando il modello diventa più pratico del reale, cambia la nostra idea di verità." />
+  <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <link rel="icon" href="/favicon.ico" />
+
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=IBM+Plex+Mono:wght@600;700&display=swap" rel="stylesheet">
+
+  <style>
+    :root{--ink:#0a0a0a;}
+    body{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial; color:var(--ink);}
+    .mono{font-family:"IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; letter-spacing:.06em; text-transform:uppercase;}
+  </style>
+
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Chapter",
+  "name": "Simulare il mondo: modelli, videogiochi e verità operativa",
+  "position": 6,
+  "isPartOf": {
+    "@type": "Book",
+    "name": "Futuro Fortissimo — 14 capitoli (outline)",
+    "url": "https://futurofortissimo.github.io/book/"
+  },
+  "url": "https://futurofortissimo.github.io/book/chapter-06.html",
+  "inLanguage": "it",
+  "description": "La simulazione è un modo di conoscere: quando il modello diventa più pratico del reale, cambia la nostra idea di verità."
+}
+</script>
+</head>
+<body class="bg-zinc-50">
+  <header class="border-b border-zinc-200 bg-white">
+    <div class="max-w-4xl mx-auto px-4 py-5 flex items-center justify-between gap-3">
+      <div>
+        <div class="mono text-xs text-zinc-500">Futuro Fortissimo — book</div>
+        <div class="text-xl font-extrabold tracking-tight">Capitolo 06 — Simulare il mondo: modelli, videogiochi e verità operativa</div>
+      </div>
+      <nav class="flex gap-3 text-sm">
+        <a data-nav="1" class="underline" href="/index.html">Home</a>
+        <a data-nav="1" class="underline" href="/book/">Libro</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="max-w-4xl mx-auto px-4 py-8">
+    
+    <section class="rounded-xl border border-zinc-200 bg-white p-5">
+      <div class="mono text-xs text-zinc-500">Capitolo 06 / 14</div>
+      <h1 class="text-2xl font-extrabold tracking-tight mt-1">Simulare il mondo: modelli, videogiochi e verità operativa</h1>
+      <p class="text-sm text-zinc-700 mt-3">La simulazione è un modo di conoscere: quando il modello diventa più pratico del reale, cambia la nostra idea di verità.</p>
+
+      
+        <div class="mt-5">
+          <div class="mono text-xs text-zinc-500">Riferimenti (placeholder)</div>
+          <ul class="mt-2 grid gap-2 text-sm">
+            <li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.117.3</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.117.4</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.98.1</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.98.4</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.132.2</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.132.3</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.132.4</code></li>
+          </ul>
+          <p class="text-xs text-zinc-500 mt-3">TODO: collegare questi refs ai subcapitoli/URL reali (ff.xx.yy) e generare estratti.</p>
+        </div>
+
+      <div class="mt-6 flex flex-wrap gap-3">
+        <a class="underline" data-track="chapter_prev" href="/book/chapter-05.html">← Precedente</a>
+        <a class="underline" data-track="chapter_index" href="/book/">Indice capitoli</a>
+        <a class="underline" data-track="chapter_next" href="/book/chapter-07.html">Successivo →</a>
+      </div>
+    </section>
+    
+  </main>
+
+  <script src="/analytics.js"></script>
+  <script>
+    // Track page view (provider-agnostic). Implemented in analytics.js
+    if (window.ffTrackPage) window.ffTrackPage();
+  </script>
+</body>
+</html>

--- a/book/chapter-07.html
+++ b/book/chapter-07.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="it">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Capitolo 07 — Attenzione: la crisi non è (solo) distrazione, è governance interiore</title>
+  <meta name="description" content="Difendere l’attenzione significa progettare ambienti e tecnologie che non colonizzino la mente: è una questione di libertà." />
+
+  <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-07.html" />
+
+  <meta property="og:title" content="Capitolo 07 — Attenzione: la crisi non è (solo) distrazione, è governance interiore" />
+  <meta property="og:description" content="Difendere l’attenzione significa progettare ambienti e tecnologie che non colonizzino la mente: è una questione di libertà." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://futurofortissimo.github.io/book/chapter-07.html" />
+  <meta property="og:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Capitolo 07 — Attenzione: la crisi non è (solo) distrazione, è governance interiore" />
+  <meta name="twitter:description" content="Difendere l’attenzione significa progettare ambienti e tecnologie che non colonizzino la mente: è una questione di libertà." />
+  <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <link rel="icon" href="/favicon.ico" />
+
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=IBM+Plex+Mono:wght@600;700&display=swap" rel="stylesheet">
+
+  <style>
+    :root{--ink:#0a0a0a;}
+    body{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial; color:var(--ink);}
+    .mono{font-family:"IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; letter-spacing:.06em; text-transform:uppercase;}
+  </style>
+
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Chapter",
+  "name": "Attenzione: la crisi non è (solo) distrazione, è governance interiore",
+  "position": 7,
+  "isPartOf": {
+    "@type": "Book",
+    "name": "Futuro Fortissimo — 14 capitoli (outline)",
+    "url": "https://futurofortissimo.github.io/book/"
+  },
+  "url": "https://futurofortissimo.github.io/book/chapter-07.html",
+  "inLanguage": "it",
+  "description": "Difendere l’attenzione significa progettare ambienti e tecnologie che non colonizzino la mente: è una questione di libertà."
+}
+</script>
+</head>
+<body class="bg-zinc-50">
+  <header class="border-b border-zinc-200 bg-white">
+    <div class="max-w-4xl mx-auto px-4 py-5 flex items-center justify-between gap-3">
+      <div>
+        <div class="mono text-xs text-zinc-500">Futuro Fortissimo — book</div>
+        <div class="text-xl font-extrabold tracking-tight">Capitolo 07 — Attenzione: la crisi non è (solo) distrazione, è governance interiore</div>
+      </div>
+      <nav class="flex gap-3 text-sm">
+        <a data-nav="1" class="underline" href="/index.html">Home</a>
+        <a data-nav="1" class="underline" href="/book/">Libro</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="max-w-4xl mx-auto px-4 py-8">
+    
+    <section class="rounded-xl border border-zinc-200 bg-white p-5">
+      <div class="mono text-xs text-zinc-500">Capitolo 07 / 14</div>
+      <h1 class="text-2xl font-extrabold tracking-tight mt-1">Attenzione: la crisi non è (solo) distrazione, è governance interiore</h1>
+      <p class="text-sm text-zinc-700 mt-3">Difendere l’attenzione significa progettare ambienti e tecnologie che non colonizzino la mente: è una questione di libertà.</p>
+
+      
+        <div class="mt-5">
+          <div class="mono text-xs text-zinc-500">Riferimenti (placeholder)</div>
+          <ul class="mt-2 grid gap-2 text-sm">
+            <li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.132.1</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.109.2</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.121.1</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.121.2</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.134.1</code></li>
+          </ul>
+          <p class="text-xs text-zinc-500 mt-3">TODO: collegare questi refs ai subcapitoli/URL reali (ff.xx.yy) e generare estratti.</p>
+        </div>
+
+      <div class="mt-6 flex flex-wrap gap-3">
+        <a class="underline" data-track="chapter_prev" href="/book/chapter-06.html">← Precedente</a>
+        <a class="underline" data-track="chapter_index" href="/book/">Indice capitoli</a>
+        <a class="underline" data-track="chapter_next" href="/book/chapter-08.html">Successivo →</a>
+      </div>
+    </section>
+    
+  </main>
+
+  <script src="/analytics.js"></script>
+  <script>
+    // Track page view (provider-agnostic). Implemented in analytics.js
+    if (window.ffTrackPage) window.ffTrackPage();
+  </script>
+</body>
+</html>

--- a/book/chapter-08.html
+++ b/book/chapter-08.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="it">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Capitolo 08 — Flow e vita ben vissuta: performance, felicità, significato</title>
+  <meta name="description" content="Il benessere è una tecnologia della vita: flow, esperienze e investimenti personali formano un portafoglio esistenziale." />
+
+  <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-08.html" />
+
+  <meta property="og:title" content="Capitolo 08 — Flow e vita ben vissuta: performance, felicità, significato" />
+  <meta property="og:description" content="Il benessere è una tecnologia della vita: flow, esperienze e investimenti personali formano un portafoglio esistenziale." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://futurofortissimo.github.io/book/chapter-08.html" />
+  <meta property="og:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Capitolo 08 — Flow e vita ben vissuta: performance, felicità, significato" />
+  <meta name="twitter:description" content="Il benessere è una tecnologia della vita: flow, esperienze e investimenti personali formano un portafoglio esistenziale." />
+  <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <link rel="icon" href="/favicon.ico" />
+
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=IBM+Plex+Mono:wght@600;700&display=swap" rel="stylesheet">
+
+  <style>
+    :root{--ink:#0a0a0a;}
+    body{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial; color:var(--ink);}
+    .mono{font-family:"IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; letter-spacing:.06em; text-transform:uppercase;}
+  </style>
+
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Chapter",
+  "name": "Flow e vita ben vissuta: performance, felicità, significato",
+  "position": 8,
+  "isPartOf": {
+    "@type": "Book",
+    "name": "Futuro Fortissimo — 14 capitoli (outline)",
+    "url": "https://futurofortissimo.github.io/book/"
+  },
+  "url": "https://futurofortissimo.github.io/book/chapter-08.html",
+  "inLanguage": "it",
+  "description": "Il benessere è una tecnologia della vita: flow, esperienze e investimenti personali formano un portafoglio esistenziale."
+}
+</script>
+</head>
+<body class="bg-zinc-50">
+  <header class="border-b border-zinc-200 bg-white">
+    <div class="max-w-4xl mx-auto px-4 py-5 flex items-center justify-between gap-3">
+      <div>
+        <div class="mono text-xs text-zinc-500">Futuro Fortissimo — book</div>
+        <div class="text-xl font-extrabold tracking-tight">Capitolo 08 — Flow e vita ben vissuta: performance, felicità, significato</div>
+      </div>
+      <nav class="flex gap-3 text-sm">
+        <a data-nav="1" class="underline" href="/index.html">Home</a>
+        <a data-nav="1" class="underline" href="/book/">Libro</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="max-w-4xl mx-auto px-4 py-8">
+    
+    <section class="rounded-xl border border-zinc-200 bg-white p-5">
+      <div class="mono text-xs text-zinc-500">Capitolo 08 / 14</div>
+      <h1 class="text-2xl font-extrabold tracking-tight mt-1">Flow e vita ben vissuta: performance, felicità, significato</h1>
+      <p class="text-sm text-zinc-700 mt-3">Il benessere è una tecnologia della vita: flow, esperienze e investimenti personali formano un portafoglio esistenziale.</p>
+
+      
+        <div class="mt-5">
+          <div class="mono text-xs text-zinc-500">Riferimenti (placeholder)</div>
+          <ul class="mt-2 grid gap-2 text-sm">
+            <li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.121.1</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.121.2</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.111.4</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.108.1</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.108.3</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.137.4</code></li>
+          </ul>
+          <p class="text-xs text-zinc-500 mt-3">TODO: collegare questi refs ai subcapitoli/URL reali (ff.xx.yy) e generare estratti.</p>
+        </div>
+
+      <div class="mt-6 flex flex-wrap gap-3">
+        <a class="underline" data-track="chapter_prev" href="/book/chapter-07.html">← Precedente</a>
+        <a class="underline" data-track="chapter_index" href="/book/">Indice capitoli</a>
+        <a class="underline" data-track="chapter_next" href="/book/chapter-09.html">Successivo →</a>
+      </div>
+    </section>
+    
+  </main>
+
+  <script src="/analytics.js"></script>
+  <script>
+    // Track page view (provider-agnostic). Implemented in analytics.js
+    if (window.ffTrackPage) window.ffTrackPage();
+  </script>
+</body>
+</html>

--- a/book/chapter-09.html
+++ b/book/chapter-09.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="it">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Capitolo 09 — Solitudine, contatto, stress: il corpo sociale come infrastruttura</title>
+  <meta name="description" content="La crisi contemporanea è anche di contatto: salute mentale e relazione sono un problema di design sociale." />
+
+  <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-09.html" />
+
+  <meta property="og:title" content="Capitolo 09 — Solitudine, contatto, stress: il corpo sociale come infrastruttura" />
+  <meta property="og:description" content="La crisi contemporanea è anche di contatto: salute mentale e relazione sono un problema di design sociale." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://futurofortissimo.github.io/book/chapter-09.html" />
+  <meta property="og:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Capitolo 09 — Solitudine, contatto, stress: il corpo sociale come infrastruttura" />
+  <meta name="twitter:description" content="La crisi contemporanea è anche di contatto: salute mentale e relazione sono un problema di design sociale." />
+  <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <link rel="icon" href="/favicon.ico" />
+
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=IBM+Plex+Mono:wght@600;700&display=swap" rel="stylesheet">
+
+  <style>
+    :root{--ink:#0a0a0a;}
+    body{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial; color:var(--ink);}
+    .mono{font-family:"IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; letter-spacing:.06em; text-transform:uppercase;}
+  </style>
+
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Chapter",
+  "name": "Solitudine, contatto, stress: il corpo sociale come infrastruttura",
+  "position": 9,
+  "isPartOf": {
+    "@type": "Book",
+    "name": "Futuro Fortissimo — 14 capitoli (outline)",
+    "url": "https://futurofortissimo.github.io/book/"
+  },
+  "url": "https://futurofortissimo.github.io/book/chapter-09.html",
+  "inLanguage": "it",
+  "description": "La crisi contemporanea è anche di contatto: salute mentale e relazione sono un problema di design sociale."
+}
+</script>
+</head>
+<body class="bg-zinc-50">
+  <header class="border-b border-zinc-200 bg-white">
+    <div class="max-w-4xl mx-auto px-4 py-5 flex items-center justify-between gap-3">
+      <div>
+        <div class="mono text-xs text-zinc-500">Futuro Fortissimo — book</div>
+        <div class="text-xl font-extrabold tracking-tight">Capitolo 09 — Solitudine, contatto, stress: il corpo sociale come infrastruttura</div>
+      </div>
+      <nav class="flex gap-3 text-sm">
+        <a data-nav="1" class="underline" href="/index.html">Home</a>
+        <a data-nav="1" class="underline" href="/book/">Libro</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="max-w-4xl mx-auto px-4 py-8">
+    
+    <section class="rounded-xl border border-zinc-200 bg-white p-5">
+      <div class="mono text-xs text-zinc-500">Capitolo 09 / 14</div>
+      <h1 class="text-2xl font-extrabold tracking-tight mt-1">Solitudine, contatto, stress: il corpo sociale come infrastruttura</h1>
+      <p class="text-sm text-zinc-700 mt-3">La crisi contemporanea è anche di contatto: salute mentale e relazione sono un problema di design sociale.</p>
+
+      
+        <div class="mt-5">
+          <div class="mono text-xs text-zinc-500">Riferimenti (placeholder)</div>
+          <ul class="mt-2 grid gap-2 text-sm">
+            <li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.97.1</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.97.2</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.97.3</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.97.4</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.119.2</code></li>
+          </ul>
+          <p class="text-xs text-zinc-500 mt-3">TODO: collegare questi refs ai subcapitoli/URL reali (ff.xx.yy) e generare estratti.</p>
+        </div>
+
+      <div class="mt-6 flex flex-wrap gap-3">
+        <a class="underline" data-track="chapter_prev" href="/book/chapter-08.html">← Precedente</a>
+        <a class="underline" data-track="chapter_index" href="/book/">Indice capitoli</a>
+        <a class="underline" data-track="chapter_next" href="/book/chapter-10.html">Successivo →</a>
+      </div>
+    </section>
+    
+  </main>
+
+  <script src="/analytics.js"></script>
+  <script>
+    // Track page view (provider-agnostic). Implemented in analytics.js
+    if (window.ffTrackPage) window.ffTrackPage();
+  </script>
+</body>
+</html>

--- a/book/chapter-10.html
+++ b/book/chapter-10.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="it">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Capitolo 10 — Mangiare il futuro: dieta, microbioma, longevità (senza culto)</title>
+  <meta name="description" content="La via d’uscita dal caos nutrizionale è unire scienza, contesto personale e umiltà epistemica." />
+
+  <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-10.html" />
+
+  <meta property="og:title" content="Capitolo 10 — Mangiare il futuro: dieta, microbioma, longevità (senza culto)" />
+  <meta property="og:description" content="La via d’uscita dal caos nutrizionale è unire scienza, contesto personale e umiltà epistemica." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://futurofortissimo.github.io/book/chapter-10.html" />
+  <meta property="og:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Capitolo 10 — Mangiare il futuro: dieta, microbioma, longevità (senza culto)" />
+  <meta name="twitter:description" content="La via d’uscita dal caos nutrizionale è unire scienza, contesto personale e umiltà epistemica." />
+  <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <link rel="icon" href="/favicon.ico" />
+
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=IBM+Plex+Mono:wght@600;700&display=swap" rel="stylesheet">
+
+  <style>
+    :root{--ink:#0a0a0a;}
+    body{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial; color:var(--ink);}
+    .mono{font-family:"IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; letter-spacing:.06em; text-transform:uppercase;}
+  </style>
+
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Chapter",
+  "name": "Mangiare il futuro: dieta, microbioma, longevità (senza culto)",
+  "position": 10,
+  "isPartOf": {
+    "@type": "Book",
+    "name": "Futuro Fortissimo — 14 capitoli (outline)",
+    "url": "https://futurofortissimo.github.io/book/"
+  },
+  "url": "https://futurofortissimo.github.io/book/chapter-10.html",
+  "inLanguage": "it",
+  "description": "La via d’uscita dal caos nutrizionale è unire scienza, contesto personale e umiltà epistemica."
+}
+</script>
+</head>
+<body class="bg-zinc-50">
+  <header class="border-b border-zinc-200 bg-white">
+    <div class="max-w-4xl mx-auto px-4 py-5 flex items-center justify-between gap-3">
+      <div>
+        <div class="mono text-xs text-zinc-500">Futuro Fortissimo — book</div>
+        <div class="text-xl font-extrabold tracking-tight">Capitolo 10 — Mangiare il futuro: dieta, microbioma, longevità (senza culto)</div>
+      </div>
+      <nav class="flex gap-3 text-sm">
+        <a data-nav="1" class="underline" href="/index.html">Home</a>
+        <a data-nav="1" class="underline" href="/book/">Libro</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="max-w-4xl mx-auto px-4 py-8">
+    
+    <section class="rounded-xl border border-zinc-200 bg-white p-5">
+      <div class="mono text-xs text-zinc-500">Capitolo 10 / 14</div>
+      <h1 class="text-2xl font-extrabold tracking-tight mt-1">Mangiare il futuro: dieta, microbioma, longevità (senza culto)</h1>
+      <p class="text-sm text-zinc-700 mt-3">La via d’uscita dal caos nutrizionale è unire scienza, contesto personale e umiltà epistemica.</p>
+
+      
+        <div class="mt-5">
+          <div class="mono text-xs text-zinc-500">Riferimenti (placeholder)</div>
+          <ul class="mt-2 grid gap-2 text-sm">
+            <li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.92.2</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.92.3</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.92.4</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.94.2</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.99.1</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.113.2</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.113.4</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.104.4</code></li>
+          </ul>
+          <p class="text-xs text-zinc-500 mt-3">TODO: collegare questi refs ai subcapitoli/URL reali (ff.xx.yy) e generare estratti.</p>
+        </div>
+
+      <div class="mt-6 flex flex-wrap gap-3">
+        <a class="underline" data-track="chapter_prev" href="/book/chapter-09.html">← Precedente</a>
+        <a class="underline" data-track="chapter_index" href="/book/">Indice capitoli</a>
+        <a class="underline" data-track="chapter_next" href="/book/chapter-11.html">Successivo →</a>
+      </div>
+    </section>
+    
+  </main>
+
+  <script src="/analytics.js"></script>
+  <script>
+    // Track page view (provider-agnostic). Implemented in analytics.js
+    if (window.ffTrackPage) window.ffTrackPage();
+  </script>
+</body>
+</html>

--- a/book/chapter-11.html
+++ b/book/chapter-11.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="it">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Capitolo 11 — Corpo, performance e rischio: allenarsi contro la mortalità (davvero?)</title>
+  <meta name="description" content="Salute e performance sono scelte di rischio: robustezza &gt; ottimizzazione fragile." />
+
+  <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-11.html" />
+
+  <meta property="og:title" content="Capitolo 11 — Corpo, performance e rischio: allenarsi contro la mortalità (davvero?)" />
+  <meta property="og:description" content="Salute e performance sono scelte di rischio: robustezza &gt; ottimizzazione fragile." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://futurofortissimo.github.io/book/chapter-11.html" />
+  <meta property="og:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Capitolo 11 — Corpo, performance e rischio: allenarsi contro la mortalità (davvero?)" />
+  <meta name="twitter:description" content="Salute e performance sono scelte di rischio: robustezza &gt; ottimizzazione fragile." />
+  <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <link rel="icon" href="/favicon.ico" />
+
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=IBM+Plex+Mono:wght@600;700&display=swap" rel="stylesheet">
+
+  <style>
+    :root{--ink:#0a0a0a;}
+    body{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial; color:var(--ink);}
+    .mono{font-family:"IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; letter-spacing:.06em; text-transform:uppercase;}
+  </style>
+
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Chapter",
+  "name": "Corpo, performance e rischio: allenarsi contro la mortalità (davvero?)",
+  "position": 11,
+  "isPartOf": {
+    "@type": "Book",
+    "name": "Futuro Fortissimo — 14 capitoli (outline)",
+    "url": "https://futurofortissimo.github.io/book/"
+  },
+  "url": "https://futurofortissimo.github.io/book/chapter-11.html",
+  "inLanguage": "it",
+  "description": "Salute e performance sono scelte di rischio: robustezza > ottimizzazione fragile."
+}
+</script>
+</head>
+<body class="bg-zinc-50">
+  <header class="border-b border-zinc-200 bg-white">
+    <div class="max-w-4xl mx-auto px-4 py-5 flex items-center justify-between gap-3">
+      <div>
+        <div class="mono text-xs text-zinc-500">Futuro Fortissimo — book</div>
+        <div class="text-xl font-extrabold tracking-tight">Capitolo 11 — Corpo, performance e rischio: allenarsi contro la mortalità (davvero?)</div>
+      </div>
+      <nav class="flex gap-3 text-sm">
+        <a data-nav="1" class="underline" href="/index.html">Home</a>
+        <a data-nav="1" class="underline" href="/book/">Libro</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="max-w-4xl mx-auto px-4 py-8">
+    
+    <section class="rounded-xl border border-zinc-200 bg-white p-5">
+      <div class="mono text-xs text-zinc-500">Capitolo 11 / 14</div>
+      <h1 class="text-2xl font-extrabold tracking-tight mt-1">Corpo, performance e rischio: allenarsi contro la mortalità (davvero?)</h1>
+      <p class="text-sm text-zinc-700 mt-3">Salute e performance sono scelte di rischio: robustezza &gt; ottimizzazione fragile.</p>
+
+      
+        <div class="mt-5">
+          <div class="mono text-xs text-zinc-500">Riferimenti (placeholder)</div>
+          <ul class="mt-2 grid gap-2 text-sm">
+            <li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.120.1</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.120.2</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.120.3</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.120.4</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.120.5</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.112.3</code></li>
+          </ul>
+          <p class="text-xs text-zinc-500 mt-3">TODO: collegare questi refs ai subcapitoli/URL reali (ff.xx.yy) e generare estratti.</p>
+        </div>
+
+      <div class="mt-6 flex flex-wrap gap-3">
+        <a class="underline" data-track="chapter_prev" href="/book/chapter-10.html">← Precedente</a>
+        <a class="underline" data-track="chapter_index" href="/book/">Indice capitoli</a>
+        <a class="underline" data-track="chapter_next" href="/book/chapter-12.html">Successivo →</a>
+      </div>
+    </section>
+    
+  </main>
+
+  <script src="/analytics.js"></script>
+  <script>
+    // Track page view (provider-agnostic). Implemented in analytics.js
+    if (window.ffTrackPage) window.ffTrackPage();
+  </script>
+</body>
+</html>

--- a/book/chapter-12.html
+++ b/book/chapter-12.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="it">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Capitolo 12 — Plastica e modernità: il costo invisibile del comfort</title>
+  <meta name="description" content="Le microplastiche rendono i costi esterni improvvisamente interni: corpo, arterie, ecosistemi." />
+
+  <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-12.html" />
+
+  <meta property="og:title" content="Capitolo 12 — Plastica e modernità: il costo invisibile del comfort" />
+  <meta property="og:description" content="Le microplastiche rendono i costi esterni improvvisamente interni: corpo, arterie, ecosistemi." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://futurofortissimo.github.io/book/chapter-12.html" />
+  <meta property="og:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Capitolo 12 — Plastica e modernità: il costo invisibile del comfort" />
+  <meta name="twitter:description" content="Le microplastiche rendono i costi esterni improvvisamente interni: corpo, arterie, ecosistemi." />
+  <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <link rel="icon" href="/favicon.ico" />
+
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=IBM+Plex+Mono:wght@600;700&display=swap" rel="stylesheet">
+
+  <style>
+    :root{--ink:#0a0a0a;}
+    body{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial; color:var(--ink);}
+    .mono{font-family:"IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; letter-spacing:.06em; text-transform:uppercase;}
+  </style>
+
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Chapter",
+  "name": "Plastica e modernità: il costo invisibile del comfort",
+  "position": 12,
+  "isPartOf": {
+    "@type": "Book",
+    "name": "Futuro Fortissimo — 14 capitoli (outline)",
+    "url": "https://futurofortissimo.github.io/book/"
+  },
+  "url": "https://futurofortissimo.github.io/book/chapter-12.html",
+  "inLanguage": "it",
+  "description": "Le microplastiche rendono i costi esterni improvvisamente interni: corpo, arterie, ecosistemi."
+}
+</script>
+</head>
+<body class="bg-zinc-50">
+  <header class="border-b border-zinc-200 bg-white">
+    <div class="max-w-4xl mx-auto px-4 py-5 flex items-center justify-between gap-3">
+      <div>
+        <div class="mono text-xs text-zinc-500">Futuro Fortissimo — book</div>
+        <div class="text-xl font-extrabold tracking-tight">Capitolo 12 — Plastica e modernità: il costo invisibile del comfort</div>
+      </div>
+      <nav class="flex gap-3 text-sm">
+        <a data-nav="1" class="underline" href="/index.html">Home</a>
+        <a data-nav="1" class="underline" href="/book/">Libro</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="max-w-4xl mx-auto px-4 py-8">
+    
+    <section class="rounded-xl border border-zinc-200 bg-white p-5">
+      <div class="mono text-xs text-zinc-500">Capitolo 12 / 14</div>
+      <h1 class="text-2xl font-extrabold tracking-tight mt-1">Plastica e modernità: il costo invisibile del comfort</h1>
+      <p class="text-sm text-zinc-700 mt-3">Le microplastiche rendono i costi esterni improvvisamente interni: corpo, arterie, ecosistemi.</p>
+
+      
+        <div class="mt-5">
+          <div class="mono text-xs text-zinc-500">Riferimenti (placeholder)</div>
+          <ul class="mt-2 grid gap-2 text-sm">
+            <li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.130.1</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.130.2</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.130.3</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.130.4</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.130.5</code></li>
+          </ul>
+          <p class="text-xs text-zinc-500 mt-3">TODO: collegare questi refs ai subcapitoli/URL reali (ff.xx.yy) e generare estratti.</p>
+        </div>
+
+      <div class="mt-6 flex flex-wrap gap-3">
+        <a class="underline" data-track="chapter_prev" href="/book/chapter-11.html">← Precedente</a>
+        <a class="underline" data-track="chapter_index" href="/book/">Indice capitoli</a>
+        <a class="underline" data-track="chapter_next" href="/book/chapter-13.html">Successivo →</a>
+      </div>
+    </section>
+    
+  </main>
+
+  <script src="/analytics.js"></script>
+  <script>
+    // Track page view (provider-agnostic). Implemented in analytics.js
+    if (window.ffTrackPage) window.ffTrackPage();
+  </script>
+</body>
+</html>

--- a/book/chapter-13.html
+++ b/book/chapter-13.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="it">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Capitolo 13 — Imperi, dollaro, Internet: geopolitica nell’era delle reti</title>
+  <meta name="description" content="La geopolitica torna imperiale, ma con reti digitali e standard tecnologici al centro." />
+
+  <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-13.html" />
+
+  <meta property="og:title" content="Capitolo 13 — Imperi, dollaro, Internet: geopolitica nell’era delle reti" />
+  <meta property="og:description" content="La geopolitica torna imperiale, ma con reti digitali e standard tecnologici al centro." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://futurofortissimo.github.io/book/chapter-13.html" />
+  <meta property="og:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Capitolo 13 — Imperi, dollaro, Internet: geopolitica nell’era delle reti" />
+  <meta name="twitter:description" content="La geopolitica torna imperiale, ma con reti digitali e standard tecnologici al centro." />
+  <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <link rel="icon" href="/favicon.ico" />
+
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=IBM+Plex+Mono:wght@600;700&display=swap" rel="stylesheet">
+
+  <style>
+    :root{--ink:#0a0a0a;}
+    body{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial; color:var(--ink);}
+    .mono{font-family:"IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; letter-spacing:.06em; text-transform:uppercase;}
+  </style>
+
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Chapter",
+  "name": "Imperi, dollaro, Internet: geopolitica nell’era delle reti",
+  "position": 13,
+  "isPartOf": {
+    "@type": "Book",
+    "name": "Futuro Fortissimo — 14 capitoli (outline)",
+    "url": "https://futurofortissimo.github.io/book/"
+  },
+  "url": "https://futurofortissimo.github.io/book/chapter-13.html",
+  "inLanguage": "it",
+  "description": "La geopolitica torna imperiale, ma con reti digitali e standard tecnologici al centro."
+}
+</script>
+</head>
+<body class="bg-zinc-50">
+  <header class="border-b border-zinc-200 bg-white">
+    <div class="max-w-4xl mx-auto px-4 py-5 flex items-center justify-between gap-3">
+      <div>
+        <div class="mono text-xs text-zinc-500">Futuro Fortissimo — book</div>
+        <div class="text-xl font-extrabold tracking-tight">Capitolo 13 — Imperi, dollaro, Internet: geopolitica nell’era delle reti</div>
+      </div>
+      <nav class="flex gap-3 text-sm">
+        <a data-nav="1" class="underline" href="/index.html">Home</a>
+        <a data-nav="1" class="underline" href="/book/">Libro</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="max-w-4xl mx-auto px-4 py-8">
+    
+    <section class="rounded-xl border border-zinc-200 bg-white p-5">
+      <div class="mono text-xs text-zinc-500">Capitolo 13 / 14</div>
+      <h1 class="text-2xl font-extrabold tracking-tight mt-1">Imperi, dollaro, Internet: geopolitica nell’era delle reti</h1>
+      <p class="text-sm text-zinc-700 mt-3">La geopolitica torna imperiale, ma con reti digitali e standard tecnologici al centro.</p>
+
+      
+        <div class="mt-5">
+          <div class="mono text-xs text-zinc-500">Riferimenti (placeholder)</div>
+          <ul class="mt-2 grid gap-2 text-sm">
+            <li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.125.1</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.125.2</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.125.3</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.125.4</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.135.5</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.102.2</code></li>
+          </ul>
+          <p class="text-xs text-zinc-500 mt-3">TODO: collegare questi refs ai subcapitoli/URL reali (ff.xx.yy) e generare estratti.</p>
+        </div>
+
+      <div class="mt-6 flex flex-wrap gap-3">
+        <a class="underline" data-track="chapter_prev" href="/book/chapter-12.html">← Precedente</a>
+        <a class="underline" data-track="chapter_index" href="/book/">Indice capitoli</a>
+        <a class="underline" data-track="chapter_next" href="/book/chapter-14.html">Successivo →</a>
+      </div>
+    </section>
+    
+  </main>
+
+  <script src="/analytics.js"></script>
+  <script>
+    // Track page view (provider-agnostic). Implemented in analytics.js
+    if (window.ffTrackPage) window.ffTrackPage();
+  </script>
+</body>
+</html>

--- a/book/chapter-14.html
+++ b/book/chapter-14.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="it">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Capitolo 14 — Sovranità digitale, proprietà e crypto: uscire (o entrare) nello Stato</title>
+  <meta name="description" content="Crypto non sono soldi magici: sono strumenti per ripensare proprietà, fiducia e istituzioni, con costi politici." />
+
+  <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-14.html" />
+
+  <meta property="og:title" content="Capitolo 14 — Sovranità digitale, proprietà e crypto: uscire (o entrare) nello Stato" />
+  <meta property="og:description" content="Crypto non sono soldi magici: sono strumenti per ripensare proprietà, fiducia e istituzioni, con costi politici." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://futurofortissimo.github.io/book/chapter-14.html" />
+  <meta property="og:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Capitolo 14 — Sovranità digitale, proprietà e crypto: uscire (o entrare) nello Stato" />
+  <meta name="twitter:description" content="Crypto non sono soldi magici: sono strumenti per ripensare proprietà, fiducia e istituzioni, con costi politici." />
+  <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <link rel="icon" href="/favicon.ico" />
+
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=IBM+Plex+Mono:wght@600;700&display=swap" rel="stylesheet">
+
+  <style>
+    :root{--ink:#0a0a0a;}
+    body{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial; color:var(--ink);}
+    .mono{font-family:"IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; letter-spacing:.06em; text-transform:uppercase;}
+  </style>
+
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Chapter",
+  "name": "Sovranità digitale, proprietà e crypto: uscire (o entrare) nello Stato",
+  "position": 14,
+  "isPartOf": {
+    "@type": "Book",
+    "name": "Futuro Fortissimo — 14 capitoli (outline)",
+    "url": "https://futurofortissimo.github.io/book/"
+  },
+  "url": "https://futurofortissimo.github.io/book/chapter-14.html",
+  "inLanguage": "it",
+  "description": "Crypto non sono soldi magici: sono strumenti per ripensare proprietà, fiducia e istituzioni, con costi politici."
+}
+</script>
+</head>
+<body class="bg-zinc-50">
+  <header class="border-b border-zinc-200 bg-white">
+    <div class="max-w-4xl mx-auto px-4 py-5 flex items-center justify-between gap-3">
+      <div>
+        <div class="mono text-xs text-zinc-500">Futuro Fortissimo — book</div>
+        <div class="text-xl font-extrabold tracking-tight">Capitolo 14 — Sovranità digitale, proprietà e crypto: uscire (o entrare) nello Stato</div>
+      </div>
+      <nav class="flex gap-3 text-sm">
+        <a data-nav="1" class="underline" href="/index.html">Home</a>
+        <a data-nav="1" class="underline" href="/book/">Libro</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="max-w-4xl mx-auto px-4 py-8">
+    
+    <section class="rounded-xl border border-zinc-200 bg-white p-5">
+      <div class="mono text-xs text-zinc-500">Capitolo 14 / 14</div>
+      <h1 class="text-2xl font-extrabold tracking-tight mt-1">Sovranità digitale, proprietà e crypto: uscire (o entrare) nello Stato</h1>
+      <p class="text-sm text-zinc-700 mt-3">Crypto non sono soldi magici: sono strumenti per ripensare proprietà, fiducia e istituzioni, con costi politici.</p>
+
+      
+        <div class="mt-5">
+          <div class="mono text-xs text-zinc-500">Riferimenti (placeholder)</div>
+          <ul class="mt-2 grid gap-2 text-sm">
+            <li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.95.1</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.95.3</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.95.5</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.110.3</code></li><li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>ff.135.4</code></li>
+          </ul>
+          <p class="text-xs text-zinc-500 mt-3">TODO: collegare questi refs ai subcapitoli/URL reali (ff.xx.yy) e generare estratti.</p>
+        </div>
+
+      <div class="mt-6 flex flex-wrap gap-3">
+        <a class="underline" data-track="chapter_prev" href="/book/chapter-13.html">← Precedente</a>
+        <a class="underline" data-track="chapter_index" href="/book/">Indice capitoli</a>
+        
+      </div>
+    </section>
+    
+  </main>
+
+  <script src="/analytics.js"></script>
+  <script>
+    // Track page view (provider-agnostic). Implemented in analytics.js
+    if (window.ffTrackPage) window.ffTrackPage();
+  </script>
+</body>
+</html>

--- a/book/index.html
+++ b/book/index.html
@@ -1,0 +1,298 @@
+<!doctype html>
+<html lang="it">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Libro — 14 capitoli (outline)</title>
+  <meta name="description" content="Outline in 14 capitoli: un percorso di lettura su AI, attenzione, società, natura, corpo e sovranità digitale." />
+
+  <link rel="canonical" href="https://futurofortissimo.github.io/book/" />
+
+  <meta property="og:title" content="Libro — 14 capitoli (outline)" />
+  <meta property="og:description" content="Outline in 14 capitoli: un percorso di lettura su AI, attenzione, società, natura, corpo e sovranità digitale." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://futurofortissimo.github.io/book/" />
+  <meta property="og:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Libro — 14 capitoli (outline)" />
+  <meta name="twitter:description" content="Outline in 14 capitoli: un percorso di lettura su AI, attenzione, società, natura, corpo e sovranità digitale." />
+  <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <link rel="icon" href="/favicon.ico" />
+
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=IBM+Plex+Mono:wght@600;700&display=swap" rel="stylesheet">
+
+  <style>
+    :root{--ink:#0a0a0a;}
+    body{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial; color:var(--ink);}
+    .mono{font-family:"IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; letter-spacing:.06em; text-transform:uppercase;}
+  </style>
+
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Book",
+  "name": "Futuro Fortissimo — 14 capitoli (outline)",
+  "inLanguage": "it",
+  "url": "https://futurofortissimo.github.io/book/",
+  "hasPart": [
+    {
+      "@type": "Chapter",
+      "name": "La nuova unità di misura: l’AI come metrica del valore",
+      "position": 1,
+      "url": "https://futurofortissimo.github.io/book/chapter-01.html"
+    },
+    {
+      "@type": "Chapter",
+      "name": "Il conto dell’intelligenza: costi, energia, compute, infrastrutture",
+      "position": 2,
+      "url": "https://futurofortissimo.github.io/book/chapter-02.html"
+    },
+    {
+      "@type": "Chapter",
+      "name": "Siamo già nella singolarità? (o nella sua versione gentile)",
+      "position": 3,
+      "url": "https://futurofortissimo.github.io/book/chapter-03.html"
+    },
+    {
+      "@type": "Chapter",
+      "name": "Il coltellino svizzero cognitivo: dal tool all’agente",
+      "position": 4,
+      "url": "https://futurofortissimo.github.io/book/chapter-04.html"
+    },
+    {
+      "@type": "Chapter",
+      "name": "Creatività post-umana: arte, stile, autenticità nell’era dei modelli",
+      "position": 5,
+      "url": "https://futurofortissimo.github.io/book/chapter-05.html"
+    },
+    {
+      "@type": "Chapter",
+      "name": "Simulare il mondo: modelli, videogiochi e verità operativa",
+      "position": 6,
+      "url": "https://futurofortissimo.github.io/book/chapter-06.html"
+    },
+    {
+      "@type": "Chapter",
+      "name": "Attenzione: la crisi non è (solo) distrazione, è governance interiore",
+      "position": 7,
+      "url": "https://futurofortissimo.github.io/book/chapter-07.html"
+    },
+    {
+      "@type": "Chapter",
+      "name": "Flow e vita ben vissuta: performance, felicità, significato",
+      "position": 8,
+      "url": "https://futurofortissimo.github.io/book/chapter-08.html"
+    },
+    {
+      "@type": "Chapter",
+      "name": "Solitudine, contatto, stress: il corpo sociale come infrastruttura",
+      "position": 9,
+      "url": "https://futurofortissimo.github.io/book/chapter-09.html"
+    },
+    {
+      "@type": "Chapter",
+      "name": "Mangiare il futuro: dieta, microbioma, longevità (senza culto)",
+      "position": 10,
+      "url": "https://futurofortissimo.github.io/book/chapter-10.html"
+    },
+    {
+      "@type": "Chapter",
+      "name": "Corpo, performance e rischio: allenarsi contro la mortalità (davvero?)",
+      "position": 11,
+      "url": "https://futurofortissimo.github.io/book/chapter-11.html"
+    },
+    {
+      "@type": "Chapter",
+      "name": "Plastica e modernità: il costo invisibile del comfort",
+      "position": 12,
+      "url": "https://futurofortissimo.github.io/book/chapter-12.html"
+    },
+    {
+      "@type": "Chapter",
+      "name": "Imperi, dollaro, Internet: geopolitica nell’era delle reti",
+      "position": 13,
+      "url": "https://futurofortissimo.github.io/book/chapter-13.html"
+    },
+    {
+      "@type": "Chapter",
+      "name": "Sovranità digitale, proprietà e crypto: uscire (o entrare) nello Stato",
+      "position": 14,
+      "url": "https://futurofortissimo.github.io/book/chapter-14.html"
+    }
+  ]
+}
+</script>
+</head>
+<body class="bg-zinc-50">
+  <header class="border-b border-zinc-200 bg-white">
+    <div class="max-w-4xl mx-auto px-4 py-5 flex items-center justify-between gap-3">
+      <div>
+        <div class="mono text-xs text-zinc-500">Futuro Fortissimo — book</div>
+        <div class="text-xl font-extrabold tracking-tight">Libro — 14 capitoli (outline)</div>
+      </div>
+      <nav class="flex gap-3 text-sm">
+        <a data-nav="1" class="underline" href="/index.html">Home</a>
+        <a data-nav="1" class="underline" href="/book/">Libro</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="max-w-4xl mx-auto px-4 py-8">
+    
+  <section class="rounded-xl border border-zinc-200 bg-white p-5">
+    <p class="text-sm text-zinc-700">Outline in 14 capitoli: un percorso di lettura su AI, attenzione, società, natura, corpo e sovranità digitale.</p>
+    <div class="mono text-xs text-zinc-500 mt-3">generated 2026-01-27</div>
+  </section>
+
+  <section class="mt-6 grid gap-4">
+    
+      <article class="rounded-xl border border-zinc-200 bg-white p-5">
+        <div class="mono text-xs text-zinc-500">Capitolo 01</div>
+        <h2 class="text-lg font-extrabold tracking-tight mt-1">La nuova unità di misura: l’AI come metrica del valore</h2>
+        <p class="text-sm text-zinc-700 mt-2">L’AI non è solo una tecnologia: è una nuova unità di misura che ridisegna valore, produttività e potere.</p>
+        <div class="mt-3 flex items-center justify-between gap-3">
+          <a class="underline font-semibold" data-track="chapter_open" href="/book/chapter-01.html">Apri capitolo</a>
+          <div class="mono text-[11px] text-zinc-500">refs: 5</div>
+        </div>
+      </article>
+      <article class="rounded-xl border border-zinc-200 bg-white p-5">
+        <div class="mono text-xs text-zinc-500">Capitolo 02</div>
+        <h2 class="text-lg font-extrabold tracking-tight mt-1">Il conto dell’intelligenza: costi, energia, compute, infrastrutture</h2>
+        <p class="text-sm text-zinc-700 mt-2">Ogni salto cognitivo artificiale è anche un salto infrastrutturale: paghiamo l’intelligenza in energia, supply chain e vincoli fisici.</p>
+        <div class="mt-3 flex items-center justify-between gap-3">
+          <a class="underline font-semibold" data-track="chapter_open" href="/book/chapter-02.html">Apri capitolo</a>
+          <div class="mono text-[11px] text-zinc-500">refs: 5</div>
+        </div>
+      </article>
+      <article class="rounded-xl border border-zinc-200 bg-white p-5">
+        <div class="mono text-xs text-zinc-500">Capitolo 03</div>
+        <h2 class="text-lg font-extrabold tracking-tight mt-1">Siamo già nella singolarità? (o nella sua versione gentile)</h2>
+        <p class="text-sm text-zinc-700 mt-2">La singolarità come cambio di regime: feedback economici/cognitivi che alterano aspettative e istituzioni.</p>
+        <div class="mt-3 flex items-center justify-between gap-3">
+          <a class="underline font-semibold" data-track="chapter_open" href="/book/chapter-03.html">Apri capitolo</a>
+          <div class="mono text-[11px] text-zinc-500">refs: 5</div>
+        </div>
+      </article>
+      <article class="rounded-xl border border-zinc-200 bg-white p-5">
+        <div class="mono text-xs text-zinc-500">Capitolo 04</div>
+        <h2 class="text-lg font-extrabold tracking-tight mt-1">Il coltellino svizzero cognitivo: dal tool all’agente</h2>
+        <p class="text-sm text-zinc-700 mt-2">L’AI utile non è quella che sa, ma quella che fa: integra strumenti, contesto e obiettivi e riscrive i workflow.</p>
+        <div class="mt-3 flex items-center justify-between gap-3">
+          <a class="underline font-semibold" data-track="chapter_open" href="/book/chapter-04.html">Apri capitolo</a>
+          <div class="mono text-[11px] text-zinc-500">refs: 7</div>
+        </div>
+      </article>
+      <article class="rounded-xl border border-zinc-200 bg-white p-5">
+        <div class="mono text-xs text-zinc-500">Capitolo 05</div>
+        <h2 class="text-lg font-extrabold tracking-tight mt-1">Creatività post-umana: arte, stile, autenticità nell’era dei modelli</h2>
+        <p class="text-sm text-zinc-700 mt-2">La creatività si sposta dal fare al dirigere: conta intenzione, gusto e firma in un mondo dove lo stile è commodity.</p>
+        <div class="mt-3 flex items-center justify-between gap-3">
+          <a class="underline font-semibold" data-track="chapter_open" href="/book/chapter-05.html">Apri capitolo</a>
+          <div class="mono text-[11px] text-zinc-500">refs: 7</div>
+        </div>
+      </article>
+      <article class="rounded-xl border border-zinc-200 bg-white p-5">
+        <div class="mono text-xs text-zinc-500">Capitolo 06</div>
+        <h2 class="text-lg font-extrabold tracking-tight mt-1">Simulare il mondo: modelli, videogiochi e verità operativa</h2>
+        <p class="text-sm text-zinc-700 mt-2">La simulazione è un modo di conoscere: quando il modello diventa più pratico del reale, cambia la nostra idea di verità.</p>
+        <div class="mt-3 flex items-center justify-between gap-3">
+          <a class="underline font-semibold" data-track="chapter_open" href="/book/chapter-06.html">Apri capitolo</a>
+          <div class="mono text-[11px] text-zinc-500">refs: 7</div>
+        </div>
+      </article>
+      <article class="rounded-xl border border-zinc-200 bg-white p-5">
+        <div class="mono text-xs text-zinc-500">Capitolo 07</div>
+        <h2 class="text-lg font-extrabold tracking-tight mt-1">Attenzione: la crisi non è (solo) distrazione, è governance interiore</h2>
+        <p class="text-sm text-zinc-700 mt-2">Difendere l’attenzione significa progettare ambienti e tecnologie che non colonizzino la mente: è una questione di libertà.</p>
+        <div class="mt-3 flex items-center justify-between gap-3">
+          <a class="underline font-semibold" data-track="chapter_open" href="/book/chapter-07.html">Apri capitolo</a>
+          <div class="mono text-[11px] text-zinc-500">refs: 5</div>
+        </div>
+      </article>
+      <article class="rounded-xl border border-zinc-200 bg-white p-5">
+        <div class="mono text-xs text-zinc-500">Capitolo 08</div>
+        <h2 class="text-lg font-extrabold tracking-tight mt-1">Flow e vita ben vissuta: performance, felicità, significato</h2>
+        <p class="text-sm text-zinc-700 mt-2">Il benessere è una tecnologia della vita: flow, esperienze e investimenti personali formano un portafoglio esistenziale.</p>
+        <div class="mt-3 flex items-center justify-between gap-3">
+          <a class="underline font-semibold" data-track="chapter_open" href="/book/chapter-08.html">Apri capitolo</a>
+          <div class="mono text-[11px] text-zinc-500">refs: 6</div>
+        </div>
+      </article>
+      <article class="rounded-xl border border-zinc-200 bg-white p-5">
+        <div class="mono text-xs text-zinc-500">Capitolo 09</div>
+        <h2 class="text-lg font-extrabold tracking-tight mt-1">Solitudine, contatto, stress: il corpo sociale come infrastruttura</h2>
+        <p class="text-sm text-zinc-700 mt-2">La crisi contemporanea è anche di contatto: salute mentale e relazione sono un problema di design sociale.</p>
+        <div class="mt-3 flex items-center justify-between gap-3">
+          <a class="underline font-semibold" data-track="chapter_open" href="/book/chapter-09.html">Apri capitolo</a>
+          <div class="mono text-[11px] text-zinc-500">refs: 5</div>
+        </div>
+      </article>
+      <article class="rounded-xl border border-zinc-200 bg-white p-5">
+        <div class="mono text-xs text-zinc-500">Capitolo 10</div>
+        <h2 class="text-lg font-extrabold tracking-tight mt-1">Mangiare il futuro: dieta, microbioma, longevità (senza culto)</h2>
+        <p class="text-sm text-zinc-700 mt-2">La via d’uscita dal caos nutrizionale è unire scienza, contesto personale e umiltà epistemica.</p>
+        <div class="mt-3 flex items-center justify-between gap-3">
+          <a class="underline font-semibold" data-track="chapter_open" href="/book/chapter-10.html">Apri capitolo</a>
+          <div class="mono text-[11px] text-zinc-500">refs: 8</div>
+        </div>
+      </article>
+      <article class="rounded-xl border border-zinc-200 bg-white p-5">
+        <div class="mono text-xs text-zinc-500">Capitolo 11</div>
+        <h2 class="text-lg font-extrabold tracking-tight mt-1">Corpo, performance e rischio: allenarsi contro la mortalità (davvero?)</h2>
+        <p class="text-sm text-zinc-700 mt-2">Salute e performance sono scelte di rischio: robustezza &gt; ottimizzazione fragile.</p>
+        <div class="mt-3 flex items-center justify-between gap-3">
+          <a class="underline font-semibold" data-track="chapter_open" href="/book/chapter-11.html">Apri capitolo</a>
+          <div class="mono text-[11px] text-zinc-500">refs: 6</div>
+        </div>
+      </article>
+      <article class="rounded-xl border border-zinc-200 bg-white p-5">
+        <div class="mono text-xs text-zinc-500">Capitolo 12</div>
+        <h2 class="text-lg font-extrabold tracking-tight mt-1">Plastica e modernità: il costo invisibile del comfort</h2>
+        <p class="text-sm text-zinc-700 mt-2">Le microplastiche rendono i costi esterni improvvisamente interni: corpo, arterie, ecosistemi.</p>
+        <div class="mt-3 flex items-center justify-between gap-3">
+          <a class="underline font-semibold" data-track="chapter_open" href="/book/chapter-12.html">Apri capitolo</a>
+          <div class="mono text-[11px] text-zinc-500">refs: 5</div>
+        </div>
+      </article>
+      <article class="rounded-xl border border-zinc-200 bg-white p-5">
+        <div class="mono text-xs text-zinc-500">Capitolo 13</div>
+        <h2 class="text-lg font-extrabold tracking-tight mt-1">Imperi, dollaro, Internet: geopolitica nell’era delle reti</h2>
+        <p class="text-sm text-zinc-700 mt-2">La geopolitica torna imperiale, ma con reti digitali e standard tecnologici al centro.</p>
+        <div class="mt-3 flex items-center justify-between gap-3">
+          <a class="underline font-semibold" data-track="chapter_open" href="/book/chapter-13.html">Apri capitolo</a>
+          <div class="mono text-[11px] text-zinc-500">refs: 6</div>
+        </div>
+      </article>
+      <article class="rounded-xl border border-zinc-200 bg-white p-5">
+        <div class="mono text-xs text-zinc-500">Capitolo 14</div>
+        <h2 class="text-lg font-extrabold tracking-tight mt-1">Sovranità digitale, proprietà e crypto: uscire (o entrare) nello Stato</h2>
+        <p class="text-sm text-zinc-700 mt-2">Crypto non sono soldi magici: sono strumenti per ripensare proprietà, fiducia e istituzioni, con costi politici.</p>
+        <div class="mt-3 flex items-center justify-between gap-3">
+          <a class="underline font-semibold" data-track="chapter_open" href="/book/chapter-14.html">Apri capitolo</a>
+          <div class="mono text-[11px] text-zinc-500">refs: 5</div>
+        </div>
+      </article>
+  </section>
+
+  <section class="mt-8 rounded-xl border border-zinc-200 bg-white p-5">
+    <h2 class="text-base font-bold">Note</h2>
+    <ul class="list-disc pl-5 mt-2 text-sm text-zinc-700 space-y-1">
+      <li>Queste pagine sono scaffolding statico: utili per SEO, condivisione e navigazione.</li>
+      <li>In futuro possono diventare un indice “vivo” con estratti e link ai subcapitoli.</li>
+    </ul>
+  </section>
+  
+  </main>
+
+  <script src="/analytics.js"></script>
+  <script>
+    // Track page view (provider-agnostic). Implemented in analytics.js
+    if (window.ffTrackPage) window.ffTrackPage();
+  </script>
+</body>
+</html>

--- a/components/BookOutlinePopup.js
+++ b/components/BookOutlinePopup.js
@@ -22,6 +22,16 @@ const BookOutlinePopup = ({ onClose }) => {
         <div className="ff-eyebrow-md text-black/80">Libro / mini‑saggi</div>
         <h2 className="ff-heading-xl mt-2">14 capitoli (outline)</h2>
         <p className="ff-body text-black/70 mt-2">Struttura consequenziale: tech → cultura/simulazione → attenzione/salute → materiale/politico.</p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <a
+            data-nav="1"
+            data-track="book_static_open"
+            href="./book/"
+            className="px-4 py-2 border-3 border-black bg-[var(--ff-yellow)] brutal-shadow ff-button hover:-translate-y-0.5 transition-transform"
+          >
+            Apri pagine (SEO)
+          </a>
+        </div>
 
         ${!data
           ? html`<p className="mt-6">Caricamento…</p>`

--- a/connections.html
+++ b/connections.html
@@ -5,11 +5,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Futuro Fortissimo — Connessioni fortissime</title>
   <meta name="description" content="Connessioni tra i post Futuro Fortissimo: hub più citati, link interni e percorsi di lettura." />
-  <link rel="canonical" href="./connections.html" />
+  <link rel="canonical" href="https://futurofortissimo.github.io/connections.html" />
 
   <meta property="og:title" content="Futuro Fortissimo — Connessioni fortissime" />
   <meta property="og:description" content="Mappa delle connessioni interne tra post e sub-capitoli." />
   <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://futurofortissimo.github.io/connections.html" />
+  <meta property="og:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Futuro Fortissimo — Connessioni fortissime" />
+  <meta name="twitter:description" content="Mappa delle connessioni interne tra post e sub-capitoli." />
+  <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png" />
 
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/index.html
+++ b/index.html
@@ -1,13 +1,24 @@
 <!DOCTYPE html>
-<html lang="en" class="scroll-smooth">
+<html lang="it" class="scroll-smooth">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Futuro Fortissimo — archive</title>
+    <title>Futuro Fortissimo — archivio</title>
     <meta name="description" content="Archivio tipografico di Futuro Fortissimo: letture, note e percorsi (AI, attenzione, società, natura)." />
+
+    <link rel="canonical" href="https://futurofortissimo.github.io/" />
+
     <meta property="og:title" content="Futuro Fortissimo" />
     <meta property="og:description" content="Archivio tipografico: letture, note e percorsi." />
     <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://futurofortissimo.github.io/" />
+    <meta property="og:image" content="https://futurofortissimo.github.io/logo.png" />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Futuro Fortissimo" />
+    <meta name="twitter:description" content="Archivio tipografico: letture, note e percorsi." />
+    <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png" />
+
     
     <!-- Tailwind CSS -->
     <script src="https://cdn.tailwindcss.com"></script>

--- a/scripts/generate_book_pages.mjs
+++ b/scripts/generate_book_pages.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+/**
+ * Generate static book outline pages from generated/book/outline.json
+ *
+ * Output:
+ * - book/index.html
+ * - book/chapter-01.html ... chapter-14
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = path.resolve(process.cwd());
+const outlinePath = path.join(ROOT, 'generated', 'book', 'outline.json');
+const outDir = path.join(ROOT, 'book');
+
+const SITE_ORIGIN = 'https://futurofortissimo.github.io';
+
+function pad2(n) {
+  return String(n).padStart(2, '0');
+}
+
+function escapeHtml(s = '') {
+  return String(s)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function pageShell({
+  lang = 'it',
+  title,
+  description,
+  canonical,
+  ogImage = `${SITE_ORIGIN}/logo.png`,
+  bodyHtml,
+  jsonLd,
+}) {
+  const safeTitle = escapeHtml(title);
+  const safeDesc = escapeHtml(description);
+  const safeCanonical = escapeHtml(canonical);
+
+  return `<!doctype html>
+<html lang="${lang}">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${safeTitle}</title>
+  <meta name="description" content="${safeDesc}" />
+
+  <link rel="canonical" href="${safeCanonical}" />
+
+  <meta property="og:title" content="${safeTitle}" />
+  <meta property="og:description" content="${safeDesc}" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="${safeCanonical}" />
+  <meta property="og:image" content="${escapeHtml(ogImage)}" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="${safeTitle}" />
+  <meta name="twitter:description" content="${safeDesc}" />
+  <meta name="twitter:image" content="${escapeHtml(ogImage)}" />
+
+  <link rel="icon" href="/favicon.ico" />
+
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=IBM+Plex+Mono:wght@600;700&display=swap" rel="stylesheet">
+
+  <style>
+    :root{--ink:#0a0a0a;}
+    body{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial; color:var(--ink);}
+    .mono{font-family:"IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; letter-spacing:.06em; text-transform:uppercase;}
+  </style>
+
+  ${jsonLd ? `<script type="application/ld+json">\n${JSON.stringify(jsonLd, null, 2)}\n</script>` : ''}
+</head>
+<body class="bg-zinc-50">
+  <header class="border-b border-zinc-200 bg-white">
+    <div class="max-w-4xl mx-auto px-4 py-5 flex items-center justify-between gap-3">
+      <div>
+        <div class="mono text-xs text-zinc-500">Futuro Fortissimo — book</div>
+        <div class="text-xl font-extrabold tracking-tight">${safeTitle}</div>
+      </div>
+      <nav class="flex gap-3 text-sm">
+        <a data-nav="1" class="underline" href="/index.html">Home</a>
+        <a data-nav="1" class="underline" href="/book/">Libro</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="max-w-4xl mx-auto px-4 py-8">
+    ${bodyHtml}
+  </main>
+
+  <script src="/analytics.js"></script>
+  <script>
+    // Track page view (provider-agnostic). Implemented in analytics.js
+    if (window.ffTrackPage) window.ffTrackPage();
+  </script>
+</body>
+</html>`;
+}
+
+function writeFile(fp, content) {
+  fs.mkdirSync(path.dirname(fp), { recursive: true });
+  fs.writeFileSync(fp, content, 'utf8');
+}
+
+function main() {
+  const outline = JSON.parse(fs.readFileSync(outlinePath, 'utf8'));
+
+  const chapters = outline.chapters || [];
+
+  // index page
+  const bookCanonical = `${SITE_ORIGIN}/book/`;
+  const bookDesc = 'Outline in 14 capitoli: un percorso di lettura su AI, attenzione, società, natura, corpo e sovranità digitale.';
+
+  const bookJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Book',
+    name: outline.title || 'Futuro Fortissimo — 14 capitoli',
+    inLanguage: 'it',
+    url: bookCanonical,
+    hasPart: chapters.map((c) => ({
+      '@type': 'Chapter',
+      name: c.title,
+      position: c.n,
+      url: `${SITE_ORIGIN}/book/chapter-${pad2(c.n)}.html`,
+    })),
+  };
+
+  const listHtml = `
+  <section class="rounded-xl border border-zinc-200 bg-white p-5">
+    <p class="text-sm text-zinc-700">${escapeHtml(bookDesc)}</p>
+    <div class="mono text-xs text-zinc-500 mt-3">generated ${escapeHtml(outline.generatedAt || '')}</div>
+  </section>
+
+  <section class="mt-6 grid gap-4">
+    ${chapters.map((c) => {
+      const href = `/book/chapter-${pad2(c.n)}.html`;
+      return `
+      <article class="rounded-xl border border-zinc-200 bg-white p-5">
+        <div class="mono text-xs text-zinc-500">Capitolo ${pad2(c.n)}</div>
+        <h2 class="text-lg font-extrabold tracking-tight mt-1">${escapeHtml(c.title)}</h2>
+        <p class="text-sm text-zinc-700 mt-2">${escapeHtml(c.thesis || '')}</p>
+        <div class="mt-3 flex items-center justify-between gap-3">
+          <a class="underline font-semibold" data-track="chapter_open" href="${href}">Apri capitolo</a>
+          <div class="mono text-[11px] text-zinc-500">refs: ${(c.refs || []).length}</div>
+        </div>
+      </article>`;
+    }).join('')}
+  </section>
+
+  <section class="mt-8 rounded-xl border border-zinc-200 bg-white p-5">
+    <h2 class="text-base font-bold">Note</h2>
+    <ul class="list-disc pl-5 mt-2 text-sm text-zinc-700 space-y-1">
+      <li>Queste pagine sono scaffolding statico: utili per SEO, condivisione e navigazione.</li>
+      <li>In futuro possono diventare un indice “vivo” con estratti e link ai subcapitoli.</li>
+    </ul>
+  </section>
+  `;
+
+  writeFile(
+    path.join(outDir, 'index.html'),
+    pageShell({
+      title: 'Libro — 14 capitoli (outline)',
+      description: bookDesc,
+      canonical: bookCanonical,
+      bodyHtml: listHtml,
+      jsonLd: bookJsonLd,
+    })
+  );
+
+  // chapter pages
+  for (const c of chapters) {
+    const canonical = `${SITE_ORIGIN}/book/chapter-${pad2(c.n)}.html`;
+    const desc = c.thesis || bookDesc;
+
+    const jsonLd = {
+      '@context': 'https://schema.org',
+      '@type': 'Chapter',
+      name: c.title,
+      position: c.n,
+      isPartOf: {
+        '@type': 'Book',
+        name: outline.title || 'Futuro Fortissimo — 14 capitoli',
+        url: bookCanonical,
+      },
+      url: canonical,
+      inLanguage: 'it',
+      description: desc,
+    };
+
+    const bodyHtml = `
+    <section class="rounded-xl border border-zinc-200 bg-white p-5">
+      <div class="mono text-xs text-zinc-500">Capitolo ${pad2(c.n)} / 14</div>
+      <h1 class="text-2xl font-extrabold tracking-tight mt-1">${escapeHtml(c.title)}</h1>
+      <p class="text-sm text-zinc-700 mt-3">${escapeHtml(desc)}</p>
+
+      ${(c.refs && c.refs.length)
+        ? `
+        <div class="mt-5">
+          <div class="mono text-xs text-zinc-500">Riferimenti (placeholder)</div>
+          <ul class="mt-2 grid gap-2 text-sm">
+            ${(c.refs || []).map((r) => `<li class="rounded-lg bg-zinc-50 border border-zinc-200 px-3 py-2"><code>${escapeHtml(r)}</code></li>`).join('')}
+          </ul>
+          <p class="text-xs text-zinc-500 mt-3">TODO: collegare questi refs ai subcapitoli/URL reali (ff.xx.yy) e generare estratti.</p>
+        </div>`
+        : ''}
+
+      <div class="mt-6 flex flex-wrap gap-3">
+        ${c.n > 1 ? `<a class="underline" data-track="chapter_prev" href="/book/chapter-${pad2(c.n - 1)}.html">← Precedente</a>` : ''}
+        <a class="underline" data-track="chapter_index" href="/book/">Indice capitoli</a>
+        ${c.n < chapters.length ? `<a class="underline" data-track="chapter_next" href="/book/chapter-${pad2(c.n + 1)}.html">Successivo →</a>` : ''}
+      </div>
+    </section>
+    `;
+
+    writeFile(
+      path.join(outDir, `chapter-${pad2(c.n)}.html`),
+      pageShell({
+        title: `Capitolo ${pad2(c.n)} — ${c.title}`,
+        description: desc,
+        canonical,
+        bodyHtml,
+        jsonLd,
+      })
+    );
+  }
+
+  console.log(`Generated ${chapters.length + 1} pages in ${path.relative(ROOT, outDir)}/`);
+}
+
+main();

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,40 +2,62 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://futurofortissimo.github.io/</loc>
-    <lastmod>2024-10-15</lastmod>
+    <lastmod>2026-01-27</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://futurofortissimo.github.io/natura/</loc>
-    <lastmod>2024-10-15</lastmod>
+    <lastmod>2026-01-27</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://futurofortissimo.github.io/tecnologia/</loc>
-    <lastmod>2024-10-15</lastmod>
+    <lastmod>2026-01-27</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://futurofortissimo.github.io/societa/</loc>
-    <lastmod>2024-10-15</lastmod>
+    <lastmod>2026-01-27</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://futurofortissimo.github.io/note/</loc>
-    <lastmod>2024-10-15</lastmod>
+    <lastmod>2026-01-27</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://futurofortissimo.github.io/libri/</loc>
-    <lastmod>2024-10-15</lastmod>
+    <lastmod>2026-01-27</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
+
+  <url>
+    <loc>https://futurofortissimo.github.io/book/</loc>
+    <lastmod>2026-01-27</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url><loc>https://futurofortissimo.github.io/book/chapter-01.html</loc><lastmod>2026-01-27</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://futurofortissimo.github.io/book/chapter-02.html</loc><lastmod>2026-01-27</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://futurofortissimo.github.io/book/chapter-03.html</loc><lastmod>2026-01-27</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://futurofortissimo.github.io/book/chapter-04.html</loc><lastmod>2026-01-27</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://futurofortissimo.github.io/book/chapter-05.html</loc><lastmod>2026-01-27</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://futurofortissimo.github.io/book/chapter-06.html</loc><lastmod>2026-01-27</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://futurofortissimo.github.io/book/chapter-07.html</loc><lastmod>2026-01-27</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://futurofortissimo.github.io/book/chapter-08.html</loc><lastmod>2026-01-27</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://futurofortissimo.github.io/book/chapter-09.html</loc><lastmod>2026-01-27</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://futurofortissimo.github.io/book/chapter-10.html</loc><lastmod>2026-01-27</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://futurofortissimo.github.io/book/chapter-11.html</loc><lastmod>2026-01-27</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://futurofortissimo.github.io/book/chapter-12.html</loc><lastmod>2026-01-27</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://futurofortissimo.github.io/book/chapter-13.html</loc><lastmod>2026-01-27</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://futurofortissimo.github.io/book/chapter-14.html</loc><lastmod>2026-01-27</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
+
   <url>
     <loc>https://futurofortissimo.github.io/themes.html</loc>
     <lastmod>2026-01-27</lastmod>

--- a/themes.html
+++ b/themes.html
@@ -5,11 +5,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Futuro Fortissimo — Indice macro‑temi</title>
   <meta name="description" content="Indice macro-temi di Futuro Fortissimo: mappa dei temi ricorrenti, esempi e percorsi di lettura." />
-  <link rel="canonical" href="./themes.html" />
+  <link rel="canonical" href="https://futurofortissimo.github.io/themes.html" />
 
   <meta property="og:title" content="Futuro Fortissimo — Indice macro‑temi" />
   <meta property="og:description" content="Mappa dei macro-temi ricorrenti nel corpus Futuro Fortissimo." />
   <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://futurofortissimo.github.io/themes.html" />
+  <meta property="og:image" content="https://futurofortissimo.github.io/logo.png" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Futuro Fortissimo — Indice macro‑temi" />
+  <meta name="twitter:description" content="Mappa dei macro-temi ricorrenti nel corpus Futuro Fortissimo." />
+  <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png" />
 
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
This PR brings in the follow-up commit that landed *after* PR #53 was merged, so it wasn't deployed.

## Includes
- Stronger SEO/sharing: canonical + OG/Twitter meta fixes (index + themes/connections)
- Tracking hooks: provider-agnostic ffTrack + ffTrackPage + data-track delegation (GA4-ready)
- Book scaffolding: /book/index.html + chapter-01..14 static pages generated from generated/book/outline.json + JSON-LD
- Sitemap updated to include /book + chapters

## Checks
- npm run build (ok)
