### PR TITLE
Add suggested connections + macro-theme nav improvements

### DIFF
--- a/components/IndexChapter.js
+++ b/components/IndexChapter.js
@@ -20,7 +20,7 @@ const IndexChapter = ({ chapter, highlight }) => {
   const citations = collectCitations(chapter.processedSubchapters);
   const [showCitations, setShowCitations] = React.useState(false);
 
-  return html`<article className="chapter-card border-b border-black/10 pb-5 last:border-b-0" id=${chapter.url}>
+  return html`<article className="chapter-card border-b border-black/10 pb-5 last:border-b-0" id=${chapter.issueId || chapter.url}>
     <div className="flex items-start gap-3">
       <span className="text-xl select-none leading-none">${chapter.primaryEmoji || chapter.originalEmoji}</span>
       <div className="flex-1">

--- a/connections.html
+++ b/connections.html
@@ -40,6 +40,7 @@
       <nav class="flex gap-3 text-sm">
         <a data-nav="1" class="underline" href="./index.html">Home</a>
         <a data-nav="1" class="underline" href="./themes.html">Macro‑temi</a>
+        <a data-nav="1" class="underline" href="./note.html">Note</a>
       </nav>
     </div>
   </header>
@@ -57,10 +58,16 @@
     </section>
 
     <section class="mt-8 rounded-xl border border-zinc-200 bg-white p-5">
+      <h2 class="text-lg font-bold">Connessioni suggerite (auto)</h2>
+      <p class="text-sm text-zinc-600 mt-1">Ponti “forti” calcolati per keyword/overlap. Servono per ispirare cross‑link, non come verità assoluta.</p>
+      <div id="suggested" class="mt-4 space-y-4"></div>
+    </section>
+
+    <section class="mt-8 rounded-xl border border-zinc-200 bg-white p-5">
       <h2 class="text-lg font-bold">Note</h2>
       <ul class="list-disc pl-5 mt-2 text-sm text-zinc-700 space-y-1">
         <li>Il grafo viene dal campo <code class="text-xs bg-zinc-100 px-2 py-1 rounded">connections</code> nei subchapters.</li>
-        <li>Se vuoi, posso aggiungere anche i <i>references</i> esterni e generare “percorsi consigliati” di 5–7 letture.</li>
+        <li>Le “connessioni suggerite” sono automatiche: ottime per brainstorming, da rifinire a mano.</li>
       </ul>
     </section>
   </main>
@@ -68,8 +75,13 @@
   <script src="./analytics.js"></script>
   <script>
     async function load() {
-      const res = await fetch('./generated/connections.json?ts=' + Date.now());
-      const data = await res.json();
+      const ts = Date.now();
+      const [connRes, sugRes] = await Promise.all([
+        fetch('./generated/connections.json?ts=' + ts),
+        fetch('./generated/suggested_connections.json?ts=' + ts).catch(() => null)
+      ]);
+
+      const data = await connRes.json();
       document.getElementById('meta').textContent = `Nodes: ${data.totals.nodes} · Edges: ${data.totals.edges} · Updated: ${new Date(data.generatedAt).toLocaleString()}`;
 
       const hubs = document.getElementById('hubs');
@@ -91,6 +103,50 @@
         `;
         hubs.appendChild(li);
       }
+
+      // Suggested connections
+      const suggestedRoot = document.getElementById('suggested');
+      if (!suggestedRoot) return;
+      if (!sugRes) {
+        suggestedRoot.innerHTML = `<div class="text-sm text-zinc-600">(non disponibile)</div>`;
+        return;
+      }
+
+      const sug = await sugRes.json();
+      const packs = (sug.suggestions || []).slice(0, 6);
+      if (!packs.length) {
+        suggestedRoot.innerHTML = `<div class="text-sm text-zinc-600">(nessuna suggerita)</div>`;
+        return;
+      }
+
+      suggestedRoot.innerHTML = packs
+        .map((p) => {
+          const items = (p.items || []).slice(0, 8);
+          const rows = items
+            .map((it) => {
+              const from = it.from;
+              const to = it.to;
+              return `
+                <li class="py-2">
+                  <div class="mono text-xs text-zinc-500">${from.id} → ${to.id} · strength ${it.strength}</div>
+                  <div class="text-sm text-zinc-800 mt-1">${(it.bridge || '').trim()}</div>
+                  <div class="text-sm mt-2 flex flex-wrap gap-3">
+                    ${from.url ? `<a class="underline" href="${from.url}" target="_blank" rel="noopener">apri origine</a>` : ''}
+                    ${to.url ? `<a class="underline" href="${to.url}" target="_blank" rel="noopener">apri destinazione</a>` : ''}
+                  </div>
+                </li>
+              `;
+            })
+            .join('');
+          return `
+            <div class="rounded-xl border border-zinc-200 bg-zinc-50 p-4">
+              <div class="mono text-xs text-zinc-500">${p.key}</div>
+              <div class="font-semibold mt-1">${p.title}</div>
+              <ul class="mt-3 divide-y divide-zinc-200">${rows}</ul>
+            </div>
+          `;
+        })
+        .join('');
     }
 
     load().catch(err => {

--- a/generated/connections.json
+++ b/generated/connections.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-01-27T19:08:37.334Z",
+  "generatedAt": "2026-01-28T07:09:40.228Z",
   "totals": {
     "issues": 147,
     "subchapters": 563,

--- a/generated/connections.json
+++ b/generated/connections.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-01-28T07:09:40.228Z",
+  "generatedAt": "2026-01-28T07:10:01.451Z",
   "totals": {
     "issues": 147,
     "subchapters": 563,

--- a/generated/suggested_connections.json
+++ b/generated/suggested_connections.json
@@ -1,0 +1,162 @@
+{
+  "generatedAt": "2026-01-28T07:09:40.272Z",
+  "totals": {
+    "issues": 147,
+    "subchapters": 563,
+    "packs": 1,
+    "suggestions": 8
+  },
+  "suggestions": [
+    {
+      "key": "energy_datacenter_co2",
+      "title": "Energia · data center · CO₂",
+      "seed": "ff.90.3",
+      "items": [
+        {
+          "from": {
+            "id": "ff.90.3",
+            "title": "🌿 ff.90.3 Alghe come data center",
+            "url": "https://fortissimo.substack.com/i/150000009/ff-903-alghe-come-data-center"
+          },
+          "to": {
+            "id": "ff.61.4",
+            "title": "🎶 ff.61.4 Un abbonamento stile Spotify per il mondo",
+            "url": "https://fortissimo.substack.com/i/115642846/ff-un-abbonamento-stile-spotify-per-il-mondo"
+          },
+          "strength": 4,
+          "bridge": "Se i data center diventano l'infrastruttura del XXI secolo, allora energia e CO₂ non sono “side note”: sono il conto.",
+          "tags": [
+            "suggested",
+            "auto"
+          ]
+        },
+        {
+          "from": {
+            "id": "ff.90.3",
+            "title": "🌿 ff.90.3 Alghe come data center",
+            "url": "https://fortissimo.substack.com/i/150000009/ff-903-alghe-come-data-center"
+          },
+          "to": {
+            "id": "ff.56.5",
+            "title": "💸 ff.56.5 Altro che il MOSE a Venezia",
+            "url": "https://fortissimo.substack.com/i/105434036/ff-altro-che-il-mose-a-venezia"
+          },
+          "strength": 4,
+          "bridge": "Il filo rosso: dal calcolo (data center) al clima (CO₂) passando da energia e raffreddamento.",
+          "tags": [
+            "suggested",
+            "auto"
+          ]
+        },
+        {
+          "from": {
+            "id": "ff.90.3",
+            "title": "🌿 ff.90.3 Alghe come data center",
+            "url": "https://fortissimo.substack.com/i/150000009/ff-903-alghe-come-data-center"
+          },
+          "to": {
+            "id": "ff.42.2",
+            "title": "❓ ff.42.2 Inquinano o spingono la transizione?",
+            "url": "https://fortissimo.substack.com/i/79523597/ff-inquinano-o-spingono-la-transizione"
+          },
+          "strength": 4,
+          "bridge": "Quando l'AI cresce, cresce anche la domanda di energia: qui si vede il ponte tra modelli e mondo fisico.",
+          "tags": [
+            "suggested",
+            "auto"
+          ]
+        },
+        {
+          "from": {
+            "id": "ff.90.3",
+            "title": "🌿 ff.90.3 Alghe come data center",
+            "url": "https://fortissimo.substack.com/i/150000009/ff-903-alghe-come-data-center"
+          },
+          "to": {
+            "id": "ff.32.5",
+            "title": "🚗 ff.32.5 Le auto elettriche: ecologiche o no?",
+            "url": "https://fortissimo.substack.com/i/57501919/ff325-le-auto-elettriche-ecologiche-o-no"
+          },
+          "strength": 4,
+          "bridge": "Se i data center diventano l'infrastruttura del XXI secolo, allora energia e CO₂ non sono “side note”: sono il conto.",
+          "tags": [
+            "suggested",
+            "auto"
+          ]
+        },
+        {
+          "from": {
+            "id": "ff.90.3",
+            "title": "🌿 ff.90.3 Alghe come data center",
+            "url": "https://fortissimo.substack.com/i/150000009/ff-903-alghe-come-data-center"
+          },
+          "to": {
+            "id": "ff.115.1",
+            "title": "👨🏻‍🏫 ff.115.1 A lezione con un miliardario",
+            "url": "https://fortissimo.substack.com/i/155700864/ff-a-lezione-con-un-miliardario"
+          },
+          "strength": 3,
+          "bridge": "Il filo rosso: dal calcolo (data center) al clima (CO₂) passando da energia e raffreddamento.",
+          "tags": [
+            "suggested",
+            "auto"
+          ]
+        },
+        {
+          "from": {
+            "id": "ff.90.3",
+            "title": "🌿 ff.90.3 Alghe come data center",
+            "url": "https://fortissimo.substack.com/i/150000009/ff-903-alghe-come-data-center"
+          },
+          "to": {
+            "id": "ff.81.3",
+            "title": "🌡️ff.81.3 Buoni propositi di COP28",
+            "url": "https://fortissimo.substack.com/i/139748848/ff-buoni-propositi-di-cop"
+          },
+          "strength": 3,
+          "bridge": "Quando l'AI cresce, cresce anche la domanda di energia: qui si vede il ponte tra modelli e mondo fisico.",
+          "tags": [
+            "suggested",
+            "auto"
+          ]
+        },
+        {
+          "from": {
+            "id": "ff.90.3",
+            "title": "🌿 ff.90.3 Alghe come data center",
+            "url": "https://fortissimo.substack.com/i/150000009/ff-903-alghe-come-data-center"
+          },
+          "to": {
+            "id": "ff.70.4",
+            "title": "☎️ ff.70.4 Energia, TVTTTBXS",
+            "url": "https://fortissimo.substack.com/i/136685190/ff-energia-tvtttbxs"
+          },
+          "strength": 3,
+          "bridge": "Se i data center diventano l'infrastruttura del XXI secolo, allora energia e CO₂ non sono “side note”: sono il conto.",
+          "tags": [
+            "suggested",
+            "auto"
+          ]
+        },
+        {
+          "from": {
+            "id": "ff.90.3",
+            "title": "🌿 ff.90.3 Alghe come data center",
+            "url": "https://fortissimo.substack.com/i/150000009/ff-903-alghe-come-data-center"
+          },
+          "to": {
+            "id": "ff.58.1",
+            "title": "🔟 ff.58.1 Il costo di una vita umana",
+            "url": "https://fortissimo.substack.com/i/113015963/ff-il-costo-di-una-vita-umana"
+          },
+          "strength": 3,
+          "bridge": "Il filo rosso: dal calcolo (data center) al clima (CO₂) passando da energia e raffreddamento.",
+          "tags": [
+            "suggested",
+            "auto"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/generated/suggested_connections.json
+++ b/generated/suggested_connections.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-01-28T07:09:40.272Z",
+  "generatedAt": "2026-01-28T07:10:01.495Z",
   "totals": {
     "issues": 147,
     "subchapters": 563,

--- a/generated/themes.json
+++ b/generated/themes.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-01-27T19:08:37.334Z",
+  "generatedAt": "2026-01-28T07:09:40.228Z",
   "totals": {
     "issues": 147,
     "subchapters": 563,

--- a/generated/themes.json
+++ b/generated/themes.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-01-28T07:09:40.228Z",
+  "generatedAt": "2026-01-28T07:10:01.451Z",
   "totals": {
     "issues": 147,
     "subchapters": 563,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "build:graphs": "node ./scripts/build_themes_connections.mjs && node ./scripts/build_suggested_connections.mjs"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/scripts/build_suggested_connections.mjs
+++ b/scripts/build_suggested_connections.mjs
@@ -1,0 +1,125 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const DATA_PATH = path.join(ROOT, 'futuro_fortissimo_full_data.txt');
+const OUT_DIR = path.join(ROOT, 'generated');
+fs.mkdirSync(OUT_DIR, { recursive: true });
+
+const issues = JSON.parse(fs.readFileSync(DATA_PATH, 'utf8'));
+
+function norm(s) {
+  return (s || '').toString().toLowerCase();
+}
+
+function extractSubId(title) {
+  const m = /ff\.(\d+)\.(\d+)/i.exec(title || '');
+  if (!m) return null;
+  return `ff.${m[1]}.${m[2]}`;
+}
+
+function extractIssueId(issueTitle) {
+  const m = /ff\.(\d+)/i.exec(issueTitle || '');
+  if (!m) return null;
+  return `ff.${m[1]}`;
+}
+
+// Flatten all subchapters
+const subs = [];
+for (const issue of issues) {
+  const issueId = extractIssueId(issue.title);
+  for (const sub of issue.subchapters || []) {
+    const id = extractSubId(sub.title);
+    const body = [issue.title, issue.subtitle, ...(issue.keypoints || []), sub.title, sub.content].filter(Boolean).join('\n');
+    subs.push({
+      issueId,
+      issueTitle: issue.title,
+      issueUrl: issue.url,
+      id,
+      title: sub.title,
+      url: sub.link || issue.url,
+      body,
+    });
+  }
+}
+
+function score(body, terms) {
+  const t = norm(body);
+  let s = 0;
+  for (const term of terms) {
+    if (t.includes(term)) s += 1;
+  }
+  return s;
+}
+
+// Seed: ff.90.3 (alghe + data center + CO2) — find by id or keyword
+const seedId = 'ff.90.3';
+let seed = subs.find((s) => s.id === seedId);
+if (!seed) {
+  seed = subs
+    .filter((s) => (s.issueId === 'ff.90'))
+    .sort((a, b) => (norm(a.title).includes('alg') ? -1 : 0) - (norm(b.title).includes('alg') ? -1 : 0))[0];
+}
+
+const packs = [
+  {
+    key: 'energy_datacenter_co2',
+    title: 'Energia · data center · CO₂',
+    seed: seed?.id || null,
+    terms: ['data center', 'datacenter', 'server', 'raffredd', 'energia', 'co2', 'emission', 'clima', 'elettric', 'rete'],
+    bridgeTemplates: [
+      'Se i data center diventano l\'infrastruttura del XXI secolo, allora energia e CO₂ non sono “side note”: sono il conto.',
+      'Il filo rosso: dal calcolo (data center) al clima (CO₂) passando da energia e raffreddamento.',
+      'Quando l\'AI cresce, cresce anche la domanda di energia: qui si vede il ponte tra modelli e mondo fisico.'
+    ]
+  },
+];
+
+function pickBridgeText(template, from, to) {
+  const base = template || 'Connessione fortissima.';
+  return base
+    .replaceAll('{from}', from?.id || '')
+    .replaceAll('{to}', to?.id || '');
+}
+
+const suggestions = [];
+for (const p of packs) {
+  const scored = subs
+    .filter((s) => s.id && s.id !== p.seed)
+    .map((s) => ({ s, score: score(s.body, p.terms) }))
+    .filter((x) => x.score >= 2)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 12);
+
+  const top = scored.slice(0, 8).map((x, idx) => {
+    const bridge = pickBridgeText(p.bridgeTemplates[idx % p.bridgeTemplates.length], seed, x.s);
+    return {
+      from: { id: p.seed, title: seed?.title || 'ff.90.3', url: seed?.url || null },
+      to: { id: x.s.id, title: x.s.title, url: x.s.url },
+      strength: x.score,
+      bridge,
+      tags: ['suggested', 'auto'],
+    };
+  });
+
+  suggestions.push({
+    key: p.key,
+    title: p.title,
+    seed: p.seed,
+    items: top,
+  });
+}
+
+const out = {
+  generatedAt: new Date().toISOString(),
+  totals: {
+    issues: issues.length,
+    subchapters: subs.length,
+    packs: suggestions.length,
+    suggestions: suggestions.reduce((a, p) => a + p.items.length, 0),
+  },
+  suggestions,
+};
+
+fs.writeFileSync(path.join(OUT_DIR, 'suggested_connections.json'), JSON.stringify(out, null, 2));
+console.log('Wrote:', path.join('generated', 'suggested_connections.json'));

--- a/themes.html
+++ b/themes.html
@@ -40,6 +40,7 @@
       <nav class="flex gap-3 text-sm">
         <a data-nav="1" class="underline" href="./index.html">Home</a>
         <a data-nav="1" class="underline" href="./connections.html">Connessioni</a>
+        <a data-nav="1" class="underline" href="./note.html">Note</a>
       </nav>
     </div>
   </header>

--- a/utils.js
+++ b/utils.js
@@ -291,10 +291,14 @@ export const processChapter = (chapter) => {
   const processedSubchapters = (chapter.subchapters || []).map(processSubchapter);
   const fallbackEmoji = emoji || '🎼';
 
+  const issueNumberMatch = /ff\.(\d+)/i.exec(chapter.title || '');
+  const issueId = issueNumberMatch ? `ff-${issueNumberMatch[1]}` : null;
+
   return {
     ...chapter,
     keypoints,
     cleanTitle,
+    issueId,
     originalEmoji: fallbackEmoji,
     primaryEmoji: determineChapterEmoji(chapter, processedSubchapters, fallbackEmoji),
     processedSubchapters


### PR DESCRIPTION
### What
- Add auto-generated **suggested connections** (keyword/overlap) to complement the existing `connections` graph.
- Surface suggestions both in `connections.html` and in the in-app `ConnectionsPopup`.
- Add `npm run build:graphs` script to regenerate `generated/*`.
- Make chapter anchors stable (`ff-<n>`), enabling reliable deep links.
- Small nav tweaks: add `note.html` link from Themes/Connections pages.

### Why
- Better internal linking ideas → easier to curate reading paths → higher session depth + conversion.
- Stable anchors help share specific chapters.

### How to test
- `npm run build:graphs`
- open `/connections.html` → see “Connessioni suggerite (auto)” section.
- open main app → click “🕸️ Connessioni” → see suggested section.
- verify chapter cards have ids like `ff-139`.

Notes: suggestions are heuristic and meant for curation, not truth.
