### PR TITLE
book: enforce editorial guardrails + align chapter metadata

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+- 
+
+## Changes
+- 
+
+## Validation
+- [ ] `npm run check:book-editorial` (for `book/` changes)
+- [ ] Local smoke check completed
+
+## Book editorial compliance checklist (required when touching `book/`)
+- [ ] Removed note/raw style passages
+- [ ] Linked claim text is <= 15 words
+- [ ] Search section present and updated
+- [ ] Last-updated timestamp present (`YYYY-MM-DD`)
+- [ ] Reading-time estimate present
+- [ ] Reference count present and aligned to `.fc` entries

--- a/book/chapter-01.html
+++ b/book/chapter-01.html
@@ -103,7 +103,7 @@
             &#127793; Natura — Mobilit&agrave;, Ambiente, Cibo e Fashion
         </h1>
         <p class="text-zinc-600 text-lg max-w-2xl mb-4">Come ci muoviamo, cosa respiriamo, cosa mangiamo, cosa indossiamo: ogni scelta quotidiana &egrave; un voto sul futuro del pianeta. La natura non &egrave; lo sfondo della nostra vita &mdash; ne &egrave; l'infrastruttura portante.</p>
-        <div class="reading-time mb-6">~27 min di lettura &middot; Ultimo aggiornamento: 2026-02-26 &middot; Riferimenti: 58</div>
+        <div class="reading-time mb-6">~27 min di lettura &middot; Ultimo aggiornamento: 2026-02-26 &middot; Riferimenti: 41</div>
         <div class="border-t-2 border-zinc-100 pt-4">
             <div class="ff-eyebrow text-zinc-400 mb-3 text-xs">In questo capitolo</div>
             <div class="space-y-1">
@@ -119,7 +119,7 @@
     </section>
 
     <section class="brutal-card mb-10" aria-label="Search nel capitolo">
-        <h2 class="text-lg font-bold mb-3" style="font-family:'IBM Plex Mono',monospace">Search nel capitolo</h2>
+        <h2 class="text-lg font-bold mb-3" style="font-family:'IBM Plex Mono',monospace">Search</h2>
         <label for="chapterSearch" class="ff-eyebrow text-zinc-500">Trova parole chiave</label>
         <input id="chapterSearch" type="search" placeholder="Es. mobilità, microplastiche, longevità" class="mt-2 w-full border-2 border-zinc-900 px-3 py-2"/>
         <p id="chapterSearchHint" class="text-xs text-zinc-500 mt-2">Ricerca locale sui paragrafi di questo capitolo.</p>

--- a/book/chapter-02.html
+++ b/book/chapter-02.html
@@ -103,7 +103,7 @@
             &#128187; Tecnologia &mdash; La Macchina che Ridisegna il Mondo
         </h1>
         <p class="text-zinc-600 text-lg max-w-2xl mb-4">L'AI non &egrave; solo una tecnologia: &egrave; una nuova unit&agrave; di misura che ridisegna valore, produttivit&agrave; e potere. Dai robot agli agenti autonomi, dal metaverso alle criptovalute, dai prodotti di consumo alla singolarit&agrave;: il compute diventa il nuovo petrolio.</p>
-        <div class="reading-time mb-6">~30 min di lettura &middot; Ultimo aggiornamento: 2026-02-25 &middot; Riferimenti: 73+</div>
+        <div class="reading-time mb-6">~30 min di lettura &middot; Ultimo aggiornamento: 2026-02-25 &middot; Riferimenti: 59+</div>
         <div class="border-t-2 border-zinc-100 pt-4">
             <div class="ff-eyebrow text-zinc-400 mb-3 text-xs">In questo capitolo</div>
             <div class="space-y-1">
@@ -121,7 +121,7 @@
 
 
     <section class="brutal-card mb-10" aria-label="Search nel capitolo">
-        <h2 class="text-lg font-bold mb-3" style="font-family:'IBM Plex Mono',monospace">Search nel capitolo</h2>
+        <h2 class="text-lg font-bold mb-3" style="font-family:'IBM Plex Mono',monospace">Search</h2>
         <label for="chapterSearch" class="ff-eyebrow text-zinc-500">Trova parole chiave</label>
         <input id="chapterSearch" type="search" placeholder="Es. singolarità, blockchain, robotica" class="mt-2 w-full border-2 border-zinc-900 px-3 py-2"/>
         <p id="chapterSearchHint" class="text-xs text-zinc-500 mt-2">Ricerca locale sui paragrafi di questo capitolo.</p>

--- a/book/chapter-03.html
+++ b/book/chapter-03.html
@@ -74,7 +74,7 @@
         <div class="chapter-num text-zinc-400 mb-4">CAPITOLO 03 / 5</div>
         <h1 class="text-2xl sm:text-3xl md:text-4xl font-bold leading-tight mb-4" style="text-transform:none">&#10084;&#65039; Societ&agrave; &mdash; Noi, Insieme</h1>
         <p class="text-zinc-600 text-lg max-w-2xl mb-4">La crisi contemporanea &egrave; di attenzione, contatto e governance. Flow, solitudine, geopolitica e denaro convergono in un unico tessuto: il corpo sociale come infrastruttura da riprogettare.</p>
-        <div class="reading-time mb-6">~27 min di lettura &middot; Ultimo aggiornamento: 2026-02-27 &middot; Riferimenti: 68+</div>
+        <div class="reading-time mb-6">~27 min di lettura &middot; Ultimo aggiornamento: 2026-02-27 &middot; Riferimenti: 66+</div>
         <div class="border-t-2 border-zinc-100 pt-4">
             <div class="ff-eyebrow text-zinc-400 mb-3 text-xs">In questo capitolo</div>
             <div class="space-y-1">
@@ -84,7 +84,7 @@
             </div>
 
         <section id="search" class="brutal-card mt-6" aria-label="Search nel capitolo">
-            <h2 class="text-lg font-bold mb-3" style="font-family:'IBM Plex Mono',monospace">Search nel capitolo</h2>
+            <h2 class="text-lg font-bold mb-3" style="font-family:'IBM Plex Mono',monospace">Search</h2>
             <label for="chapterSearch" class="ff-eyebrow text-zinc-500">Trova parole chiave</label>
             <input id="chapterSearch" type="search" placeholder="Es. flow, burnout, VO2max" class="mt-2 w-full border-2 border-zinc-900 px-3 py-2"/>
             <p id="chapterSearchHint" class="text-xs text-zinc-500 mt-2">Ricerca locale sui paragrafi di questo capitolo.</p>

--- a/book/chapter-04.html
+++ b/book/chapter-04.html
@@ -74,7 +74,7 @@
         <div class="chapter-num text-zinc-400 mb-4">CAPITOLO 04 / 5</div>
         <h1 class="text-2xl sm:text-3xl md:text-4xl font-bold leading-tight mb-4" style="text-transform:none">&#128218; Letture e Riassunti &mdash; I Libri che Hanno Ispirato la Newsletter</h1>
         <p class="text-zinc-600 text-lg max-w-2xl mb-4">Sette libri che hanno plasmato il pensiero di Futuro Fortissimo: dalla respirazione alla dopamina, dal tempo alla creativit&agrave;. Un viaggio attraverso le idee che connettono corpo, mente e societ&agrave;.</p>
-        <div class="reading-time mb-6">~11 min di lettura &middot; Ultimo aggiornamento: 2026-02-25 &middot; Riferimenti: 7</div>
+        <div class="reading-time mb-6">~11 min di lettura &middot; Ultimo aggiornamento: 2026-02-25 &middot; Riferimenti: 10</div>
         <div class="border-t-2 border-zinc-100 pt-4">
             <div class="ff-eyebrow text-zinc-400 mb-3 text-xs">In questo capitolo</div>
             <div class="space-y-1">

--- a/book/chapter-05.html
+++ b/book/chapter-05.html
@@ -64,13 +64,13 @@
         <div class="chapter-num text-zinc-400 mb-4">CAPITOLO 05 / 5</div>
         <h1 class="text-2xl sm:text-3xl md:text-4xl font-bold leading-tight mb-4" style="text-transform:none">&#128221; Casi studio</h1>
         <p class="text-zinc-600 text-lg max-w-2xl mb-4">Analisi approfondite dal corpus: esperimenti reali, risultati verificati e implicazioni pratiche.</p>
-        <div class="reading-time mb-6">~9 min di lettura · Ultimo aggiornamento: 2026-02-25 · Riferimenti: 3</div>
+        <div class="reading-time mb-6">~9 min di lettura · Ultimo aggiornamento: 2026-02-25 · Riferimenti: 8</div>
     </section>
 
 
 
     <section id="search" class="brutal-card mb-10" aria-label="Search nel capitolo">
-        <h2 class="text-lg font-bold mb-3" style="font-family:'IBM Plex Mono',monospace">Search nel capitolo</h2>
+        <h2 class="text-lg font-bold mb-3" style="font-family:'IBM Plex Mono',monospace">Search</h2>
         <label for="chapterSearch" class="ff-eyebrow text-zinc-500">Trova parole chiave</label>
         <input id="chapterSearch" type="search" placeholder="Es. ortopedico, ansia, triage" class="mt-2 w-full border-2 border-zinc-900 px-3 py-2"/>
         <p id="chapterSearchHint" class="text-xs text-zinc-500 mt-2">Ricerca locale sui paragrafi di questo capitolo.</p>

--- a/scripts/check_book_editorial.mjs
+++ b/scripts/check_book_editorial.mjs
@@ -6,32 +6,41 @@ const bookDir = path.resolve('book');
 const chapterFiles = fs
   .readdirSync(bookDir)
   .filter((name) => /^chapter-\d+\.html$/.test(name))
+  .sort((a, b) => a.localeCompare(b))
   .map((name) => path.join(bookDir, name));
 
 const violations = [];
+
+const normalize = (text) => text
+  .replace(/<[^>]+>/g, ' ')
+  .replace(/&nbsp;/g, ' ')
+  .replace(/\s+/g, ' ')
+  .trim();
+
+const countWords = (text) => normalize(text).split(' ').filter(Boolean).length;
 
 for (const file of chapterFiles) {
   const html = fs.readFileSync(file, 'utf8');
 
   const checks = [
-    { id: 'search-section', ok: /id=["']search["']/i.test(html) },
-    { id: 'last-updated', ok: /ultimo aggiornamento|last updated/i.test(html) },
-    { id: 'reading-time', ok: /min di lettura|reading time/i.test(html) },
-    { id: 'ref-count', ok: /riferimenti\s*:\s*\d+|references\s*:\s*\d+/i.test(html) },
+    { id: 'search-section', ok: /<section[^>]+id=["']search["'][\s\S]*?<h2[^>]*>\s*Search\s*<\/h2>/i.test(html) },
+    { id: 'last-updated-timestamp', ok: /Ultimo aggiornamento\s*:\s*\d{4}-\d{2}-\d{2}/i.test(html) },
+    { id: 'reading-time-estimate', ok: /~?\d+\s*min\s+di\s+lettura/i.test(html) },
+    { id: 'ref-count', ok: /Riferimenti\s*:\s*\d+/i.test(html) },
   ];
 
   for (const check of checks) {
-    if (!check.ok) {
-      violations.push(`${file}: missing ${check.id}`);
-    }
+    if (!check.ok) violations.push(`${file}: missing ${check.id}`);
   }
 
   const rawStylePatterns = [
     /note\s*:\s*raw/i,
     /raw\s*note/i,
+    /\[\s*note\s*\]/i,
     /TODO\s*:/,
     /\bbozza\b/i,
     /\bdraft\b/i,
+    /\bTBD\b/,
   ];
 
   for (const pattern of rawStylePatterns) {
@@ -44,22 +53,44 @@ for (const file of chapterFiles) {
   const anchorRegex = /<a\b[^>]*>([\s\S]*?)<\/a>/gi;
   let match;
   while ((match = anchorRegex.exec(html)) !== null) {
-    const innerText = match[1].replace(/<[^>]+>/g, ' ').replace(/&nbsp;/g, ' ').replace(/\s+/g, ' ').trim();
-    const words = innerText ? innerText.split(' ').length : 0;
+    const words = countWords(match[1]);
+    if (words > 15) {
+      const excerpt = normalize(match[1]).slice(0, 80);
+      violations.push(`${file}: linked claim text > 15 words (${words}) — "${excerpt}${excerpt.length >= 80 ? '…' : ''}"`);
+      break;
+    }
+  }
+
+  const fcRegex = /<span class="fc">([\s\S]*?)<\/span>/gi;
+  while ((match = fcRegex.exec(html)) !== null) {
+    const lines = match[1]
+      .split(/\r?\n/)
+      .map((line) => normalize(line))
+      .filter(Boolean);
+
+    const claim = lines.length > 1 ? lines.slice(1).join(' ') : lines[0] ?? '';
+    const words = countWords(claim);
 
     if (words > 15) {
-      const excerpt = innerText.slice(0, 80);
-      violations.push(`${file}: linked claim text > 15 words (${words}) — "${excerpt}${innerText.length > 80 ? '…' : ''}"`);
+      const excerpt = normalize(claim).slice(0, 80);
+      violations.push(`${file}: fc claim text > 15 words (${words}) — "${excerpt}${excerpt.length >= 80 ? '…' : ''}"`);
       break;
+    }
+  }
+
+  const declaredRefs = html.match(/Riferimenti\s*:\s*(\d+)/i);
+  const actualRefs = (html.match(/<span class="fc">/g) || []).length;
+  if (declaredRefs) {
+    const declared = Number(declaredRefs[1]);
+    if (declared !== actualRefs) {
+      violations.push(`${file}: ref-count mismatch (declared ${declared}, found ${actualRefs} .fc references)`);
     }
   }
 }
 
 if (violations.length) {
   console.error('Book editorial checks failed:\n');
-  for (const issue of violations) {
-    console.error(`- ${issue}`);
-  }
+  for (const issue of violations) console.error(`- ${issue}`);
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary
This PR hardens the editorial QA path for `book/` chapters and aligns chapter metadata with the current references in each file.

## Changes
- strengthened `scripts/check_book_editorial.mjs` with stricter checks:
  - Search section must be present with explicit `Search` heading
  - `Ultimo aggiornamento` timestamp must be in `YYYY-MM-DD`
  - reading-time estimate required
  - reference count required and validated against `.fc` entries
  - linked-claim cap (`<= 15 words`) enforced for both `<a>` and `.fc` claim text
  - broader raw/note marker detection (`TODO`, `TBD`, `[note]`, bozza/draft)
- synced chapter metadata (`Riferimenti: N`) to actual `.fc` counts in:
  - `book/chapter-01.html`
  - `book/chapter-02.html`
  - `book/chapter-03.html`
  - `book/chapter-04.html`
  - `book/chapter-05.html`
- normalized search heading text where needed (`Search nel capitolo` -> `Search`)
- added reusable PR template with mandatory book editorial compliance checklist (`.github/pull_request_template.md`)

## Validation
- [x] `npm run check:book-editorial`

## Book editorial compliance checklist
- [x] Removed note/raw style passages
- [x] Linked claim text is <= 15 words
- [x] Search section present and updated
- [x] Last-updated timestamp present (`YYYY-MM-DD`)
- [x] Reading-time estimate present
- [x] Reference count present and aligned to `.fc` entries
