### PR TITLE
Index UX: per-subchapter link toggles + remove preview summary lines

### DIFF
--- a/App.js
+++ b/App.js
@@ -84,7 +84,17 @@ const InnerApp = () => {
   const { incrementInteraction, searchQuery, setSearchQuery, debouncedSearchQuery } = useNavigation();
 
   React.useEffect(() => {
-    const processed = rawData.map(processChapter).filter(Boolean);
+    const getIssueNumber = (chapter) => {
+      const label = chapter?.ffLabel || chapter?.title || '';
+      const match = /ff\.(\d+)/i.exec(label);
+      return match ? Number(match[1]) : -1;
+    };
+
+    const processed = rawData
+      .map(processChapter)
+      .filter(Boolean)
+      .sort((a, b) => getIssueNumber(b) - getIssueNumber(a));
+
     setProcessedData(processed);
   }, []);
 

--- a/components/IndexChapter.js
+++ b/components/IndexChapter.js
@@ -2,24 +2,18 @@ import { React, html } from '../runtime.js';
 import { HighlightText, isLinkValid } from '../utils.js';
 import { t } from '../i18n.js';
 
-const collectCitations = (subchapters = []) => {
+const collectSubchapterCitations = (sub) => {
   const seen = new Set();
-
-  return subchapters.reduce((acc, sub) => {
-    [...(sub.references || []), ...(sub.connections || [])].forEach((ref) => {
-      if (!isLinkValid(ref.text, ref.url)) return;
-      const key = ref.url || ref.text;
-      if (seen.has(key)) return;
-      seen.add(key);
-      acc.push(ref);
-    });
-    return acc;
-  }, []);
+  return [...(sub.references || []), ...(sub.connections || [])].filter((ref) => {
+    if (!isLinkValid(ref?.text, ref?.url)) return false;
+    const key = ref.url || ref.text;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
 };
 
 const IndexChapter = ({ chapter, highlight }) => {
-  const citations = collectCitations(chapter.processedSubchapters);
-  const [showCitations, setShowCitations] = React.useState(false);
 
   return html`<article className="chapter-card border-b border-black/10 pb-4 sm:pb-5 last:border-b-0" id=${chapter.issueId || chapter.url}>
     <div className="flex items-start gap-2 sm:gap-3">
@@ -50,8 +44,9 @@ const IndexChapter = ({ chapter, highlight }) => {
     </div>
 
     <div className="mt-3 sm:mt-5 space-y-2 sm:space-y-3">
-      ${chapter.processedSubchapters.map((sub, idx) =>
-        html`<div key=${idx} className="flex gap-2 items-start">
+      ${chapter.processedSubchapters.map((sub, idx) => {
+        const citations = collectSubchapterCitations(sub);
+        return html`<div key=${idx} className="flex gap-2 items-start">
           <span className="text-lg sm:text-xl leading-none mt-0.5">${sub.originalEmoji}</span>
           <div className="flex-1 min-w-0">
             ${sub.ffLabel ? html`<span className="ff-label ff-label-sub">${sub.ffLabel}</span> ` : null}
@@ -63,44 +58,31 @@ const IndexChapter = ({ chapter, highlight }) => {
             >
               <${HighlightText} text=${sub.cleanTitle} highlight=${highlight} />
             </a>
-            ${sub.summary
-              ? html`<p className="ff-body-sm text-black/70 leading-snug mt-1">
-                  <${HighlightText} text=${sub.summary} highlight=${highlight} />
-                </p>`
+
+            ${citations.length
+              ? html`<details className="mt-2">
+                  <summary className="links-toggle inline-flex items-center gap-2 border-3 border-black bg-white brutal-shadow ff-button px-3 py-2 cursor-pointer">
+                    ${t('showCitations')} (${citations.length})
+                  </summary>
+                  <div className="flex flex-wrap gap-2 mt-3">
+                    ${citations.map((ref, refIdx) =>
+                      html`<a
+                        key=${refIdx}
+                        href=${ref.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center bg-[var(--ff-yellow)] ff-caption px-2 py-1 text-black hover:underline decoration-2 brutal-shadow"
+                      >
+                        <${HighlightText} text=${ref.text} highlight=${highlight} />
+                      </a>`
+                    )}
+                  </div>
+                </details>`
               : null}
           </div>
-        </div>`
-      )}
+        </div>`;
+      })}
     </div>
-
-    ${citations.length
-      ? html`<div className="mt-5 border-t border-black/10 pt-3">
-          <button
-            type="button"
-            className="links-toggle inline-flex items-center gap-2 border-3 border-black bg-white brutal-shadow ff-button px-3 py-2"
-            onClick=${() => setShowCitations((prev) => !prev)}
-            aria-expanded=${showCitations}
-          >
-            ${showCitations ? t('hideCitations') : `${t('showCitations')} (${citations.length})`}
-            <span aria-hidden="true">${showCitations ? '▲' : '▼'}</span>
-          </button>
-          ${showCitations
-            ? html`<div className="flex flex-wrap gap-2 mt-3">
-                ${citations.map((ref, idx) =>
-                  html`<a
-                    key=${idx}
-                    href=${ref.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center bg-[var(--ff-yellow)] ff-caption px-2 py-1 text-black hover:underline decoration-2 brutal-shadow"
-                  >
-                    <${HighlightText} text=${ref.text} highlight=${highlight} />
-                  </a>`
-                )}
-              </div>`
-            : null}
-        </div>`
-      : null}
   </article>`;
 };
 


### PR DESCRIPTION
## Changes\n- Remove subchapter preview summary text from index cards (e.g. lines like "In 3 mesi...")\n- Move reference links from chapter-level toggle to each individual subchapter\n- Add per-subchapter collapsible toggle () showing only that subchapter's links\n\n## Why\n- Cleaner mobile reading\n- Links stay attached to the exact subchapter where they appear\n- Avoid noisy long preview text in front page