### PR TITLE
Add GA4 gtag to homepage and main section entry pages

### DIFF
--- a/book/index.html
+++ b/book/index.html
@@ -21,7 +21,17 @@
 
   <link rel="icon" href="/favicon.ico" />
 
-  <script src="https://cdn.tailwindcss.com"></script>
+  
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-NQ7MQR0VL8"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-NQ7MQR0VL8');
+    </script>
+
+    <script src="https://cdn.tailwindcss.com"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@600;700&family=Press+Start+2P&display=swap" rel="stylesheet">

--- a/index.html
+++ b/index.html
@@ -19,6 +19,15 @@
     <meta name="twitter:description" content="Archivio tipografico: letture, note e percorsi." />
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png" />
 
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-NQ7MQR0VL8"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-NQ7MQR0VL8');
+    </script>
+
     
     <!-- Tailwind CSS -->
     <script src="https://cdn.tailwindcss.com"></script>

--- a/libri/index.html
+++ b/libri/index.html
@@ -326,6 +326,16 @@
             }
         }
     </style>
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-NQ7MQR0VL8"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-NQ7MQR0VL8');
+    </script>
+
 </head>
 <body>
     <div class="app-container">

--- a/natura/index.html
+++ b/natura/index.html
@@ -282,6 +282,16 @@
             }
         }
     </style>
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-NQ7MQR0VL8"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-NQ7MQR0VL8');
+    </script>
+
 </head>
 <body>
     <div class="app-container">

--- a/societa/index.html
+++ b/societa/index.html
@@ -315,6 +315,16 @@
             }
         }
     </style>
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-NQ7MQR0VL8"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-NQ7MQR0VL8');
+    </script>
+
 </head>
 
 <body>

--- a/tecnologia/index.html
+++ b/tecnologia/index.html
@@ -10,6 +10,16 @@
     <link rel="canonical" href="https://futurofortissimo.github.io/tecnologia/">
     <link rel="icon" href="/index_files/ff.webp" type="image/webp">
     <link rel="apple-touch-icon" href="/index_files/ff.webp">
+    
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-NQ7MQR0VL8"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-NQ7MQR0VL8');
+    </script>
+
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@600;700&family=Press+Start+2P&display=swap" rel="stylesheet">
     <style>


### PR DESCRIPTION
### Motivation
- The site lacked the Google Analytics 4 initialization on several entry pages so pageviews were not being sent to the provided Measurement ID `G-NQ7MQR0VL8`.
- Adding the `gtag.js` snippet ensures consistent pageview/event collection across the main site sections.

### Description
- Inserted the GA4 global site tag snippet (async load of `https://www.googletagmanager.com/gtag/js?id=G-NQ7MQR0VL8`, `window.dataLayer` init, `gtag('js', new Date())`, and `gtag('config', 'G-NQ7MQR0VL8')`) into the `<head>` of the main entry pages.
- Files updated: `index.html`, `tecnologia/index.html`, `societa/index.html`, `natura/index.html`, `book/index.html`, and `libri/index.html`.
- The snippet was placed near other head resources (immediately before or alongside existing head scripts such as Tailwind and fonts) so analytics initializes early on page load.

### Testing
- Verified presence of the GA script URL and config call on each updated page using `rg -n "googletagmanager.com/gtag/js?id=G-NQ7MQR0VL8|gtag('config', 'G-NQ7MQR0VL8')"` which reported matches in all modified files (success).
- Confirmed the modified pages contain both the `https://www.googletagmanager.com/gtag/js?id=G-NQ7MQR0VL8` script tag and the `gtag('config', 'G-NQ7MQR0VL8')` initialization (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c7665499c8320babad9b1b05c4dca)