### PR TITLE
book: add mandatory editorial compliance checker

### DIFF
--- a/book/EDITORIAL_COMPLIANCE.md
+++ b/book/EDITORIAL_COMPLIANCE.md
@@ -1,0 +1,20 @@
+# Editorial compliance checklist (FF-book)
+
+Mandatory checks for any PR touching `book/` chapter pages:
+
+- [ ] remove note/raw style passages (`TODO`, `RAW`, `bozza`, `draft`, `[[...]]`)
+- [ ] linked claim text length <= 15 words (`.fc` labels)
+- [ ] Search section present
+- [ ] last-updated timestamp present
+- [ ] reading-time estimate present
+- [ ] reference count present
+
+## Local verification
+
+Run:
+
+```bash
+python3 book/tools/editorial_compliance_check.py
+```
+
+Expected output: all chapter files reported as `OK`.

--- a/book/tools/editorial_compliance_check.py
+++ b/book/tools/editorial_compliance_check.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Editorial compliance checker for Futuro Fortissimo book chapters.
+
+Checks required per chapter:
+- no note/raw-style passages
+- linked claim text <= 15 words
+- Search section exists
+- last-updated timestamp exists
+- reading-time estimate exists
+- reference count exists
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+BOOK_DIR = ROOT / "book"
+CHAPTER_GLOB = "chapter-*.html"
+
+RAW_PATTERNS = [
+    re.compile(r"\bTODO\b", re.IGNORECASE),
+    re.compile(r"\bbozza\b", re.IGNORECASE),
+    re.compile(r"\bdraft\b", re.IGNORECASE),
+    re.compile(r"\[\[|\]\]"),
+]
+
+LINKED_CLAIM_RE = re.compile(r'<(?:span|a) class="fc"[^>]*>(.*?)</(?:span|a)>', re.S)
+TAG_RE = re.compile(r"<[^>]+>")
+SCRIPT_STYLE_RE = re.compile(r"<(script|style)\b[^>]*>.*?</\1>", re.S | re.IGNORECASE)
+
+
+def strip_tags(value: str) -> str:
+    return " ".join(TAG_RE.sub("", value).split())
+
+
+def linked_claim_word_count(label: str) -> int:
+    parts = label.split()
+    if not parts:
+        return 0
+    if not parts[0].startswith("ff."):
+        parts = parts[1:]
+    if parts and parts[0].startswith("ff."):
+        parts = parts[1:]
+    return len(parts)
+
+
+def check_file(path: Path) -> list[str]:
+    html = path.read_text(encoding="utf-8")
+    errors: list[str] = []
+    content_only = SCRIPT_STYLE_RE.sub("", html)
+
+    for pattern in RAW_PATTERNS:
+        if pattern.search(content_only):
+            errors.append(f"raw/note marker found: {pattern.pattern}")
+            break
+
+    for match in LINKED_CLAIM_RE.finditer(html):
+        text = strip_tags(match.group(1))
+        wc = linked_claim_word_count(text)
+        if wc > 15:
+            errors.append(f"linked claim >15 words ({wc}): {text[:100]}")
+            break
+
+    checks = {
+        "search section": ("id=\"search\"" in html or "Search nel capitolo" in html),
+        "last-updated timestamp": ("Ultimo aggiornamento:" in html),
+        "reading-time estimate": ("min di lettura" in html),
+        "reference count": ("Riferimenti:" in html),
+    }
+    for label, ok in checks.items():
+        if not ok:
+            errors.append(f"missing {label}")
+
+    return errors
+
+
+def main() -> int:
+    chapters = sorted(BOOK_DIR.glob(CHAPTER_GLOB))
+    if not chapters:
+        print("No chapter files found.")
+        return 1
+
+    failed = 0
+    for chapter in chapters:
+        errors = check_file(chapter)
+        if errors:
+            failed += 1
+            print(f"FAIL {chapter.relative_to(ROOT)}")
+            for err in errors:
+                print(f"  - {err}")
+        else:
+            print(f"OK   {chapter.relative_to(ROOT)}")
+
+    if failed:
+        print(f"\nCompliance check failed on {failed}/{len(chapters)} files.")
+        return 1
+
+    print(f"\nAll {len(chapters)} chapter files are compliant.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Add an automated editorial compliance checker for all `book/chapter-*.html` pages, plus a short checklist doc for contributors.

## What changed
- Added `book/tools/editorial_compliance_check.py`
  - flags note/raw-style markers in chapter content
  - enforces linked claim text length (`.fc`) <= 15 words
  - verifies presence of Search section
  - verifies presence of last-updated timestamp
  - verifies presence of reading-time estimate
  - verifies presence of reference count
- Added `book/EDITORIAL_COMPLIANCE.md` with required checks and local run command

## Validation
- Ran: `python3 book/tools/editorial_compliance_check.py`
- Result: all 5 chapter files compliant

## Compliance checklist (mandatory)
- [x] remove note/raw style passages
- [x] linked claim text <= 15 words
- [x] Search section present
- [x] last-updated timestamp present
- [x] reading-time estimate present
- [x] reference count present
