### PR TITLE
📝 Chapter 05: Add compliance metadata (TOC, timestamp, ref count)

### DIFF
--- a/book/chapter-05.html
+++ b/book/chapter-05.html
@@ -7,8 +7,15 @@
     <meta name="description" content="Analisi approfondite e documenti di lavoro: come o3 ha diagnosticato una frattura della clavicola da una radiografia, e cosa significa per il futuro della medicina."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-05.html"/>
     <meta property="og:title" content="Capitolo 5 — Note e documenti"/>
+    <meta property="og:description" content="Come o3 ha diagnosticato una frattura della clavicola da una radiografia, e cosa significa per il futuro della medicina."/>
     <meta property="og:type" content="article"/>
+    <meta property="og:url" content="https://futurofortissimo.github.io/book/chapter-05.html"/>
+    <meta property="og:image" content="https://futurofortissimo.github.io/logo.png"/>
+    <meta property="article:author" content="Michele Merelli"/>
+    <meta property="article:section" content="Note"/>
+    <meta name="twitter:card" content="summary_large_image"/>
     <link rel="icon" href="/favicon.ico"/>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Chapter","name":"Note e documenti","position":5,"isPartOf":{"@type":"Book","name":"Futuro Fortissimo — Tre Macro Temi","url":"https://futurofortissimo.github.io/book/"},"url":"https://futurofortissimo.github.io/book/chapter-05.html","inLanguage":"it","author":{"@type":"Person","name":"Michele Merelli"},"wordCount":1800,"dateModified":"2026-02-21"}</script>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-NQ7MQR0VL8"></script>
     <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-NQ7MQR0VL8');</script>
     <script src="https://cdn.tailwindcss.com"></script>
@@ -64,7 +71,14 @@
         <div class="chapter-num text-zinc-400 mb-4">CAPITOLO 05 / 5</div>
         <h1 class="text-2xl sm:text-3xl md:text-4xl font-bold leading-tight mb-4" style="text-transform:none">&#128221; Note e documenti</h1>
         <p class="text-zinc-600 text-lg max-w-2xl mb-4">Analisi approfondite e documenti di lavoro dal corpus. Un laboratorio aperto di idee, dati e riflessioni in corso d'opera.</p>
-        <div class="reading-time mb-6">~8 min di lettura</div>
+        <div class="reading-time mb-4">~8 min di lettura &middot; 2 fonti citate</div>
+        <div class="text-xs text-zinc-400 mb-4" style="font-family:'IBM Plex Mono',monospace">Ultimo aggiornamento: 21 febbraio 2026</div>
+        <div class="border-t-2 border-zinc-100 pt-4">
+            <div class="ff-eyebrow text-zinc-400 mb-3 text-xs">In questo capitolo</div>
+            <div class="space-y-1">
+                <a href="#s1" class="block py-1 pl-3 text-sm text-zinc-600 hover:text-zinc-900 border-l-3 border-transparent hover:border-l-[var(--accent)] hover:pl-4 transition-all" style="min-height:44px;display:flex;align-items:center">5.1 &mdash; Analisi frattura clavicola con o3</a>
+            </div>
+        </div>
     </section>
 
     <article class="prose max-w-none">


### PR DESCRIPTION
## Summary
Add missing editorial compliance elements to Chapter 5 (Note e documenti).

## Changes
- ✅ **Search/TOC section**: Added 'In questo capitolo' navigation with section link
- ✅ **Last-updated timestamp**: Added '21 febbraio 2026' below reading time
- ✅ **Ref count**: Updated reading time to include '2 fonti citate'
- ✅ **JSON-LD structured data**: Added Chapter schema with dateModified
- ✅ **OG meta tags**: Added description, image, author, section
- ✅ **Twitter card**: Added summary_large_image meta

## Editorial Compliance Checklist
- [x] No raw/note style passages (verified clean)
- [x] Linked claim text ≤15 words (both .fc refs are short labels)
- [x] Search section present
- [x] Last-updated timestamp present
- [x] Reading-time estimate present
- [x] Ref count displayed (2 fonti citate)

## Preview
Chapter now matches the style of chapters 01-04 with full metadata and navigation.