### PR TITLE
Refactor language switcher and improve modal accessibility

### DIFF
--- a/App.js
+++ b/App.js
@@ -371,8 +371,8 @@ const InnerApp = () => {
     </div>
 
     ${isMediaOpen
-      ? html`<div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
-          <div role="dialog" aria-modal="true" aria-label="Media deck" className="relative max-w-5xl w-full">
+      ? html`<div className="fixed inset-0 z-50 flex items-start justify-center p-4 bg-black/60 backdrop-blur-sm overflow-y-auto">
+          <div role="dialog" aria-modal="true" aria-label="Media deck" className="relative max-w-5xl w-full my-auto">
             <div className="absolute right-4 top-4 z-10">
               <button
                 onClick=${handleCloseMedia}

--- a/components/BooksPopup.js
+++ b/components/BooksPopup.js
@@ -56,9 +56,9 @@ const BooksPopup = ({ isOpen, onClose, books }) => {
     .filter(Boolean)
     .join(' · ');
 
-  return html`<div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/40 backdrop-blur-sm" onClick=${onClose}>
+  return html`<div className="fixed inset-0 z-50 flex items-start justify-center p-4 bg-black/40 backdrop-blur-sm overflow-y-auto" onClick=${onClose}>
     <div
-      className="bg-white border-4 border-black brutal-shadow max-w-2xl w-full overflow-hidden animate-in fade-in zoom-in-95 duration-300 no-round"
+      className="bg-white border-4 border-black brutal-shadow max-w-2xl w-full overflow-y-auto max-h-[90dvh] animate-in fade-in zoom-in-95 duration-300 no-round my-auto"
       onClick=${(e) => e.stopPropagation()}
     >
       <div className="relative p-6 md:p-8 bg-white accent-bar accent-yellow">

--- a/components/MediaSlider.js
+++ b/components/MediaSlider.js
@@ -1,4 +1,5 @@
 import { React, html } from '../runtime.js';
+import { t } from '../i18n.js';
 
 const extractReference = (title = '') => {
   const match = title.match(/ff\.?\d+(\.\d+)?/i);
@@ -51,12 +52,12 @@ const MediaSlider = ({ chapters }) => {
 
   const captionText = currentItem.caption?.trim();
 
-  return html`<section className="mb-12 md:mb-16">
+  return html`<section>
     <div className="relative overflow-hidden brutal-card no-round bg-white accent-bar accent-yellow">
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_1px_1px,#000_1px,transparent_0)] [background-size:22px_22px] opacity-10 pointer-events-none"></div>
       <div className="relative p-5 md:p-8 flex flex-col gap-6">
         <div className="flex items-center justify-between gap-4">
-          <h2 className="font-heading ff-heading-lg text-black tracking-tight">Media dall'archivio</h2>
+          <h2 className="font-heading ff-heading-lg text-black tracking-tight">${t('mediaTitle')}</h2>
           <div className="flex gap-2">
             <button aria-label="Previous media" onClick=${goToPrev} className="h-10 w-10 border-3 border-black bg-white brutal-shadow hover:-translate-y-1 transition-transform">⟵</button>
             <button aria-label="Next media" onClick=${goToNext} className="h-10 w-10 border-3 border-black bg-white brutal-shadow hover:-translate-y-1 transition-transform">⟶</button>

--- a/components/SupportPopup.js
+++ b/components/SupportPopup.js
@@ -18,8 +18,8 @@ const SupportPopup = () => {
 
   if (!showSupportPopup) return null;
 
-  return html`<div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/40 backdrop-blur-sm">
-    <div className="bg-white border-4 border-black brutal-shadow max-w-xl w-full overflow-hidden animate-in fade-in zoom-in-95 duration-300 no-round">
+  return html`<div className="fixed inset-0 z-50 flex items-start justify-center p-4 bg-black/40 backdrop-blur-sm overflow-y-auto">
+    <div className="bg-white border-4 border-black brutal-shadow max-w-xl w-full overflow-y-auto max-h-[90dvh] animate-in fade-in zoom-in-95 duration-300 no-round my-auto">
       <div className="relative p-6 md:p-8 bg-white accent-bar accent-blue">
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_1px_1px,#000_1px,transparent_0)] [background-size:20px_20px] opacity-10 pointer-events-none"></div>
         <div className="relative space-y-5">

--- a/en/index.html
+++ b/en/index.html
@@ -363,16 +363,20 @@
         border-bottom: 2px solid var(--ff-yellow);
       }
     </style>
+    <!-- Redirect to Google Translate English version of the Italian site -->
+    <script>
+      window.location.replace('https://futurofortissimo-github-io.translate.goog/?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=it&_x_tr_pto=wapp');
+    </script>
 </head>
   <body class="bg-white text-gray-900 antialiased selection:bg-gray-900 selection:text-white">
     <!-- Language switcher bar -->
     <nav class="ff-lang-bar" aria-label="Language">
       <div class="max-w-5xl mx-auto flex items-center justify-end gap-1 px-4 py-1">
-        <a href="/" title="Italiano">IT</a>
-        <span class="text-gray-600 select-none">/</span>
-        <a href="/en/" aria-current="page" title="English">EN</a>
-        <span class="text-gray-600 select-none">/</span>
-        <a href="/hi/" title="Hindi">HI</a>
+        <a href="https://futurofortissimo.github.io/" title="Italiano">IT</a>
+        <span style="color:rgba(255,255,255,0.3);user-select:none;">/</span>
+        <a href="https://futurofortissimo-github-io.translate.goog/?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=it&_x_tr_pto=wapp" aria-current="page" title="English" rel="noopener">EN</a>
+        <span style="color:rgba(255,255,255,0.3);user-select:none;">/</span>
+        <a href="https://futurofortissimo-github-io.translate.goog/?_x_tr_sl=auto&_x_tr_tl=hi&_x_tr_hl=it&_x_tr_pto=wapp" title="Hindi" rel="noopener">HI</a>
       </div>
     </nav>
 

--- a/hi/index.html
+++ b/hi/index.html
@@ -328,36 +328,45 @@
       }
 
       /* Language switcher bar */
-      .lang-bar {
+      .ff-lang-bar {
         font-family: 'IBM Plex Mono', monospace;
-        font-size: 0.7rem;
-        letter-spacing: 0.18em;
-        font-weight: 700;
+        font-size: 0.6875rem;
+        letter-spacing: 0.16em;
         text-transform: uppercase;
+        font-weight: 700;
         background: var(--ff-black);
         color: #fff;
-        text-align: center;
-        padding: 6px 0;
       }
-      .lang-bar a {
-        color: rgba(255,255,255,0.6);
+      .ff-lang-bar a {
+        color: rgba(255, 255, 255, 0.55);
         text-decoration: none;
-        padding: 0 6px;
+        padding: 6px 8px;
+        transition: color 0.15s ease;
       }
-      .lang-bar a:hover {
+      .ff-lang-bar a:hover {
         color: #fff;
       }
-      .lang-bar .current {
+      .ff-lang-bar a[aria-current="page"] {
         color: #fff;
         border-bottom: 2px solid var(--ff-yellow);
       }
     </style>
+    <!-- Redirect to Google Translate Hindi version of the Italian site -->
+    <script>
+      window.location.replace('https://futurofortissimo-github-io.translate.goog/?_x_tr_sl=auto&_x_tr_tl=hi&_x_tr_hl=it&_x_tr_pto=wapp');
+    </script>
 </head>
   <body class="bg-white text-gray-900 antialiased selection:bg-gray-900 selection:text-white">
-    <!-- Language Switcher Bar -->
-    <div class="lang-bar">
-      <a href="/">IT</a> | <a href="/en/">EN</a> | <a href="/hi/" class="current">HI</a>
-    </div>
+    <!-- Language switcher bar -->
+    <nav class="ff-lang-bar" aria-label="Language">
+      <div class="max-w-5xl mx-auto flex items-center justify-end gap-1 px-4 py-1">
+        <a href="https://futurofortissimo.github.io/" title="Italiano">IT</a>
+        <span style="color:rgba(255,255,255,0.3);user-select:none;">/</span>
+        <a href="https://futurofortissimo-github-io.translate.goog/?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=it&_x_tr_pto=wapp" title="English" rel="noopener">EN</a>
+        <span style="color:rgba(255,255,255,0.3);user-select:none;">/</span>
+        <a href="https://futurofortissimo-github-io.translate.goog/?_x_tr_sl=auto&_x_tr_tl=hi&_x_tr_hl=it&_x_tr_pto=wapp" aria-current="page" title="Hindi" rel="noopener">HI</a>
+      </div>
+    </nav>
     <div id="root"></div>
     <script type="module" src="../analytics.js"></script>
     <script type="module" src="../index.js"></script>

--- a/i18n.js
+++ b/i18n.js
@@ -79,6 +79,7 @@ const translations = {
     filterByEmoji: 'Filtra per emoji',
     supportTitle: 'Sostieni Futuro Fortissimo',
     paypalHint: 'Il modo pi\u00f9 rapido per mandare un grazie e supportare l\u2019archivio.',
+    mediaTitle: "Media dall'archivio",
   },
   en: {
     searchPlaceholder: 'Search stories...',
@@ -160,6 +161,7 @@ const translations = {
     filterByEmoji: 'Filter by emoji',
     supportTitle: 'Support Futuro Fortissimo',
     paypalHint: 'The quickest way to say thanks and support the archive.',
+    mediaTitle: 'Media from the archive',
   },
   hi: {
     searchPlaceholder: 'कहानियाँ खोजें...',
@@ -241,6 +243,7 @@ const translations = {
     filterByEmoji: 'इमोजी के अनुसार फ़िल्टर करें',
     supportTitle: 'फ्यूचरो फोर्टिसिमो का समर्थन करें',
     paypalHint: 'धन्यवाद कहने और संग्रह का समर्थन करने का सबसे तेज़ तरीका।',
+    mediaTitle: 'संग्रह से मीडिया',
   }
 };
 

--- a/index.html
+++ b/index.html
@@ -346,15 +346,43 @@
           -ms-overflow-style: none;  /* IE and Edge */
           scrollbar-width: none;  /* Firefox */
       }
+
+      /* Language switcher bar */
+      .ff-lang-bar {
+        font-family: 'IBM Plex Mono', monospace;
+        font-size: 0.6875rem;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        font-weight: 700;
+        background: var(--ff-black);
+        color: #fff;
+      }
+      .ff-lang-bar a {
+        color: rgba(255, 255, 255, 0.55);
+        text-decoration: none;
+        padding: 6px 8px;
+        transition: color 0.15s ease;
+      }
+      .ff-lang-bar a:hover {
+        color: #fff;
+      }
+      .ff-lang-bar a[aria-current="page"] {
+        color: #fff;
+        border-bottom: 2px solid var(--ff-yellow);
+      }
     </style>
 </head>
   <body class="bg-white text-gray-900 antialiased selection:bg-gray-900 selection:text-white">
-    <!-- Language Switcher -->
-    <div style="background:#0a0a0a;padding:6px 16px;display:flex;justify-content:flex-end;gap:12px;font-family:'IBM Plex Mono',monospace;font-size:0.7rem;letter-spacing:0.2em;text-transform:uppercase;">
-      <span style="color:#fff;font-weight:700;">IT</span>
-      <a href="/en/" style="color:#888;text-decoration:none;">EN</a>
-      <a href="/hi/" style="color:#888;text-decoration:none;">HI</a>
-    </div>
+    <!-- Language switcher bar -->
+    <nav class="ff-lang-bar" aria-label="Language">
+      <div class="max-w-5xl mx-auto flex items-center justify-end gap-1 px-4 py-1">
+        <a href="https://futurofortissimo.github.io/" aria-current="page" title="Italiano">IT</a>
+        <span style="color:rgba(255,255,255,0.3);user-select:none;">/</span>
+        <a href="https://futurofortissimo-github-io.translate.goog/?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=it&_x_tr_pto=wapp" title="English" rel="noopener">EN</a>
+        <span style="color:rgba(255,255,255,0.3);user-select:none;">/</span>
+        <a href="https://futurofortissimo-github-io.translate.goog/?_x_tr_sl=auto&_x_tr_tl=hi&_x_tr_hl=it&_x_tr_pto=wapp" title="Hindi" rel="noopener">HI</a>
+      </div>
+    </nav>
     <div id="root"></div>
     <script type="module" src="./analytics.js"></script>
     <script type="module" src="./index.js"></script>


### PR DESCRIPTION
## Summary
This PR refactors the language switcher component across all language versions, consolidates styling, improves modal accessibility for mobile devices, and adds internationalization support for the media section title.

## Key Changes

- **Language Switcher Refactoring**
  - Unified `.ff-lang-bar` CSS class across all HTML files (main, en, hi)
  - Standardized styling with consistent font sizing (0.6875rem), letter-spacing (0.16em), and padding
  - Replaced inline styles with semantic CSS classes
  - Updated language links to use full URLs (Google Translate for EN/HI versions)
  - Added `aria-current="page"` attribute for current language indication instead of `.current` class
  - Added visual separators (/) between language options with proper styling

- **Modal Accessibility Improvements**
  - Changed modal containers from `items-center` to `items-start` with `overflow-y-auto` for better mobile support
  - Added `my-auto` to modal content divs for vertical centering on larger screens
  - Added `max-h-[90dvh]` and `overflow-y-auto` to BooksPopup and SupportPopup for scrollable content on small screens
  - Updated App.js media modal to support scrolling on mobile devices

- **Internationalization**
  - Added `mediaTitle` translation key to i18n.js for Italian, English, and Hindi
  - Updated MediaSlider.js to use `t('mediaTitle')` instead of hardcoded Italian text
  - Imported translation function in MediaSlider.js

- **Redirect Implementation**
  - Added redirect scripts in en/index.html and hi/index.html to route to Google Translate versions of the Italian site

- **Minor Styling Adjustments**
  - Removed bottom margin from MediaSlider section (`mb-12 md:mb-16` → no margin)
  - Standardized separator styling across language switchers

https://claude.ai/code/session_01HaKnzABAfJoDiCuJo3K8xQ