### PR TITLE
Natura: integrazione ff.122.1–4 (efficienza biologica, DNA, biomimicry)

### DIFF
--- a/book/chapter-01.html
+++ b/book/chapter-01.html
@@ -260,7 +260,22 @@
     
     <p>La biologia sintetica, nel frattempo, spinge i confini dell'immaginazione. Colossal Biosciences sta tentando di resuscitare il mammut lanoso attraverso l'editing genetico CRISPR, non per nostalgia ma per riequilibrare l'ecosistema della tundra: i mammut compattavano la neve, mantenendo il permafrost freddo e impedendo il rilascio di metano. DeepMind, con AlphaFold, ha predetto la struttura 3D di 200 milioni di proteine &mdash; risolvendo in 18 mesi un enigma cinquantennale della biologia. Un'AI ha ridotto il tempo di ricerca farmacologica da <mark class="note-highlight">3 mesi a 3 ore</mark>, mentre il DNA viene oggi usato come supporto di archiviazione: George Church ha codificato un intero libro in molecole di DNA
     (<span class="fc">&#129428; ff.4
-    Mammut resuscitati</span>).</p>
+    Mammut resuscitati</span>).
+    La questione va oltre la curiosit&agrave; scientifica: Church e Asimov Press vendono oggi libri scritti letteralmente nel DNA &mdash; <mark class="note-highlight">60 euro, 240 pagine, 500.000 molecole</mark> &mdash; trasformando la doppia elica da deposito di istruzioni biologiche a supporto di archiviazione culturale
+    (<span class="fc">&#129516; ff.122.3
+    Scrivere con il DNA</span>).
+    &Egrave; un rovesciamento interessante: la natura come tecnologia dell'informazione, non il contrario.</p>
+
+    <p>Il paradosso pi&ugrave; rivelatore, per&ograve;, riguarda l'efficienza. Un cervello umano funziona con <mark class="note-highlight">20 watt</mark> &mdash; un milione di volte meno del supercomputer Frontier, che ne richiede 21 milioni. AlphaGo ha battuto il campione mondiale di Go consumando l'energia che un essere umano userebbe in un decennio
+    (<span class="fc">&#129504; ff.122.1
+    L'efficienza computazionale del cervello</span>).
+    L'AI simula le connessioni cerebrali a livello software, ma l'hardware resta binario dove i neuroni sono analogici e continui: il chip neuomorfico &egrave; ancora un progetto, non un prodotto
+    (<span class="fc">&#128190; ff.122.2
+    Computer neuromorfici?</span>).
+    Se la natura &egrave; cos&igrave; pi&ugrave; efficiente, ha senso provare a replicarla anche nei materiali. Al MIT, Neri Oxman unisce design, biologia e ingegneria per creare strutture prodotte direttamente da organismi viventi &mdash; calzature fatte da vermi, padiglioni tessuti da bachi da seta &mdash; in una convergenza che rende obsoleta la distinzione tra fabbricato e cresciuto
+    (<span class="fc">&#128028; ff.122.4
+    Nike fatte da vermi</span>).
+    Dalla tundra dei mammut al laboratorio del DNA, il filo &egrave; lo stesso: ogni volta che la tecnologia ascolta la biologia invece di ignorarla, il risultato &egrave; pi&ugrave; elegante, pi&ugrave; efficiente e meno costoso.</p>
 
     <figure>
         <img src="/index_files/pubs/ff4.webp" alt="Illustrazione di mammut e biotecnologia" loading="lazy" width="800" height="450"/>


### PR DESCRIPTION
## Natura — integrazione ff.122.1–4 (efficienza biologica, DNA, biomimicry)

### Approccio editoriale
Le 4 note di ff.122 ("Naturale è meglio?") sono state tessute **dentro il filo esistente** sulla biologia sintetica in sezione 1.2, non accodate in fondo. George Church e il DNA erano già citati — il nuovo testo espande quel passaggio con la connessione archiviazione culturale su DNA (Asimov Press), il paradosso efficienza cervello vs supercomputer, i chip neuromorfici, e la convergenza design/biologia di Neri Oxman. Il blocco si chiude con un raccordo che riannoda tundra-mammut e laboratorio-DNA nello stesso principio: ascoltare la biologia produce risultati migliori.

### FF.X.Y integrati
- ff.122.1 (efficienza computazionale cervello)
- ff.122.2 (computer neuromorfici)
- ff.122.3 (scrivere con il DNA)
- ff.122.4 (Nike fatte da vermi / Neri Oxman)

### Wordcount
~250 parole aggiunte (passaggio esistente rivisto + 2 nuovi paragrafi)

### Compliance
- [x] Solo corpus FF (content_it.json)
- [x] Nessuna fonte esterna
- [x] ≥200 parole reali
- [x] Formato ref: <span class="fc">emoji ff.X.Y\n    Titolo</span>
- [x] Dati quantitativi con <mark class="note-highlight">
- [x] Tono mini-saggio coerente con capitolo
- [x] Integrazione nel filo argomentativo (non appendice)
