### PR TITLE
Expand Chapter 3 content with philosophical frameworks

### DIFF
--- a/book/chapter-03.html
+++ b/book/chapter-03.html
@@ -51,7 +51,7 @@
         @media print{body::before{display:none}.brutal-card{box-shadow:none;border:1px solid #999}.newsletter-cta,.skip-link{display:none}}
         @media(prefers-reduced-motion:reduce){*{transition-duration:0.01ms!important;animation-duration:0.01ms!important}}
     </style>
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Chapter","name":"Società — Noi, Insieme","position":3,"isPartOf":{"@type":"Book","name":"Futuro Fortissimo — Tre Macro Temi","url":"https://futurofortissimo.github.io/book/"},"url":"https://futurofortissimo.github.io/book/chapter-03.html","inLanguage":"it","author":{"@type":"Person","name":"Michele Merelli"},"wordCount":5100}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Chapter","name":"Società — Noi, Insieme","position":3,"isPartOf":{"@type":"Book","name":"Futuro Fortissimo — Tre Macro Temi","url":"https://futurofortissimo.github.io/book/"},"url":"https://futurofortissimo.github.io/book/chapter-03.html","inLanguage":"it","author":{"@type":"Person","name":"Michele Merelli"},"wordCount":5750}</script>
 </head>
 <body class="antialiased">
 <a href="#content" class="skip-link">Vai al contenuto</a>
@@ -74,7 +74,7 @@
         <div class="chapter-num text-zinc-400 mb-4">CAPITOLO 03 / 5</div>
         <h1 class="text-2xl sm:text-3xl md:text-4xl font-bold leading-tight mb-4" style="text-transform:none">&#10084;&#65039; Societ&agrave; &mdash; Noi, Insieme</h1>
         <p class="text-zinc-600 text-lg max-w-2xl mb-4">La crisi contemporanea &egrave; di attenzione, contatto e governance. Flow, solitudine, geopolitica e denaro convergono in un unico tessuto: il corpo sociale come infrastruttura da riprogettare.</p>
-        <div class="reading-time mb-6">~28 min di lettura &middot; Ultimo aggiornamento: 2026-03-04 &middot; Riferimenti: 56</div>
+        <div class="reading-time mb-6">~32 min di lettura &middot; Ultimo aggiornamento: 2026-03-04 &middot; Riferimenti: 60</div>
         <div class="border-t-2 border-zinc-100 pt-4">
             <div class="ff-eyebrow text-zinc-400 mb-3 text-xs">In questo capitolo</div>
             <div class="space-y-1">
@@ -130,6 +130,24 @@
     Arthur Brooks, professore a Harvard e editorialista dell'<em>Atlantic</em>, studia le curve di produttivit&agrave; nel tempo: l'intelligenza fluida (problem-solving rapido) declina dopo i 40, ma l'intelligenza cristallizzata (saggezza, sintesi, insegnamento) cresce fino alla fine. Darwin era fluido; Bach era cristallizzato. La seconda met&agrave; della vita non &egrave; un declino: &egrave; una trasformazione
     (<span class="fc">&#128142; ff.137.3
     Cristalli e Bach</span>).</p>
+
+    <p>Ma prima di cristallizzarsi, bisogna sopravvivere alla discesa. Brooks, nel suo celebre saggio dell&#39;<em>Atlantic</em> del 2019, va oltre l&#39;intelligenza e formula il <strong>principio di psicogravit&agrave; professionale</strong> &mdash; una legge spietata: pi&ugrave; si arriva in alto, pi&ugrave; &egrave; dura andarsene
+    (<span class="fc">🏆 ff.137.2
+    Picchi entropici</span>).
+    Non si tratta solo di atleti olimpici in forma straordinaria o di attori che guadagnano un milione a episodio: Brooks lo vive in prima persona, nel modo pi&ugrave; intimo. Un giorno si sveglia e non suona pi&ugrave; il corno con la stessa fluidit&agrave;. L&#39;entropia vince sempre. Eliud Kipchoge, in lacrime dopo quella che &mdash; a quarant&#39;anni &mdash; potrebbe essere la sua ultima maratona da professionista, incarna questa matematica crudele con la dignit&agrave; di chi ha corso pi&ugrave; forte di chiunque altro: anche il pi&ugrave; grande non sfugge alla curva discendente. Rimanere al livello raggiunto diventa sempre pi&ugrave; difficile. Il segreto non &egrave; fermare l&#39;entropia &mdash; &egrave; cambiare l&#39;<em>asse delle ordinate</em>: ridefinire cosa contiamo come progresso.</p>
+
+    <p>La risposta di Warren Buffett &egrave; matematicamente identica ma applicata all&#39;intera vita: <mark class="note-highlight">il 95% del suo patrimonio si &egrave; accumulato dopo i suoi sessantacinque anni</mark>. Non &egrave; fortuna, &egrave; <em>compound</em> &mdash; l&#39;interesse composto applicato al tempo e alle abitudini. Accumulare buone routine &mdash; attivit&agrave; sportiva, una dieta sana, relazioni coltivate &mdash; deve essere percepito come una <strong>crescita continua anche quando i numeri sembrano fermi</strong>: ogni ripetizione non &egrave; identica alla precedente, &egrave; un cristallo che si deposita su altri cristalli
+    (<span class="fc">📈 ff.137.4
+    Filosofia dell&#39;accumulo</span>).
+    La dashboard <em>League of Strava</em> &mdash; che trasforma chilometri percorsi e anni di allenamento in qualcosa di tangibile, come un conto corrente di salute guadagnata &mdash; &egrave; la versione ironica e operativa di questa filosofia. Il corto <em>Hag</em> di Anna Ginsburg restituisce invece dignit&agrave; estetica alla fase post-picco nelle donne, sfilandola dalla logica della decadenza inevitabile: <strong>il dopo-picco ha una sua architettura</strong>, e chi non la progetta la subisce.</p>
+
+    <p>Il complemento percettivo a questa filosofia dell&#39;accumulo viene, sorprendentemente, dal Giappone. Il calendario tradizionale divide l&#39;anno non in quattro stagioni ma in <mark class="note-highlight">settantadue</mark> <em>sekku</em> &mdash; micro-stagioni che nominano sfumature altrimenti invisibili: <em>Hakuro</em>, la rugiada bianca che brilla tra l&#39;8 e il 12 settembre; <em>Tsuchi urou&#771;te mushi atsushi</em>, terra umida e caldo soffocante tra il 29 luglio e il 2 agosto; <em>Uo k&#333;ri o izuru</em>, i pesci che fanno capolino dal ghiaccio tra il 14 e il 18 febbraio
+    (<span class="fc">❄️ ff.134.3
+    Le 72 stagioni giapponesi</span>).
+    Settantadue occasioni all&#39;anno di accorgersi di ci&ograve; che c&#39;&egrave; gi&agrave; ma che l&#39;abitudine ha reso invisibile. Non &egrave; un calendario alternativo: &egrave; un <strong>modello cognitivo di granularit&agrave;</strong>. Il &ldquo;non esistono pi&ugrave; le mezze stagioni&rdquo; del qualunquismo meteorologico &egrave; la rinuncia al vocabolario prima ancora che alla percezione. E la perdita del vocabolario &egrave; la perdita del mondo stesso. Scriveva William James nel 1884: <em>&ldquo;Un&#39;emozione puramente disincarnata &egrave; un non-ente.&rdquo;</em> Vale anche per un&#39;esperienza non nominata: esiste a met&agrave;
+    (<span class="fc">🦴 ff.134.4
+    Umanit&agrave; all&#39;osso</span>).
+    In un mondo in cui sempre pi&ugrave; pensiero viene allocato ai modelli linguistici &mdash; dove &ldquo;scaliamo&rdquo; startup invece di scalare montagne &mdash; ri-attaccarsi alle parole come <strong>legame tra Pensiero e Mondo</strong> diventa un atto di resistenza culturale. Le settantadue stagioni, le emozioni nominate con precisione, la rugiada che brilla otto giorni l&#39;anno: sono la difesa pi&ugrave; efficace contro l&#39;appiattimento dell&#39;esperienza in contenuto algoritmico.</p>
 
     <p>L'ansia moderna ha una dimensione quantitativa: il tempo accettabile per il caricamento di una pagina web &egrave; sceso da 4 a 2 secondi in tre anni. Misuriamo tutto &mdash; dal sonno alle calorie &mdash; con un incremento nell'uso di app di tracking che, paradossalmente, aumenta l'ansia invece di ridurla. Naval Ravikant propone la cura: meno ego e controllo, pi&ugrave; flow e presente
     (<span class="fc">&#128552; ff.68


### PR DESCRIPTION
## Summary
- Added ~650 words of new content to Chapter 3 exploring professional psychogravity, compound growth philosophy, and Japanese micro-seasons as cognitive models
- Updated word count from 5100 to 5750 words
- Updated reading time estimate from ~28 to ~32 minutes
- Added 4 new reference citations (56 → 60 total references)

## Changes
- Inserted new section after "Cristalli e Bach" reference exploring:
  - Brooks' principle of professional psychogravity and entropy in peak performance
  - Eliud Kipchoge's post-peak dignity and redefining progress metrics
  - Warren Buffett's compound growth philosophy (95% wealth accumulated after age 65)
  - Japanese *sekku* calendar (72 micro-seasons) as a cognitive granularity model
  - Connection between language, perception, and resistance to algorithmic flattening
- Updated metadata:
  - `wordCount`: 5100 → 5750
  - Reading time: "~28 min" → "~32 min"
  - Reference count: 56 → 60
- Added 4 new `.fc` reference markers (ff.137.2, ff.137.4, ff.134.3, ff.134.4)

## Validation
- [x] `npm run check:book-editorial` (for `book/` changes)
- [x] Local smoke check completed

## Book editorial compliance checklist (required when touching `book/`)
- [x] Removed note/raw style passages
- [x] Linked claim text is <= 15 words
- [x] Search section present and updated
- [x] Last-updated timestamp present (2026-03-04)
- [x] Reading-time estimate present (~32 min)
- [x] Reference count present and aligned to `.fc` entries (60 references, 4 new `.fc` markers added)

https://claude.ai/code/session_01Hm8Sp18XtmKo4a51KKqnvP