### PR TITLE
book/ch4: enforce concise claim-link labels

### DIFF
--- a/book/chapter-04.html
+++ b/book/chapter-04.html
@@ -74,7 +74,7 @@
         <div class="chapter-num text-zinc-400 mb-4">CAPITOLO 04 / 5</div>
         <h1 class="text-2xl sm:text-3xl md:text-4xl font-bold leading-tight mb-4" style="text-transform:none">&#128218; Letture e Riassunti &mdash; I Libri che Hanno Ispirato la Newsletter</h1>
         <p class="text-zinc-600 text-lg max-w-2xl mb-4">Sette libri che hanno plasmato il pensiero di Futuro Fortissimo: dalla respirazione alla dopamina, dal tempo alla creativit&agrave;. Un viaggio attraverso le idee che connettono corpo, mente e societ&agrave;.</p>
-        <div class="reading-time mb-6">~11 min di lettura &middot; Ultimo aggiornamento: 2026-02-25 &middot; Riferimenti: 10</div>
+        <div class="reading-time mb-6">~11 min di lettura &middot; Ultimo aggiornamento: 2026-02-28 &middot; Riferimenti: 10</div>
         <div class="border-t-2 border-zinc-100 pt-4">
             <div class="ff-eyebrow text-zinc-400 mb-3 text-xs">In questo capitolo</div>
             <div class="space-y-1">
@@ -214,7 +214,38 @@
 </footer>
 <script>
 const substackMap={"22":"https://fortissimo.substack.com/p/-ff22-mangiamo-troppo","44":"https://fortissimo.substack.com/p/ff42-che-ansia-pt-1","86":"https://fortissimo.substack.com/p/ff86-movimento","87":"https://fortissimo.substack.com/p/ff87-siamo-quello-che-respiriamo","90":"https://fortissimo.substack.com/p/ff91-lepidemia-di-stress","120":"https://fortissimo.substack.com/p/ff120-sport-e-longevita","127":"https://fortissimo.substack.com/p/ff127-jazz-con-chatgpt"};
-document.querySelectorAll('.fc').forEach(el=>{const m=el.textContent.match(/ff\.(\d+)/);if(m){const url=substackMap[m[1]]||('https://fortissimo.substack.com/p/ff'+m[1]);const a=document.createElement('a');a.href=url;a.className=el.className;a.innerHTML=el.innerHTML;a.target='_blank';a.rel='noopener noreferrer';el.replaceWith(a);}});
+
+const compactClaimLabel = (raw, maxWords = 15) => {
+  const cleaned = raw.replace(/\s+/g, ' ').trim();
+  const words = cleaned.split(' ').filter(Boolean);
+  if (words.length <= maxWords) return cleaned;
+  return `${words.slice(0, maxWords).join(' ')}…`;
+};
+
+document.querySelectorAll('.fc').forEach((el)=>{
+  const rawText = el.textContent || '';
+  const ffMatch = rawText.match(/ff\.\d+(?:\.\d+)?/);
+  const m = rawText.match(/ff\.(\d+)/);
+  if (!m) return;
+
+  const url = substackMap[m[1]] || (`https://fortissimo.substack.com/p/ff${m[1]}`);
+  const titlePart = rawText
+    .replace(/\s*\(\s*ff\.\d+(?:\.\d+)?\s*\)\s*/i, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const fallback = ffMatch ? `Source ${ffMatch[0]}` : `Source ff.${m[1]}`;
+  const label = compactClaimLabel(titlePart || fallback, 15);
+
+  const a = document.createElement('a');
+  a.href = url;
+  a.className = el.className;
+  a.target = '_blank';
+  a.rel = 'noopener noreferrer';
+  a.textContent = label;
+  a.setAttribute('aria-label', `${label} — apre la fonte`);
+  a.title = titlePart || fallback;
+  el.replaceWith(a);
+});
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add the same linked-claim label compaction guardrail used in other chapters to chapter 04
- force autogenerated `.fc` link text to max 15 words and keep full text in `title`
- keep source mapping auto-linking intact while improving readability/accessibility
- update chapter metadata timestamp (Ultimo aggiornamento) to 2026-02-28

## Why
Chapter 04 still had the older `.fc` linker logic. This aligns it with the editorial guardrail so linked claim text stays concise and scan-friendly.

## Mandatory editorial compliance checklist
- [x] repo target verified: `futurofortissimo/futurofortissimo.github.io`, folder `book/`
- [x] removed note/raw style passages (none introduced; no note/raw placeholders added)
- [x] linked claim text <= 15 words (enforced via `compactClaimLabel(..., 15)` for `.fc` links)
- [x] Search section present
- [x] last-updated timestamp present and updated
- [x] reading-time estimate present
- [x] ref count present

## Testing
- static review of generated chapter script behavior
- verified metadata/search/ref/read-time blocks still present in chapter 04
