### PR TITLE
🧹 Chapter 02: editorial compliance pass + local search

### DIFF
--- a/book/chapter-02.html
+++ b/book/chapter-02.html
@@ -103,7 +103,7 @@
             &#128187; Tecnologia &mdash; La Macchina che Ridisegna il Mondo
         </h1>
         <p class="text-zinc-600 text-lg max-w-2xl mb-4">L'AI non &egrave; solo una tecnologia: &egrave; una nuova unit&agrave; di misura che ridisegna valore, produttivit&agrave; e potere. Dai robot agli agenti autonomi, dal metaverso alle criptovalute, dai prodotti di consumo alla singolarit&agrave;: il compute diventa il nuovo petrolio.</p>
-        <div class="reading-time mb-6">~28 min di lettura &middot; 70+ riferimenti dal corpus</div>
+        <div class="reading-time mb-6">~29 min di lettura &middot; Ultimo aggiornamento: 2026-02-25 &middot; Riferimenti: 70+</div>
         <div class="border-t-2 border-zinc-100 pt-4">
             <div class="ff-eyebrow text-zinc-400 mb-3 text-xs">In questo capitolo</div>
             <div class="space-y-1">
@@ -112,6 +112,15 @@
                 <a href="#s3" class="toc-link block py-1 pl-3 text-sm text-zinc-600 hover:text-zinc-900">2.3 &mdash; Prodotti di consumo</a>
             </div>
         </div>
+    </section>
+
+
+
+    <section class="brutal-card mb-10" aria-label="Search nel capitolo">
+        <h2 class="text-lg font-bold mb-3" style="font-family:'IBM Plex Mono',monospace">Search nel capitolo</h2>
+        <label for="chapterSearch" class="ff-eyebrow text-zinc-500">Trova parole chiave</label>
+        <input id="chapterSearch" type="search" placeholder="Es. singolarità, blockchain, robotica" class="mt-2 w-full border-2 border-zinc-900 px-3 py-2"/>
+        <p id="chapterSearchHint" class="text-xs text-zinc-500 mt-2">Ricerca locale sui paragrafi di questo capitolo.</p>
     </section>
 
     <article class="prose max-w-none">
@@ -145,7 +154,7 @@
     <p>&ldquo;L'AI non &egrave; lo strumento della singolarit&agrave;; l'AI &egrave; la singolarit&agrave;. Non stiamo costruendo uno strumento che cambia il mondo &mdash; stiamo costruendo un mondo che cambia gli strumenti.&rdquo;<br>&mdash; Alexander Wissner-Gross, fisico di Harvard</p>
     </blockquote>
 
-    <p>Siamo nella singolarit&agrave;? Google Gemini<a href="https://x.com/gdb/status/1954412082121580848" class="fc" target="_blank" rel="noopener">3 risolve un terzo delle domande dell'Humanity's Last Exam &mdash; un test progettato per essere la sfida cognitiva definitiva. GPT-5 ha proposto un meccanismo scientifico paragonato alla mossa 37 di AlphaGo &mdash; una scoperta che nessun umano aveva intuito</a><a href="https://x.com/gdb/status/1954412082121580848" class="fc" target="_blank" rel="noopener">. GPT-5 ha proposto un meccanismo scientifico paragonato alla mossa 37 di AlphaGo</a>, e risolve il 25% di FrontierMath, benchmark di matematica avanzata che sei mesi fa nessun modello superava l'1%
+    <p>Siamo nella singolarit&agrave;? Gemini 3 risolve un terzo delle domande dell'Humanity's Last Exam e GPT-5 propone meccanismi scientifici inediti <a href="https://x.com/gdb/status/1954412082121580848" class="fc" target="_blank" rel="noopener">(fonte benchmark)</a>, e risolve il 25% di FrontierMath, benchmark di matematica avanzata che sei mesi fa nessun modello superava l'1%
     (<span class="fc">&#128165; ff.135.3
     Siamo nella singolarit&agrave;?</span>).
     Sam Altman preferisce parlare di &ldquo;singolarit&agrave; gentile&rdquo;: non un'esplosione improvvisa, ma un'accelerazione continua che entra nella vita quotidiana senza essere percepita come discontinuit&agrave;
@@ -153,8 +162,8 @@
     La singolarit&agrave; gentile di Altman</span>).
     Ray Kurzweil, nel 2005, aveva previsto il raggiungimento dell'AGI entro il 2029. L'economista Tyler Cowen, in un sondaggio Polymarket del 2025, stima la probabilit&agrave; al 30% &mdash; un anno prima era al 5%
     (<span class="fc">&#128300; ff.123.1
-    L'AI con il coltellino svizzero</span><a href="https://deepmind.google/discover/blog/advanced-version-of-gemini-with-deep-think-officially-achieves-gold-medal-standard-at-the-international-mathematical-olympiad/" class="fc" target="_blank" rel="noopener">).
-    Una versione avanzata di Gemini con Deep Think ha raggiunto il livello di medaglia d'oro all'Olimpiade Internazionale di Matematica</a>. Il modello o3 di OpenAI ha raggiunto un <mark class="note-highlight">QI misurato di 136</mark> &mdash; pi&ugrave; alto del 98% della popolazione mondiale.</p>
+    L'AI con il coltellino svizzero</span>).
+    Una versione avanzata di Gemini con Deep Think ha raggiunto il livello di medaglia d'oro all'Olimpiade Internazionale di Matematica <a href="https://deepmind.google/discover/blog/advanced-version-of-gemini-with-deep-think-officially-achieves-gold-medal-standard-at-the-international-mathematical-olympiad/" class="fc" target="_blank" rel="noopener">(fonte DeepMind)</a>. Il modello o3 di OpenAI ha raggiunto un <mark class="note-highlight">QI misurato di 136</mark> &mdash; pi&ugrave; alto del 98% della popolazione mondiale.</p>
 
     <figure>
         <img src="/index_files/pubs/ff2.webp" alt="Illustrazione di intelligenza artificiale e mente digitale" loading="lazy" width="800" height="450"/>
@@ -166,8 +175,8 @@
     ChatGPT controlla un robot</span>).
     La visione artificiale supera gi&agrave; l'occhio umano in compiti specifici: diagnosi di retinopatia diabetica, classificazione di nei, lettura di TAC
     (<span class="fc">&#128064; ff.88.3
-    Dalle parole ai fatti</span><a href="https://www.linkedin.com/posts/brettadcock_excited-to-introduce-the-worlds-first-humanoid-activity-7361057524160086017-B8Ss" class="fc" target="_blank" rel="noopener">).
-    Il primo robot umanoide al mondo ha imparato a piegare il bucato usando una rete neurale, senza modifiche architetturali</a><a href="https://www.bloomberg.com/news/articles/2025-07-25/china-s-unitree-r1-is-a-humanoid-robot-costing-less-than-6-000?srnd=phx-technology" class="fc" target="_blank" rel="noopener">. In Cina, Unitree ha presentato un robot umanoide a meno di 6.000 dollari</a>. Tesla ha presentato Optimus, un robot umanoide con l'obiettivo di costare <mark class="note-highlight">meno di 20.000 dollari</mark> &mdash; un ordine di grandezza sotto i robot industriali attuali
+    Dalle parole ai fatti</span>).
+    Il primo robot umanoide al mondo ha imparato a piegare il bucato usando una rete neurale, senza modifiche architetturali <a href="https://www.linkedin.com/posts/brettadcock_excited-to-introduce-the-worlds-first-humanoid-activity-7361057524160086017-B8Ss" class="fc" target="_blank" rel="noopener">(fonte Figure)</a>. In Cina, Unitree ha presentato un robot umanoide a meno di 6.000 dollari <a href="https://www.bloomberg.com/news/articles/2025-07-25/china-s-unitree-r1-is-a-humanoid-robot-costing-less-than-6-000?srnd=phx-technology" class="fc" target="_blank" rel="noopener">(fonte Bloomberg)</a>. Tesla ha presentato Optimus, un robot umanoide con l'obiettivo di costare <mark class="note-highlight">meno di 20.000 dollari</mark> &mdash; un ordine di grandezza sotto i robot industriali attuali
     (<span class="fc">&#129302; ff.37.2
     Tesla AI Day</span>).
     Negli USA, gli ordini di robot industriali hanno raggiunto le 29.000 unit&agrave; nel 2023, con un aumento del 37% annuo
@@ -177,8 +186,8 @@
 
     <p>L'AI per la scienza &egrave; forse la frontiera pi&ugrave; sottovalutata. Sakana AI ha creato <em>The AI Scientist</em> &mdash; un sistema che genera, sperimenta e scrive articoli scientifici al costo di <mark class="note-highlight">15 dollari ciascuno</mark>
     (<span class="fc">&#128218; ff.102.3
-    Automatizzare la ricerca scientifica</span><a href="https://www.sciencedaily.com/releases/2025/07/250714052105.htm" class="fc" target="_blank" rel="noopener">).
-    La capacit&agrave; di produrre ipotesi verificabili a costo marginale quasi zero cambia l'economia della scoperta. Un laboratorio alimentato da AI si auto-gestisce e scopre materiali 10 volte pi&ugrave; velocemente dei ricercatori umani</a>. AlphaFold di DeepMind ha predetto la struttura 3D di 200 milioni di proteine &mdash; il lavoro di un secolo di cristallografi &mdash; in 18 mesi. L'AI applicata alla scoperta di farmaci sta accelerando: nel 2024, Insilico Medicine ha portato il primo farmaco scoperto interamente dall'AI alla fase 2 dei trial clinici, per la fibrosi polmonare idiopatica
+    Automatizzare la ricerca scientifica</span>).
+    La capacit&agrave; di produrre ipotesi verificabili a costo marginale quasi zero cambia l'economia della scoperta. Un laboratorio alimentato da AI pu&ograve; scoprire materiali 10 volte pi&ugrave; velocemente dei ricercatori umani <a href="https://www.sciencedaily.com/releases/2025/07/250714052105.htm" class="fc" target="_blank" rel="noopener">(fonte ScienceDaily)</a>. AlphaFold di DeepMind ha predetto la struttura 3D di 200 milioni di proteine &mdash; il lavoro di un secolo di cristallografi &mdash; in 18 mesi. L'AI applicata alla scoperta di farmaci sta accelerando: nel 2024, Insilico Medicine ha portato il primo farmaco scoperto interamente dall'AI alla fase 2 dei trial clinici, per la fibrosi polmonare idiopatica
     (<span class="fc">&#128138; ff.53
     La cura ai tumori?</span>).
     Watson di IBM, seppur criticato per i suoi risultati in oncologia, ha aperto la strada all'idea che la chimica e la biologia potessero essere &ldquo;lette&rdquo; da una macchina come si legge un testo
@@ -217,7 +226,7 @@
     <p class="drop-cap">Mark Zuckerberg ha scommesso il futuro di Facebook su una parola: metaverso. Ha cambiato il nome dell'azienda in Meta, investito <mark class="note-highlight">13,7 miliardi di dollari</mark> nel 2022 e perso il 70% del valore azionario in un anno. I critici hanno dichiarato il metaverso morto. Avevano torto &mdash; ma anche Zuckerberg, in parte. Il metaverso non &egrave; morto: si &egrave; trasformato. Non &egrave; un visore da indossare in soggiorno, ma un tessuto digitale che avvolge progressivamente ogni interazione economica e sociale
     (<span class="fc">&#127760; ff.3
     Metaverso</span>).
-    <em>Fortnite</em> ospita concerti con <mark class="note-highlight">12 milioni di spettatori contemporanei</mark>. Roblox ha 70 milioni di utenti attivi al g<a href="https://news.stanford.edu/stories/2025/07/mixed-reality-displays-artificial-intelligence-holograms-research-innovation" class="fc" target="_blank" rel="noopener">iorno, molti sotto i 13 anni. Il tempo medio giornaliero sullo smartphone &egrave; salito a 4,2 ore &mdash; per la GenZ 6,5. Un display VR da 3mm con ologrammi AI crea un'esperienza di realt&agrave; mista che avvicina il metaverso alla realt&agrave; quotidiana</a>. Viviamo gi&agrave; nel metaverso: non come avatar con visore, ma come profili con notifiche
+    <em>Fortnite</em> ospita concerti con <mark class="note-highlight">12 milioni di spettatori contemporanei</mark>. Roblox ha 70 milioni di utenti attivi al giorno, molti sotto i 13 anni. Il tempo medio giornaliero sullo smartphone &egrave; salito a 4,2 ore &mdash; per la GenZ 6,5. Un nuovo display VR da 3mm con ologrammi AI avvicina il metaverso alla vita quotidiana <a href="https://news.stanford.edu/stories/2025/07/mixed-reality-displays-artificial-intelligence-holograms-research-innovation" class="fc" target="_blank" rel="noopener">(fonte Stanford)</a>. Viviamo gi&agrave; nel metaverso: non come avatar con visore, ma come profili con notifiche
     (<span class="fc">&#128299; ff.11
     Sparare nel metaverso</span>).</p>
 
@@ -233,7 +242,7 @@
         <figcaption>Dal feudalesimo digitale alla sovranit&agrave;: blockchain, metaverso e il futuro della propriet&agrave;.</figcaption>
     </figure>
 
-    <p>La blockchain promette un'uscita dal feudalesimo. Se internet ha decentralizzato l'informazione, la blockchain decentralizza la <em>propriet&agrave;</em>. Un NFT non &egrave; un JPEG costoso: &egrave; un titolo di propriet&agrave;<a href="https://share.google/dUhg1lDdTgZJLiP9f" class="fc" target="_blank" rel="noopener">digitale verificabile senza intermediari. Ethereum ha elaborato pi&ugrave; transazioni nel 2024 che Visa nel 2010. La DeFi (finanza decentralizzata). Coinbase ha lanciato aggiornamenti per Base, e Zora tokenizzer&agrave; ogni post per monetizzazione immediata</a>. La DeFi gestisce <mark class="note-highlight">90 miliardi di dollari in protocolli</mark> automatizzati che funzionano 24 ore al giorno, senza banche, senza orari, senza confini
+    <p>La blockchain promette un'uscita dal feudalesimo. Se internet ha decentralizzato l'informazione, la blockchain decentralizza la <em>propriet&agrave;</em>. Un NFT non &egrave; un JPEG costoso: &egrave; un titolo di propriet&agrave; digitale verificabile senza intermediari <a href="https://share.google/dUhg1lDdTgZJLiP9f" class="fc" target="_blank" rel="noopener">(fonte approfondimento)</a>. Ethereum ha elaborato pi&ugrave; transazioni nel 2024 che Visa nel 2010. Coinbase ha lanciato aggiornamenti per Base, e Zora punta a tokenizzare i post per monetizzazione immediata. La DeFi gestisce <mark class="note-highlight">90 miliardi di dollari in protocolli</mark> automatizzati che funzionano 24 ore al giorno, senza banche, senza orari, senza confini
     (<span class="fc">&#128279; ff.95.3
     La propriet&agrave; privata digitale</span>).
     Cosa risolve la blockchain, in sostanza? Il problema della fiducia senza intermediari &mdash; una &ldquo;VPN finanziaria&rdquo; che bypassa i custodi tradizionali del valore
@@ -289,8 +298,8 @@
     Claude usa il computer</span>).
     La domesticazione dell'AI &egrave; in corso: come il fuoco pass&ograve; da pericolo a strumento, l'intelligenza artificiale sta transitando da curiosit&agrave; a utility. Il 75% delle startup nel batch invernale 2025 di Y Combinator &egrave; basato sull'AI; il mercato dell'AI generativa &egrave; passato da zero a 100 miliardi in due anni
     (<span class="fc">&#128200; ff.45.3
-    Quali trend decolleranno?</span><a href="https://substack.com/profile/710379-azeem-azhar/note/c-142398076" class="fc" target="_blank" rel="noopener">).
-    Il 50% dei ricavi API di Anthropic proviene da GitHub Copilot e Cursor, per un totale di 1,4 miliardi di dollari &mdash; la programmazione AI &egrave; gi&agrave; un mercato colossale</a>. Devin, il primo &ldquo;programmatore AI&rdquo; autonomo, ha guadagnato 4.000 dollari nella prima settimana su Upwork
+    Quali trend decolleranno?</span>).
+    Il 50% dei ricavi API di Anthropic proviene da GitHub Copilot e Cursor, per un totale di 1,4 miliardi di dollari &mdash; la programmazione AI &egrave; gi&agrave; un mercato colossale <a href="https://substack.com/profile/710379-azeem-azhar/note/c-142398076" class="fc" target="_blank" rel="noopener">(fonte Azeem Azhar)</a>. Devin, il primo &ldquo;programmatore AI&rdquo; autonomo, ha guadagnato 4.000 dollari nella prima settimana su Upwork
     (<span class="fc">&#127774; ff.88.5
     Un paio di esempi di accelerazione</span>).</p>
 
@@ -393,6 +402,25 @@ document.querySelectorAll('.fc').forEach(el => {
     el.replaceWith(a);
   }
 });
+</script>
+
+<script>
+const searchInput=document.getElementById('chapterSearch');
+const hint=document.getElementById('chapterSearchHint');
+const searchable=[...document.querySelectorAll('article p, article h2, article blockquote')];
+if(searchInput&&hint){
+  searchInput.addEventListener('input',()=>{
+    const q=searchInput.value.trim().toLowerCase();
+    if(!q){searchable.forEach(el=>el.style.background='');hint.textContent='Ricerca locale sui paragrafi di questo capitolo.';return;}
+    let m=0;
+    searchable.forEach(el=>{
+      const t=el.textContent.toLowerCase();
+      if(t.includes(q)){el.style.background='rgba(74,144,226,0.10)';m++;}
+      else{el.style.background='';}
+    });
+    hint.textContent=`${m} blocchi trovati per "${q}".`;
+  });
+}
 </script>
 <script src="/analytics.js"></script>
 <script>if (window.ffTrackPage) window.ffTrackPage();</script>


### PR DESCRIPTION
## Summary
- ripuliti passaggi raw/rotti nel capitolo 02 (anchor corrotti e claim-link troppo lunghi)
- uniformata la metadata line con **last-updated**, **reading-time** e **ref count**
- aggiunta sezione **Search nel capitolo** con filtro locale lato client
- mantenuto il tono editoriale e la struttura del capitolo

## Mandatory editorial compliance checklist (book/)
- [x] Removed note/raw style passages (incl. malformed inline anchors)
- [x] Linked claim text capped to <= 15 words
- [x] Added/updated Search section
- [x] Added/updated last-updated timestamp
- [x] Added/updated reading-time estimate
- [x] Added/updated reference count

## Validation
- test manuale su file: book/chapter-02.html
- ricerca locale: highlight + conteggio blocchi trovati
- nessun anchor con testo >15 parole