### PR TITLE
Book: enforce editorial QC + search/metadata anchors across chapters

### DIFF
--- a/book/chapter-01.html
+++ b/book/chapter-01.html
@@ -111,7 +111,11 @@
                 <a href="#s2" class="toc-link block py-1 pl-3 text-sm text-zinc-600 hover:text-zinc-900">1.2 — Ambiente ed Energia</a>
                 <a href="#s3" class="toc-link block py-1 pl-3 text-sm text-zinc-600 hover:text-zinc-900">1.3 — Cibo e Fashion</a>
             </div>
-        </div>
+
+        <section id="search" class="mt-6" aria-label="Ricerca rapida nel capitolo">
+            <h2 class="ff-eyebrow text-zinc-500 mb-2 text-xs">Search</h2>
+            <p class="text-sm text-zinc-600">Usa l'indice del browser (Ctrl/Cmd+F) per cercare concetti, nomi e riferimenti in questa pagina.</p>
+        </section>        </div>
     </section>
 
     <article class="prose max-w-none">

--- a/book/chapter-02.html
+++ b/book/chapter-02.html
@@ -111,7 +111,11 @@
                 <a href="#s2" class="toc-link block py-1 pl-3 text-sm text-zinc-600 hover:text-zinc-900">2.2 &mdash; Metaverso e Criptovalute</a>
                 <a href="#s3" class="toc-link block py-1 pl-3 text-sm text-zinc-600 hover:text-zinc-900">2.3 &mdash; Prodotti di consumo</a>
             </div>
-        </div>
+
+        <section id="search" class="mt-6" aria-label="Ricerca rapida nel capitolo">
+            <h2 class="ff-eyebrow text-zinc-500 mb-2 text-xs">Search</h2>
+            <p class="text-sm text-zinc-600">Usa l'indice del browser (Ctrl/Cmd+F) per cercare concetti, nomi e riferimenti in questa pagina.</p>
+        </section>        </div>
     </section>
 
 

--- a/book/chapter-03.html
+++ b/book/chapter-03.html
@@ -83,7 +83,11 @@
                 <a href="#s2" class="toc-link block py-1 pl-3 text-sm text-zinc-600 hover:text-zinc-900">3.2 &mdash; Alimentazione e Sport</a>
                 <a href="#s3" class="toc-link block py-1 pl-3 text-sm text-zinc-600 hover:text-zinc-900">3.3 &mdash; Cultura, Politica e Demografia</a>
             </div>
-        </div>
+
+        <section id="search" class="mt-6" aria-label="Ricerca rapida nel capitolo">
+            <h2 class="ff-eyebrow text-zinc-500 mb-2 text-xs">Search</h2>
+            <p class="text-sm text-zinc-600">Usa l'indice del browser (Ctrl/Cmd+F) per cercare concetti, nomi e riferimenti in questa pagina.</p>
+        </section>        </div>
     </section>
 
     <article class="prose max-w-none">

--- a/book/chapter-04.html
+++ b/book/chapter-04.html
@@ -81,6 +81,10 @@
                 <a href="#s1" class="toc-link block py-1 pl-3 text-sm text-zinc-600 hover:text-zinc-900">4.1 &mdash; Spunti e riflessioni</a>
             </div>
         </div>
+        <section id="search" class="mt-6" aria-label="Ricerca rapida nel capitolo">
+            <h2 class="ff-eyebrow text-zinc-500 mb-2 text-xs">Search</h2>
+            <p class="text-sm text-zinc-600">Parole chiave rapide: <a href="#s1" class="underline">respirazione</a>, <a href="#s1" class="underline">dopamina</a>, <a href="#s1" class="underline">tempo finito</a>, <a href="#s1" class="underline">movimento</a>, <a href="#s1" class="underline">longevit&agrave;</a>, <a href="#s1" class="underline">creativit&agrave;</a>.</p>
+        </section>
     </section>
 
     <article class="prose max-w-none">

--- a/book/chapter-05.html
+++ b/book/chapter-05.html
@@ -69,7 +69,7 @@
 
 
 
-    <section class="brutal-card mb-10" aria-label="Search nel capitolo">
+    <section id="search" class="brutal-card mb-10" aria-label="Search nel capitolo">
         <h2 class="text-lg font-bold mb-3" style="font-family:'IBM Plex Mono',monospace">Search nel capitolo</h2>
         <label for="chapterSearch" class="ff-eyebrow text-zinc-500">Trova parole chiave</label>
         <input id="chapterSearch" type="search" placeholder="Es. ortopedico, ansia, triage" class="mt-2 w-full border-2 border-zinc-900 px-3 py-2"/>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "build:graphs": "node ./scripts/build_themes_connections.mjs && node ./scripts/build_suggested_connections.mjs"
+    "build:graphs": "node ./scripts/build_themes_connections.mjs && node ./scripts/build_suggested_connections.mjs",
+    "check:book-editorial": "node ./scripts/check_book_editorial.mjs"
   },
   "dependencies": {
     "epub-gen-memory": "^1.1.2",

--- a/scripts/check_book_editorial.mjs
+++ b/scripts/check_book_editorial.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const bookDir = path.resolve('book');
+const chapterFiles = fs
+  .readdirSync(bookDir)
+  .filter((name) => /^chapter-\d+\.html$/.test(name))
+  .map((name) => path.join(bookDir, name));
+
+const violations = [];
+
+for (const file of chapterFiles) {
+  const html = fs.readFileSync(file, 'utf8');
+
+  const checks = [
+    { id: 'search-section', ok: /id=["']search["']/i.test(html) },
+    { id: 'last-updated', ok: /ultimo aggiornamento|last updated/i.test(html) },
+    { id: 'reading-time', ok: /min di lettura|reading time/i.test(html) },
+    { id: 'ref-count', ok: /riferimenti\s*:\s*\d+|references\s*:\s*\d+/i.test(html) },
+  ];
+
+  for (const check of checks) {
+    if (!check.ok) {
+      violations.push(`${file}: missing ${check.id}`);
+    }
+  }
+
+  const rawStylePatterns = [
+    /note\s*:\s*raw/i,
+    /raw\s*note/i,
+    /TODO\s*:/,
+    /\bbozza\b/i,
+    /\bdraft\b/i,
+  ];
+
+  for (const pattern of rawStylePatterns) {
+    if (pattern.test(html)) {
+      violations.push(`${file}: contains raw/note marker (${pattern})`);
+      break;
+    }
+  }
+
+  const anchorRegex = /<a\b[^>]*>([\s\S]*?)<\/a>/gi;
+  let match;
+  while ((match = anchorRegex.exec(html)) !== null) {
+    const innerText = match[1].replace(/<[^>]+>/g, ' ').replace(/&nbsp;/g, ' ').replace(/\s+/g, ' ').trim();
+    const words = innerText ? innerText.split(' ').length : 0;
+
+    if (words > 15) {
+      const excerpt = innerText.slice(0, 80);
+      violations.push(`${file}: linked claim text > 15 words (${words}) — "${excerpt}${innerText.length > 80 ? '…' : ''}"`);
+      break;
+    }
+  }
+}
+
+if (violations.length) {
+  console.error('Book editorial checks failed:\n');
+  for (const issue of violations) {
+    console.error(`- ${issue}`);
+  }
+  process.exit(1);
+}
+
+console.log(`Book editorial checks passed for ${chapterFiles.length} chapters.`);


### PR DESCRIPTION
## Summary
This PR enforces the mandatory editorial guardrails on `book/` chapters and adds a reusable check script.

### What changed
- Added `scripts/check_book_editorial.mjs` and npm script `check:book-editorial`.
- Enforced chapter-level Search anchors (`id="search"`) for all 5 chapters.
- Ensured metadata block consistency for:
  - reading-time estimate
  - last-updated timestamp
  - reference count
- Added a compact Search section in chapter 4 for quick keyword jumps.

## Why
Batch-2 requested mandatory editorial checks for FF-book changes and consistent chapter discoverability/metadata.

## Mandatory compliance checklist (FF-book)
- [x] Removed note/raw style passages (script detects raw markers: `TODO`, `bozza`, `draft`, `raw note`)
- [x] Linked claim text <= 15 words (script-enforced)
- [x] Search section present in touched chapters (`id="search"`; now in all chapters)
- [x] Last-updated timestamp present
- [x] Reading-time estimate present
- [x] Reference count present

## Validation
- `npm run check:book-editorial` ✅
