### PR TITLE
Tecnologia: pass editoriale su agency, attenzione e responsabilità

### DIFF
--- a/book/chapter-02.html
+++ b/book/chapter-02.html
@@ -372,6 +372,8 @@
     L'AI con il coltellino svizzero</span>). La traiettoria verso la singolarità, nelle note, non è un evento unico ma una sequenza di miglioramenti cumulativi su modelli, chip e interfacce (<span class="fc">🌱 ff.129
     Singolarità gentile</span>).</p>
 
+    <p>C&apos;&egrave; poi un punto che nel dibattito pubblico viene spesso rimosso: la tecnologia non &egrave; neutra nemmeno quando sembra solo &ldquo;utile&rdquo;. Ogni interfaccia decide cosa rendere visibile e cosa far sparire; ogni automazione sposta potere da una persona a un protocollo; ogni scorciatoia cognitiva pu&ograve; liberare tempo o ridurre autonomia, dipende da come &egrave; disegnata. Per questo la vera metrica non &egrave; il numero di feature rilasciate, ma la qualit&agrave; delle decisioni che restano in mano agli esseri umani. Nel corpus ricorre una linea coerente: l&apos;AI genera valore quando si incastra in workflow semplici, verificabili, ripetibili, dove il costo energetico e il costo d&apos;attenzione sono espliciti. Se invece la usiamo come sostituto generalista della responsabilit&agrave;, otteniamo l&apos;effetto opposto: pi&ugrave; output, meno direzione. La promessa giusta non &egrave; &ldquo;fare tutto con un prompt&rdquo;, ma aumentare lucidit&agrave; nelle scelte ad alto impatto: cosa automatizzare, cosa mantenere umano, cosa misurare davvero. In questo senso, chip, batterie e modelli sono solo met&agrave; della storia; l&apos;altra met&agrave; &egrave; governance quotidiana dell&apos;attenzione. Una buona tecnologia non ti toglie il giudizio: ti restituisce margine per esercitarlo meglio, con meno rumore e pi&ugrave; responsabilit&agrave;.</p>
+
     </article>
 
     <!-- Newsletter CTA -->


### PR DESCRIPTION
## Summary\nEditorial pass su **Cap. 02 Tecnologia** con blocco mini-saggio su agency, governance dell'attenzione e responsabilità d'uso dell'AI.\n\n## Changes\n- aggiunto paragrafo conclusivo con focus su metriche utili (decision quality > feature count)\n- reso esplicito il trade-off automazione/autonomia\n- mantenuta coerenza con linea del capitolo (chip + energia + interfacce + uso reale)\n\n## Corpus-only sources (FF.X.Y)\n- ff.123\n- ff.129\n- ff.135.2\n- ff.42\n- ff.83\n\n## Editorial compliance\n- [x] Solo corpus/notes interni FF\n- [x] Nessuna fonte esterna nuova\n- [x] Intervento >= 200 parole tra aggiunte/revisioni/tagli\n- [x] Tono mini-saggio coerente\n