### PR TITLE
i18n: force EN/HI to translate from Italian source

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -365,7 +365,7 @@
     </style>
     <!-- Redirect to Google Translate English version of the Italian site -->
     <script>
-      window.location.replace('https://futurofortissimo-github-io.translate.goog/?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=it&_x_tr_pto=wapp');
+      window.location.replace('https://translate.google.com/translate?sl=it&tl=en&u=https://futurofortissimo.github.io/');
     </script>
 </head>
   <body class="bg-white text-gray-900 antialiased selection:bg-gray-900 selection:text-white">
@@ -374,9 +374,9 @@
       <div class="max-w-5xl mx-auto flex items-center justify-end gap-1 px-4 py-1">
         <a href="https://futurofortissimo.github.io/" title="Italiano">IT</a>
         <span style="color:rgba(255,255,255,0.3);user-select:none;">/</span>
-        <a href="https://futurofortissimo-github-io.translate.goog/?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=it&_x_tr_pto=wapp" aria-current="page" title="English" rel="noopener">EN</a>
+        <a href="https://translate.google.com/translate?sl=it&tl=en&u=https://futurofortissimo.github.io/" aria-current="page" title="English" rel="noopener">EN</a>
         <span style="color:rgba(255,255,255,0.3);user-select:none;">/</span>
-        <a href="https://futurofortissimo-github-io.translate.goog/?_x_tr_sl=auto&_x_tr_tl=hi&_x_tr_hl=it&_x_tr_pto=wapp" title="Hindi" rel="noopener">HI</a>
+        <a href="https://translate.google.com/translate?sl=it&tl=hi&u=https://futurofortissimo.github.io/" title="Hindi" rel="noopener">HI</a>
       </div>
     </nav>
 

--- a/hi/index.html
+++ b/hi/index.html
@@ -353,7 +353,7 @@
     </style>
     <!-- Redirect to Google Translate Hindi version of the Italian site -->
     <script>
-      window.location.replace('https://futurofortissimo-github-io.translate.goog/?_x_tr_sl=auto&_x_tr_tl=hi&_x_tr_hl=it&_x_tr_pto=wapp');
+      window.location.replace('https://translate.google.com/translate?sl=it&tl=hi&u=https://futurofortissimo.github.io/');
     </script>
 </head>
   <body class="bg-white text-gray-900 antialiased selection:bg-gray-900 selection:text-white">
@@ -362,9 +362,9 @@
       <div class="max-w-5xl mx-auto flex items-center justify-end gap-1 px-4 py-1">
         <a href="https://futurofortissimo.github.io/" title="Italiano">IT</a>
         <span style="color:rgba(255,255,255,0.3);user-select:none;">/</span>
-        <a href="https://futurofortissimo-github-io.translate.goog/?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=it&_x_tr_pto=wapp" title="English" rel="noopener">EN</a>
+        <a href="https://translate.google.com/translate?sl=it&tl=en&u=https://futurofortissimo.github.io/" title="English" rel="noopener">EN</a>
         <span style="color:rgba(255,255,255,0.3);user-select:none;">/</span>
-        <a href="https://futurofortissimo-github-io.translate.goog/?_x_tr_sl=auto&_x_tr_tl=hi&_x_tr_hl=it&_x_tr_pto=wapp" aria-current="page" title="Hindi" rel="noopener">HI</a>
+        <a href="https://translate.google.com/translate?sl=it&tl=hi&u=https://futurofortissimo.github.io/" aria-current="page" title="Hindi" rel="noopener">HI</a>
       </div>
     </nav>
     <div id="root"></div>

--- a/index.html
+++ b/index.html
@@ -378,9 +378,9 @@
       <div class="max-w-5xl mx-auto flex items-center justify-end gap-1 px-4 py-1">
         <a href="https://futurofortissimo.github.io/" aria-current="page" title="Italiano">IT</a>
         <span style="color:rgba(255,255,255,0.3);user-select:none;">/</span>
-        <a href="https://futurofortissimo-github-io.translate.goog/?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=it&_x_tr_pto=wapp" title="English" rel="noopener">EN</a>
+        <a href="https://translate.google.com/translate?sl=it&tl=en&u=https://futurofortissimo.github.io/" title="English" rel="noopener">EN</a>
         <span style="color:rgba(255,255,255,0.3);user-select:none;">/</span>
-        <a href="https://futurofortissimo-github-io.translate.goog/?_x_tr_sl=auto&_x_tr_tl=hi&_x_tr_hl=it&_x_tr_pto=wapp" title="Hindi" rel="noopener">HI</a>
+        <a href="https://translate.google.com/translate?sl=it&tl=hi&u=https://futurofortissimo.github.io/" title="Hindi" rel="noopener">HI</a>
       </div>
     </nav>
     <div id="root"></div>


### PR DESCRIPTION
## Summary\n- Update language links to always use Google Translate with \n- Ensure HI translation uses Italian source directly (not EN->HI chain)\n- Apply consistently on root, /en, /hi pages\n\n## Why\nPrevents translation drift and keeps EN/HI logically consistent with original Italian content.\n\n## Files\n- index.html\n- en/index.html\n- hi/index.html