### PR TITLE
Sync Substack RSS latest posts to front-page pubs index

### DIFF
--- a/index_files/pubs.json
+++ b/index_files/pubs.json
@@ -1,5 +1,26 @@
 [
   {
+    "img": "https://substack-post-media.s3.amazonaws.com/public/images/387b1821-9616-4c39-ae7d-fe96bf4944a5_786x545.png",
+    "title": "🎼 ff.145 Zucchero, ossa e crème brûlée",
+    "subtitle": "Food design contro \"il nuovo fumo\", il cibo",
+    "links": [],
+    "readMoreUrl": "https://fortissimo.substack.com/p/ff145-zucchero-ossa-e-creme-brulee"
+  },
+  {
+    "img": "https://substack-post-media.s3.amazonaws.com/public/images/55c89a6c-6ba4-428d-b3a5-3410a9f194a2_2752x1536.png",
+    "title": "🎼 ff.144 Il fischio dell'aragosta",
+    "subtitle": "Il rischio di una \"semplicità\" accelerata (dalle GPU)",
+    "links": [],
+    "readMoreUrl": "https://fortissimo.substack.com/p/ff144-il-fischio-dellaragosta"
+  },
+  {
+    "img": "https://substack-post-media.s3.amazonaws.com/public/images/36cd5ac7-7c62-4da0-ba6a-26dccf81b4ca_1024x1024.jpeg",
+    "title": "🎼 ff.143 Scimmie col Rolex",
+    "subtitle": "Preparare un IRONMAN \"fumando\" 30 sigarette al giorno",
+    "links": [],
+    "readMoreUrl": "https://fortissimo.substack.com/p/ff143-scimmie-col-rolex"
+  },
+  {
     "img": "/index_files/pubs/ff81.png",
     "title": "🎼 ff.81 Siamo quello che respiriamo",
     "subtitle": "Respiro tra ansia, aria inquinata e purificatori d'aria",
@@ -64,20 +85,20 @@
     "readMoreUrl": "https://fortissimo.substack.com/p/ff71-giochiamo-a-uno"
   },
   {
-  "img": "/index_files/pubs/ff77.png",
-  "title": "🎼 ff.77 Famiglia cercasi",
-  "subtitle": "Tra Giorgia Meloni, Nobel per l'economia e l'individuo moderno",
-  "links": [
-    {
-      "text": "🥊 Papa Francesco VS Giorgia Meloni",
-      "url": "https://www.youtube.com/watch?v=TbEiQV4pGhs"
-    },
-    {
-      "text": "👨‍👩‍👧‍👦 Valori famigliari e fertilità - Studio su EVS",
-      "url": "https://www.worksinprogress.news/p/the-value-of-family"
-    }
-  ],
-  "readMoreUrl": "https://fortissimo.substack.com/p/ff77-famiglia-cercasi"
+    "img": "/index_files/pubs/ff77.png",
+    "title": "🎼 ff.77 Famiglia cercasi",
+    "subtitle": "Tra Giorgia Meloni, Nobel per l'economia e l'individuo moderno",
+    "links": [
+      {
+        "text": "🥊 Papa Francesco VS Giorgia Meloni",
+        "url": "https://www.youtube.com/watch?v=TbEiQV4pGhs"
+      },
+      {
+        "text": "👨‍👩‍👧‍👦 Valori famigliari e fertilità - Studio su EVS",
+        "url": "https://www.worksinprogress.news/p/the-value-of-family"
+      }
+    ],
+    "readMoreUrl": "https://fortissimo.substack.com/p/ff77-famiglia-cercasi"
   },
   {
     "img": "/index_files/pubs/ff76.png",
@@ -100,248 +121,245 @@
     "readMoreUrl": "https://fortissimo.substack.com/p/ff76-quello-che-resta-del-lockdown"
   },
   {
-  "img": "/index_files/pubs/ff74.png",
-  "title": "🎼 ff.74 Sono giapponese!",
-  "subtitle": "Giappone: tra infanzia e futuro",
-  "links": [
-    {
-      "text": "📚 La storia e il nostro futuro",
-      "url": "https://www.borsaitaliana.it/speciali/fisherinvestments/italia/perche-gli-investitori-non-devono-temere-la-giapponesizzazione-dell-europa.htm"
-    },
-    {
-      "text": "🐉 Un'infanzia tra Goku e Pikachu",
-      "url": "https://fortissimo.substack.com/i/137321489/ff-la-magia-come-fuga-dalla-realta"
-    }
-  ],
-  "readMoreUrl": "https://fortissimo.substack.com/p/ff74-made-in-japan"
-}
-,
-{
-  "img": "/index_files/pubs/ff73.png",
-  "title": "🎼 ff.73 Futuro criptato",
-  "subtitle": "Criptovalute, Monna Lisa Majin Buu e l'inflazione",
-  "links": [
-    {
-      "text": "💾 L'update di A16Z sulle criptovalute",
-      "url": "https://a16zcrypto.com/stateofcrypto"
-    },
-    {
-      "text": "🌍 Il futuro è in Nigeria?",
-      "url": "https://www.pwc.com/ng/en/publications/nigeria-india-learnings-from-two-democracies.html"
-    }
-  ],
-  "readMoreUrl": "https://fortissimo.substack.com/p/ff72-criptico"
-},
-{
-"img": "https://substack-post-media.s3.amazonaws.com/public/images/beaacdf6-7dcb-46a4-88f2-fa64f1c108a2_1024x538.jpeg",
-"title": "🎼 ff.52 Fondare una Nazione in garage",
-"subtitle": "Centralizzazione o decentralizzazione? Un equilibrio instabile",
-"links": [
-  {
-    "text": "🌆 La crescita accade in città",
-    "url": "https://www.mckinsey.com/mgi/our-research/Pixels-of-progress-chapter-1?utm_source=substack&utm_medium=email"
+    "img": "/index_files/pubs/ff74.png",
+    "title": "🎼 ff.74 Sono giapponese!",
+    "subtitle": "Giappone: tra infanzia e futuro",
+    "links": [
+      {
+        "text": "📚 La storia e il nostro futuro",
+        "url": "https://www.borsaitaliana.it/speciali/fisherinvestments/italia/perche-gli-investitori-non-devono-temere-la-giapponesizzazione-dell-europa.htm"
+      },
+      {
+        "text": "🐉 Un'infanzia tra Goku e Pikachu",
+        "url": "https://fortissimo.substack.com/i/137321489/ff-la-magia-come-fuga-dalla-realta"
+      }
+    ],
+    "readMoreUrl": "https://fortissimo.substack.com/p/ff74-made-in-japan"
   },
   {
-    "text": "💸‍ Il libro The Network State",
-    "url": "https://amzn.to/4ctVwv2"
-  }
-],
-"readMoreUrl": "https://fortissimo.substack.com/p/ff77-famiglia-cercasi"
-},
-{
-"img": "/index_files/pubs/ff44.webp",
-"title": "🎼 ff.44 Che ansia! (pt. 1)",
-"subtitle": "Perché pensare meno al futuro a volte fa bene",
-"links": [
-  {
-    "text": "🥊 Fissare un quadro per tre ore",
-    "url": "https://www.youtube.com/watch?v=TbEiQV4pGhs"
+    "img": "/index_files/pubs/ff73.png",
+    "title": "🎼 ff.73 Futuro criptato",
+    "subtitle": "Criptovalute, Monna Lisa Majin Buu e l'inflazione",
+    "links": [
+      {
+        "text": "💾 L'update di A16Z sulle criptovalute",
+        "url": "https://a16zcrypto.com/stateofcrypto"
+      },
+      {
+        "text": "🌍 Il futuro è in Nigeria?",
+        "url": "https://www.pwc.com/ng/en/publications/nigeria-india-learnings-from-two-democracies.html"
+      }
+    ],
+    "readMoreUrl": "https://fortissimo.substack.com/p/ff72-criptico"
   },
   {
-    "text": "‍📚 Il libro contro l'ansia",
-    "url": "https://amzn.to/3TLSOtr"
-  }
-],
-"readMoreUrl": "https://fortissimo.substack.com/p/ff77-famiglia-cercasi"
-},
-{
-  "img": "/index_files/pubs/ff1.webp",
-  "title": "🎼 ff.1 Clima",
-  "subtitle": "COP26, The Big Greta Is Watching You e le strategie per net-zero",
-  "links": [
-    {
-      "text": "🌍 Sito Ufficiale COP26 ",
-      "url": "https://ukcop26.org/"
-    },
-    {
-      "text": "📘 Guida per raggiungere il net-zero",
-      "url": "https://www.iea.org/reports/net-zero-by-2050"
-    }
-  ],
-  "readMoreUrl": "https://fortissimo.substack.com/p/-ff1-clima"
-},
-{
-  "img": "https://substack-post-media.s3.amazonaws.com/public/images/b610d5e9-0de9-4790-8df1-98984a470bc3_889x492.jpeg",
-  "title": "🎼 ff.65 Come fermare il tempo",
-  "subtitle": "Da routine sempre più veloci a esercizi mentali per rallentare un attimo",
-  "links": [
-    {
-      "text": "⌛ Un cerchio dura di più se statico",
-      "url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2685822/"
-    },
-    {
-      "text": "📝 ff.65.3 Il compito a casa per la vita",
-      "url": "https://fortissimo.substack.com/i/107595173/ff-il-compito-a-casa-per-la-vita"
-    }
-  ],
-  "readMoreUrl": "https://fortissimo.substack.com/p/ff65-come-fermare-il-tempo"
-},
-{
-  "img": "/index_files/pubs/ff56.webp",
-  "title": "🎼 ff.56 Il Condizionatore Terrestre",
-  "subtitle": "Ozono, agricoltura e industrializzazione: siamo già geo-ingegneri?",
-  "links": [
-    {
-      "text": "🦣 ff.56.1 Gli ultimi 22k anni di termometro terrestre",
-      "url": "https://fortissimo.substack.com/i/105434036/ff-gli-ultimi-k-anni-di-termometro-terrestre"
-    },
-    {
-      "text": "📚 Il libro sulla geo-ingegneria",
-      "url": "https://amzn.to/43CpGYN"
-    }
-  ],
-  "readMoreUrl": "https://fortissimo.substack.com/p/ff54-il-condizionatore-terrestre"
-},
-{
-  "img": "/index_files/pubs/ff34.webp",
-  "title": "🎼 ff.34 Ripensare le città",
-  "subtitle": "Quello che il COVID e il cambiamento climatico ci hanno insegnato sulle città",
-  "links": [
-    {
-      "text": "🏙 Viviamo sempre più in aree urbanizzate",
-      "url": "https://ourworldindata.org/urbanization"
-    },
-    {
-      "text": "🚦 ff.34.3 Ripensare le città: spazi vivibili",
-      "url": "https://fortissimo.substack.com/i/67910559/ff-ripensare-le-citta-spazi-vivibili"
-    }
-  ],
-  "readMoreUrl": "https://fortissimo.substack.com/p/ff34-ripensare-le-citta"
-},
-{
-  "img": "https://substack-post-media.s3.amazonaws.com/public/images/d34c7b5d-0c03-4b87-a314-58c0fcdb0dd9_936x526.jpeg",
-  "title": "🎼 ff.88 Singolarità nel 2029?",
-  "subtitle": "L'accelerazione robotica grazie a ChatGPT e OpenAI",
-  "links": [
-    {
-      "text": "🤖 Robot controllato da ChatGPT",
-      "url": "https://www.figure.ai/"
-    },
-    {
-      "text": "👀 ff.88.3 Dalle parole ai fatti",
-      "url": "https://fortissimo.substack.com/i/142632080/ff-dalle-parole-ai-fatti"
-    }
-  ],
-  "readMoreUrl": "https://fortissimo.substack.com/p/ff88-singolarita-nel-2029"
-},
-{
-  "img": "/index_files/pubs/ff89.webp",
-  "title": "🎼 ff.89 Meno Tinder, più relazioni",
-  "subtitle": "Piccolo principe, Conad e persone oltre le cose.",
-  "links": [
-    {
-      "text": "🔺 ff.89.2 Piramide di Maslow 2.0",
-      "url": "https://fortissimo.substack.com/i/141331290/ff-piramide-di-maslow"
-    },
-    {
-      "text": "📚 Il libro sull'Essenzialismo",
-      "url": "https://amzn.to/3UIJkAd"
-    }
-  ],
-  "readMoreUrl": "https://fortissimo.substack.com/p/ff89-meno-tinder-piu-relazioni"
-},
-{
-  "img": "/index_files/pubs/ff70.webp",
-  "title": "🎼 ff.70 Il sole: soluzione o morte",
-  "subtitle": "Benvenuti su 🎼 ff, futuro fortissimo, uno spartito digitale in continua evoluzione con la musica del futuro.",
-  "links": [
-    {
-      "text": "Un necrologio alla tintarella in riva al mare",
-      "url": "https://www.bloomberg.com/opinion/articles/2023-07-30/record-heat-is-killing-summer-vacation-for-hotels-airlines-beaches"
-    },
-    {
-      "text": "Soldi fusi",
-      "url": "https://fortissimo.substack.com/i/44894125/ff-soldi-fusi"
-    }
-  ],
-  "readMoreUrl": "https://fortissimo.substack.com/p/ff70-il-sole-soluzione-o-morte"
-},
-{
-  "img": "https://substack-post-media.s3.amazonaws.com/public/images/dc5dc9fd-6203-4f0b-a830-d790337c609f_1280x701.jpeg",
-  "title": "🎼 ff.69 Futuro Quantico",
-  "subtitle": "Dai qu-bit alla sfida tra Google Sycamore e il supercomputer Frontier, un viaggio nel mondo della computazione quantistica.",
-  "links": [
-    {
-      "text": "🐱 Dal gatto di Schrödinger ai qu-bit",
-      "url": "https://fortissimo.substack.com/i/134659141/ff-dal-gatto-di-schrodinger-ai-qu-bit"
-    },
-    {
-      "text": "🤔 Quali utilizzi e pericoli?",
-      "url": "https://fortissimo.substack.com/i/134659141/ff-quali-utilizzi-e-pericoli"
-    }
-  ],
-  "readMoreUrl": "https://fortissimo.substack.com/p/ff69-quantico"
-},
-{
-  "img": "https://substack-post-media.s3.amazonaws.com/public/images/9adc929c-9b90-4d7e-a396-c8ab0439bb0b_1200x900.png",
-  "title": "🎼 ff.60 DriveGPT e il futuro della guida autonoma",
-  "subtitle": "Tra robotaxi, Tesla, e AI, esploriamo come la tecnologia sta cambiando il modo di guidare.",
-  "links": [
-    {
-      "text": "🤠 ff.60.1 Westworld della guida autonoma: SF",
-      "url": "https://fortissimo.substack.com/i/117901757/ff-westworld-della-guida-autonoma-sf"
-    },
-    {
-      "text": "💀 ff.60.5 Meno morti sulle strade?",
-      "url": "https://fortissimo.substack.com/i/117901757/ff-meno-morti-sulle-strade"
-    }
-  ],
-  "readMoreUrl": "https://fortissimo.substack.com/i/117901757"
-},{
-        "img": "https://substack-post-media.s3.amazonaws.com/public/images/027c3a41-2f85-44df-8907-358a8a68bca7_751x510.png",
-        "title": "🎼 ff.103 Fuoco, Ferro, Intelligenza",
-        "subtitle": "futuro fortissimo",
-        "links": [
-            {
-                "text": "🎓 ff.103.2 NASA, MENSA e QI",
-                "url": "https://fortissimo.substack.com/p/ff103-fuoco-ferro-intelligenza#%C2%A7ff-ff1032-nasa-mensa-e-qi"
-            },
-            {
-                "text": "🆕 ff.103.3 La nuova Era dell’Intelligenza",
-                "url": "https://fortissimo.substack.com/p/ff103-fuoco-ferro-intelligenza#%C2%A7ff--ff1033-la-nuova-era-dellintelligenza"
-            }
-        ],
-        "readMoreUrl": "https://fortissimo.substack.com/p/ff103-fuoco-ferro-intelligenza"
-    },
-
-    {
-        "img": "https://substack-post-media.s3.amazonaws.com/public/images/dc2c77b8-1d27-4d31-b98e-96a27d87db37_652x404.png",
-        "title": "🎼 ff.102 Il futuro in una conchiglia",
-        "subtitle": "🐚La musica (in conchiglia) del mare di progresso di quest’estate:",
-        "links": [
-            {
-                "text": "🩸 ff.102.4 Dal sangue ad Amazon",
-                "url": "https://fortissimo.substack.com/p/ff102-il-futuro-in-una-conchiglia#%C2%A7ff--ff1024-dal-sangue-ad-amazon"
-            },
-            {
-                "text": "🔭 ff.102.3 Automatizzare la ricerca scientifica",
-                "url": "https://fortissimo.substack.com/p/ff102-il-futuro-in-una-conchiglia#%C2%A7ff-automatizzare-la-ricerca-scientifica"
-            }
-        ],
-        "readMoreUrl": "https://fortissimo.substack.com/p/ff102-il-futuro-in-una-conchiglia"
-    }
-,
-
+    "img": "https://substack-post-media.s3.amazonaws.com/public/images/beaacdf6-7dcb-46a4-88f2-fa64f1c108a2_1024x538.jpeg",
+    "title": "🎼 ff.52 Fondare una Nazione in garage",
+    "subtitle": "Centralizzazione o decentralizzazione? Un equilibrio instabile",
+    "links": [
+      {
+        "text": "🌆 La crescita accade in città",
+        "url": "https://www.mckinsey.com/mgi/our-research/Pixels-of-progress-chapter-1?utm_source=substack&utm_medium=email"
+      },
+      {
+        "text": "💸‍ Il libro The Network State",
+        "url": "https://amzn.to/4ctVwv2"
+      }
+    ],
+    "readMoreUrl": "https://fortissimo.substack.com/p/ff77-famiglia-cercasi"
+  },
+  {
+    "img": "/index_files/pubs/ff44.webp",
+    "title": "🎼 ff.44 Che ansia! (pt. 1)",
+    "subtitle": "Perché pensare meno al futuro a volte fa bene",
+    "links": [
+      {
+        "text": "🥊 Fissare un quadro per tre ore",
+        "url": "https://www.youtube.com/watch?v=TbEiQV4pGhs"
+      },
+      {
+        "text": "‍📚 Il libro contro l'ansia",
+        "url": "https://amzn.to/3TLSOtr"
+      }
+    ],
+    "readMoreUrl": "https://fortissimo.substack.com/p/ff77-famiglia-cercasi"
+  },
+  {
+    "img": "/index_files/pubs/ff1.webp",
+    "title": "🎼 ff.1 Clima",
+    "subtitle": "COP26, The Big Greta Is Watching You e le strategie per net-zero",
+    "links": [
+      {
+        "text": "🌍 Sito Ufficiale COP26 ",
+        "url": "https://ukcop26.org/"
+      },
+      {
+        "text": "📘 Guida per raggiungere il net-zero",
+        "url": "https://www.iea.org/reports/net-zero-by-2050"
+      }
+    ],
+    "readMoreUrl": "https://fortissimo.substack.com/p/-ff1-clima"
+  },
+  {
+    "img": "https://substack-post-media.s3.amazonaws.com/public/images/b610d5e9-0de9-4790-8df1-98984a470bc3_889x492.jpeg",
+    "title": "🎼 ff.65 Come fermare il tempo",
+    "subtitle": "Da routine sempre più veloci a esercizi mentali per rallentare un attimo",
+    "links": [
+      {
+        "text": "⌛ Un cerchio dura di più se statico",
+        "url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2685822/"
+      },
+      {
+        "text": "📝 ff.65.3 Il compito a casa per la vita",
+        "url": "https://fortissimo.substack.com/i/107595173/ff-il-compito-a-casa-per-la-vita"
+      }
+    ],
+    "readMoreUrl": "https://fortissimo.substack.com/p/ff65-come-fermare-il-tempo"
+  },
+  {
+    "img": "/index_files/pubs/ff56.webp",
+    "title": "🎼 ff.56 Il Condizionatore Terrestre",
+    "subtitle": "Ozono, agricoltura e industrializzazione: siamo già geo-ingegneri?",
+    "links": [
+      {
+        "text": "🦣 ff.56.1 Gli ultimi 22k anni di termometro terrestre",
+        "url": "https://fortissimo.substack.com/i/105434036/ff-gli-ultimi-k-anni-di-termometro-terrestre"
+      },
+      {
+        "text": "📚 Il libro sulla geo-ingegneria",
+        "url": "https://amzn.to/43CpGYN"
+      }
+    ],
+    "readMoreUrl": "https://fortissimo.substack.com/p/ff54-il-condizionatore-terrestre"
+  },
+  {
+    "img": "/index_files/pubs/ff34.webp",
+    "title": "🎼 ff.34 Ripensare le città",
+    "subtitle": "Quello che il COVID e il cambiamento climatico ci hanno insegnato sulle città",
+    "links": [
+      {
+        "text": "🏙 Viviamo sempre più in aree urbanizzate",
+        "url": "https://ourworldindata.org/urbanization"
+      },
+      {
+        "text": "🚦 ff.34.3 Ripensare le città: spazi vivibili",
+        "url": "https://fortissimo.substack.com/i/67910559/ff-ripensare-le-citta-spazi-vivibili"
+      }
+    ],
+    "readMoreUrl": "https://fortissimo.substack.com/p/ff34-ripensare-le-citta"
+  },
+  {
+    "img": "https://substack-post-media.s3.amazonaws.com/public/images/d34c7b5d-0c03-4b87-a314-58c0fcdb0dd9_936x526.jpeg",
+    "title": "🎼 ff.88 Singolarità nel 2029?",
+    "subtitle": "L'accelerazione robotica grazie a ChatGPT e OpenAI",
+    "links": [
+      {
+        "text": "🤖 Robot controllato da ChatGPT",
+        "url": "https://www.figure.ai/"
+      },
+      {
+        "text": "👀 ff.88.3 Dalle parole ai fatti",
+        "url": "https://fortissimo.substack.com/i/142632080/ff-dalle-parole-ai-fatti"
+      }
+    ],
+    "readMoreUrl": "https://fortissimo.substack.com/p/ff88-singolarita-nel-2029"
+  },
+  {
+    "img": "/index_files/pubs/ff89.webp",
+    "title": "🎼 ff.89 Meno Tinder, più relazioni",
+    "subtitle": "Piccolo principe, Conad e persone oltre le cose.",
+    "links": [
+      {
+        "text": "🔺 ff.89.2 Piramide di Maslow 2.0",
+        "url": "https://fortissimo.substack.com/i/141331290/ff-piramide-di-maslow"
+      },
+      {
+        "text": "📚 Il libro sull'Essenzialismo",
+        "url": "https://amzn.to/3UIJkAd"
+      }
+    ],
+    "readMoreUrl": "https://fortissimo.substack.com/p/ff89-meno-tinder-piu-relazioni"
+  },
+  {
+    "img": "/index_files/pubs/ff70.webp",
+    "title": "🎼 ff.70 Il sole: soluzione o morte",
+    "subtitle": "Benvenuti su 🎼 ff, futuro fortissimo, uno spartito digitale in continua evoluzione con la musica del futuro.",
+    "links": [
+      {
+        "text": "Un necrologio alla tintarella in riva al mare",
+        "url": "https://www.bloomberg.com/opinion/articles/2023-07-30/record-heat-is-killing-summer-vacation-for-hotels-airlines-beaches"
+      },
+      {
+        "text": "Soldi fusi",
+        "url": "https://fortissimo.substack.com/i/44894125/ff-soldi-fusi"
+      }
+    ],
+    "readMoreUrl": "https://fortissimo.substack.com/p/ff70-il-sole-soluzione-o-morte"
+  },
+  {
+    "img": "https://substack-post-media.s3.amazonaws.com/public/images/dc5dc9fd-6203-4f0b-a830-d790337c609f_1280x701.jpeg",
+    "title": "🎼 ff.69 Futuro Quantico",
+    "subtitle": "Dai qu-bit alla sfida tra Google Sycamore e il supercomputer Frontier, un viaggio nel mondo della computazione quantistica.",
+    "links": [
+      {
+        "text": "🐱 Dal gatto di Schrödinger ai qu-bit",
+        "url": "https://fortissimo.substack.com/i/134659141/ff-dal-gatto-di-schrodinger-ai-qu-bit"
+      },
+      {
+        "text": "🤔 Quali utilizzi e pericoli?",
+        "url": "https://fortissimo.substack.com/i/134659141/ff-quali-utilizzi-e-pericoli"
+      }
+    ],
+    "readMoreUrl": "https://fortissimo.substack.com/p/ff69-quantico"
+  },
+  {
+    "img": "https://substack-post-media.s3.amazonaws.com/public/images/9adc929c-9b90-4d7e-a396-c8ab0439bb0b_1200x900.png",
+    "title": "🎼 ff.60 DriveGPT e il futuro della guida autonoma",
+    "subtitle": "Tra robotaxi, Tesla, e AI, esploriamo come la tecnologia sta cambiando il modo di guidare.",
+    "links": [
+      {
+        "text": "🤠 ff.60.1 Westworld della guida autonoma: SF",
+        "url": "https://fortissimo.substack.com/i/117901757/ff-westworld-della-guida-autonoma-sf"
+      },
+      {
+        "text": "💀 ff.60.5 Meno morti sulle strade?",
+        "url": "https://fortissimo.substack.com/i/117901757/ff-meno-morti-sulle-strade"
+      }
+    ],
+    "readMoreUrl": "https://fortissimo.substack.com/i/117901757"
+  },
+  {
+    "img": "https://substack-post-media.s3.amazonaws.com/public/images/027c3a41-2f85-44df-8907-358a8a68bca7_751x510.png",
+    "title": "🎼 ff.103 Fuoco, Ferro, Intelligenza",
+    "subtitle": "futuro fortissimo",
+    "links": [
+      {
+        "text": "🎓 ff.103.2 NASA, MENSA e QI",
+        "url": "https://fortissimo.substack.com/p/ff103-fuoco-ferro-intelligenza#%C2%A7ff-ff1032-nasa-mensa-e-qi"
+      },
+      {
+        "text": "🆕 ff.103.3 La nuova Era dell’Intelligenza",
+        "url": "https://fortissimo.substack.com/p/ff103-fuoco-ferro-intelligenza#%C2%A7ff--ff1033-la-nuova-era-dellintelligenza"
+      }
+    ],
+    "readMoreUrl": "https://fortissimo.substack.com/p/ff103-fuoco-ferro-intelligenza"
+  },
+  {
+    "img": "https://substack-post-media.s3.amazonaws.com/public/images/dc2c77b8-1d27-4d31-b98e-96a27d87db37_652x404.png",
+    "title": "🎼 ff.102 Il futuro in una conchiglia",
+    "subtitle": "🐚La musica (in conchiglia) del mare di progresso di quest’estate:",
+    "links": [
+      {
+        "text": "🩸 ff.102.4 Dal sangue ad Amazon",
+        "url": "https://fortissimo.substack.com/p/ff102-il-futuro-in-una-conchiglia#%C2%A7ff--ff1024-dal-sangue-ad-amazon"
+      },
+      {
+        "text": "🔭 ff.102.3 Automatizzare la ricerca scientifica",
+        "url": "https://fortissimo.substack.com/p/ff102-il-futuro-in-una-conchiglia#%C2%A7ff-automatizzare-la-ricerca-scientifica"
+      }
+    ],
+    "readMoreUrl": "https://fortissimo.substack.com/p/ff102-il-futuro-in-una-conchiglia"
+  },
   {
     "img": "/index_files/pubs/ff2.webp",
     "title": "🎼 ff.2 Mente artificiale e psichedelia",
@@ -390,13 +408,13 @@
     ],
     "readMoreUrl": "https://fortissimo.substack.com/p/-ff4-mammut-e-torneo-tremaghi"
   },
-    {
-      "img": "/index_files/pubs/ff12.webp",
-      "title": "🎼 ff.12 Sole, cuore e amore",
-      "subtitle": "Come l'energia rinnovabile può vincere il Festivalbar",
-      "links": [
-        {
-          "text": "💡 La rivincita delle rinnovabili",
+  {
+    "img": "/index_files/pubs/ff12.webp",
+    "title": "🎼 ff.12 Sole, cuore e amore",
+    "subtitle": "Come l'energia rinnovabile può vincere il Festivalbar",
+    "links": [
+      {
+        "text": "💡 La rivincita delle rinnovabili",
         "url": "https://fortissimo.substack.com/i/44894125/ff-la-rivincita-delle-rinnovabili"
       },
       {
@@ -438,133 +456,132 @@
     ],
     "readMoreUrl": "https://fortissimo.substack.com/p/-ff13-popolazioni-e-polluzioni"
   },
-    {
-  "img": "https://substack-post-media.s3.amazonaws.com/public/images/7ee37fdc-da13-4049-9c7e-78b487b6c81f_601x353.png",
-  "title": "🎼 ff.90 L'epidemia di stress",
-  "subtitle": "Notifiche e social: questa giungla mi distrugge",
-  "links": [
   {
-  "text": "🦁 Scappare da un leone o una notifica",
-  "url": "https://fortissimo.substack.com/p/ff91-lepidemia-di-stress#§ff-scappare-da-un-leone-o-una-notifica"
+    "img": "https://substack-post-media.s3.amazonaws.com/public/images/7ee37fdc-da13-4049-9c7e-78b487b6c81f_601x353.png",
+    "title": "🎼 ff.90 L'epidemia di stress",
+    "subtitle": "Notifiche e social: questa giungla mi distrugge",
+    "links": [
+      {
+        "text": "🦁 Scappare da un leone o una notifica",
+        "url": "https://fortissimo.substack.com/p/ff91-lepidemia-di-stress#§ff-scappare-da-un-leone-o-una-notifica"
+      },
+      {
+        "text": "🏓 Sport contro lo stress",
+        "url": "https://fortissimo.substack.com/p/ff91-lepidemia-di-stress#§ff-sport-contro-lo-stress"
+      }
+    ],
+    "readMoreUrl": "https://fortissimo.substack.com/p/ff91-lepidemia-di-stress"
   },
   {
-  "text": "🏓 Sport contro lo stress",
-  "url": "https://fortissimo.substack.com/p/ff91-lepidemia-di-stress#§ff-sport-contro-lo-stress"
-  }
-  ],
-  "readMoreUrl": "https://fortissimo.substack.com/p/ff91-lepidemia-di-stress"
-},
-{
-  "img": "/index_files/pubs/ff93.webp",
-  "title": "🎼 ff.98 Giochi e simulazioni",
-  "subtitle": "L'intreccio tra videogiochi e mondi paralleli che vanno più veloci.",
-  "links": [
-    {
-      "text": "📚 L'infinitudine là fuori",
-      "url": "https://fortissimo.substack.com/i/82346421/ff-linfinitudine-la-fuori"
-    },
-    {
-      "text": "🎙️ Beyond Our Reality",
-      "url": "https://www.youtube.com/watch?v=ObUBUKOn-bo"
-    }
-  ],
-  "readMoreUrl": "https://fortissimo.substack.com/p/ff98-giochi-e-simulazioni"
-},
+    "img": "/index_files/pubs/ff93.webp",
+    "title": "🎼 ff.98 Giochi e simulazioni",
+    "subtitle": "L'intreccio tra videogiochi e mondi paralleli che vanno più veloci.",
+    "links": [
+      {
+        "text": "📚 L'infinitudine là fuori",
+        "url": "https://fortissimo.substack.com/i/82346421/ff-linfinitudine-la-fuori"
+      },
+      {
+        "text": "🎙️ Beyond Our Reality",
+        "url": "https://www.youtube.com/watch?v=ObUBUKOn-bo"
+      }
+    ],
+    "readMoreUrl": "https://fortissimo.substack.com/p/ff98-giochi-e-simulazioni"
+  },
   {
-  "img": "/index_files/pubs/ff93.webp",
-  "title": "🎼 ff.93 Tesla: la fine di un'era?",
-  "subtitle": "Guida autonoma e robot salveranno Elon Musk?",
-  "links": [
-    {
-      "text": "⚠️ ff.83.2 Stai attento!",
-      "url": "https://fortissimo.substack.com/i/140010460/ff-stai-attento"
-    },
-    {
-      "text": "🚑 Tesla: un'ambulanza personale",
-      "url": "https://x.com/alex_avoigt/status/1777240872716751190?mx=2"
-    }
-  ],
-  "readMoreUrl": "https://fortissimo.substack.com/p/ff93-tesla-la-fine-o-linizio"
-},
-{
-  "img": "/index_files/pubs/ff99.webp",
-  "title": "🎼 ff.99 Cibi per non invecchiare",
-  "subtitle": "Spermidina, patate viola e altri superfood?",
-  "links": [
-    {
-      "text": "🍏 La spermidina può allungare la vita di quasi 6 anni",
-      "url": "https://pubmed.ncbi.nlm.nih.gov/29955838/"
-    },
-    {
-      "text": "📚 L'infinitudine là fuori",
-      "url": "https://fortissimo.substack.com/i/82346421/ff-linfinitudine-la-fuori"
-    }
-  ],
-  "readMoreUrl": "https://fortissimo.substack.com/p/ff99-cibi-per-non-invecchiare"
-},
-{
-  "img": "https://substackcdn.com/image/fetch/$s_!RdJR!,w_1200,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F334c89c8-21f8-4cd1-846e-018b76afe57e_1000x1520.jpeg",
-  "title": "🎼 ff.59 L'ottimismo vola!",
-  "subtitle": "Superare la stagnazione tecnologica (se esiste) per un futuro positivo",
-  "links": [
-    {
-      "text": "🌐 C'è davvero stagnazione tecnologica?",
-      "url": "https://www.worksinprogress.co/issue/there-was-no-great-stagnation/"
-    },
-    {
-      "text": "🎥 The Purpose of Technology",
-      "url": "https://balajis.com/the-purpose-of-technology/?utm_source=substack&utm_medium=email"
-    }
-  ],
-  "readMoreUrl": "https://fortissimo.substack.com/p/ff59-lottimismo-vola"
-},
-{
-  "img": "https://substackcdn.com/image/fetch/$s_!KEoj!,w_1200,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F9614772f-949d-44af-aa74-437869bb73b7_470x470.png",
-  "title": "🎼 ff.58 Le banane inquinano troppo?",
-  "subtitle": "Come diminuire e monitorare le emissioni delle attività di ogni giorno",
-  "links": [
-    {
-      "text": "📗 How Bad Are Bananas",
-      "url": "https://amzn.to/3WHf16M"
-    },
-    {
-      "text": "🚗 L'impronta di viaggio",
-      "url": "https://ourworldindata.org/travel-carbon-footprint"
-    }
-  ],
-  "readMoreUrl": "https://fortissimo.substack.com/p/ff58-le-banane-inquinano-troppo"
-},
-{
-  "img": "https://substackcdn.com/image/fetch/$s_!iuBT!,w_1200,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F14b71ab3-3fcd-4863-a4ad-4d351939c114_1200x697.png",
-  "title": "🎼 ff.57 Il medico mi ha prescritto una maratona",
-  "subtitle": "Una storia millenaria tra Crocs, salute e limiti umani",
-  "links": [
-    {
-      "text": "🩺 Fitness e rischio cardiovascolare",
-      "url": "https://www.jacc.org/doi/full/10.1016/j.jacc.2022.05.031"
-    },
-    {
-      "text": "🐊 Correre una mezza maratona in Crocs",
-      "url": "https://coinunited.io/news/en/2023-03-16/stocks/cunews-credit-suisse-valuation-drops-below-crocs-amid-financial-turmoil"
-    }
-  ],
-  "readMoreUrl": "https://fortissimo.substack.com/p/ff56-il-medico-mi-ha-prescritto-una"
-},
-{
-  "img": "https://substackcdn.com/image/fetch/$s_!F_6Q!,w_1200,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fa573e176-c010-458c-9df5-a9095301650b_480x360.jpeg",
-  "title": "🎼 ff.55 Sopravvivere alla rivoluzione",
-  "subtitle": "Intelligenza artificiale tra ghigliottine, impotenza e perdizione",
-  "links": [
-    {
-      "text": "🧠 L'efficienza del lavoro con l'AI",
-      "url": "https://arxiv.org/pdf/2302.06590.pdf"
-    },
-    {
-      "text": "🧠 Leggere il cervello con Stable Diffusion",
-      "url": "https://sites.google.com/view/stablediffusion-with-brain/?utm_source=substack&utm_medium=email"
-    }
-  ],
-  "readMoreUrl": "https://fortissimo.substack.com/p/ff54-come-capire-una-rivoluzione"
-}
-
+    "img": "/index_files/pubs/ff93.webp",
+    "title": "🎼 ff.93 Tesla: la fine di un'era?",
+    "subtitle": "Guida autonoma e robot salveranno Elon Musk?",
+    "links": [
+      {
+        "text": "⚠️ ff.83.2 Stai attento!",
+        "url": "https://fortissimo.substack.com/i/140010460/ff-stai-attento"
+      },
+      {
+        "text": "🚑 Tesla: un'ambulanza personale",
+        "url": "https://x.com/alex_avoigt/status/1777240872716751190?mx=2"
+      }
+    ],
+    "readMoreUrl": "https://fortissimo.substack.com/p/ff93-tesla-la-fine-o-linizio"
+  },
+  {
+    "img": "/index_files/pubs/ff99.webp",
+    "title": "🎼 ff.99 Cibi per non invecchiare",
+    "subtitle": "Spermidina, patate viola e altri superfood?",
+    "links": [
+      {
+        "text": "🍏 La spermidina può allungare la vita di quasi 6 anni",
+        "url": "https://pubmed.ncbi.nlm.nih.gov/29955838/"
+      },
+      {
+        "text": "📚 L'infinitudine là fuori",
+        "url": "https://fortissimo.substack.com/i/82346421/ff-linfinitudine-la-fuori"
+      }
+    ],
+    "readMoreUrl": "https://fortissimo.substack.com/p/ff99-cibi-per-non-invecchiare"
+  },
+  {
+    "img": "https://substackcdn.com/image/fetch/$s_!RdJR!,w_1200,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F334c89c8-21f8-4cd1-846e-018b76afe57e_1000x1520.jpeg",
+    "title": "🎼 ff.59 L'ottimismo vola!",
+    "subtitle": "Superare la stagnazione tecnologica (se esiste) per un futuro positivo",
+    "links": [
+      {
+        "text": "🌐 C'è davvero stagnazione tecnologica?",
+        "url": "https://www.worksinprogress.co/issue/there-was-no-great-stagnation/"
+      },
+      {
+        "text": "🎥 The Purpose of Technology",
+        "url": "https://balajis.com/the-purpose-of-technology/?utm_source=substack&utm_medium=email"
+      }
+    ],
+    "readMoreUrl": "https://fortissimo.substack.com/p/ff59-lottimismo-vola"
+  },
+  {
+    "img": "https://substackcdn.com/image/fetch/$s_!KEoj!,w_1200,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F9614772f-949d-44af-aa74-437869bb73b7_470x470.png",
+    "title": "🎼 ff.58 Le banane inquinano troppo?",
+    "subtitle": "Come diminuire e monitorare le emissioni delle attività di ogni giorno",
+    "links": [
+      {
+        "text": "📗 How Bad Are Bananas",
+        "url": "https://amzn.to/3WHf16M"
+      },
+      {
+        "text": "🚗 L'impronta di viaggio",
+        "url": "https://ourworldindata.org/travel-carbon-footprint"
+      }
+    ],
+    "readMoreUrl": "https://fortissimo.substack.com/p/ff58-le-banane-inquinano-troppo"
+  },
+  {
+    "img": "https://substackcdn.com/image/fetch/$s_!iuBT!,w_1200,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F14b71ab3-3fcd-4863-a4ad-4d351939c114_1200x697.png",
+    "title": "🎼 ff.57 Il medico mi ha prescritto una maratona",
+    "subtitle": "Una storia millenaria tra Crocs, salute e limiti umani",
+    "links": [
+      {
+        "text": "🩺 Fitness e rischio cardiovascolare",
+        "url": "https://www.jacc.org/doi/full/10.1016/j.jacc.2022.05.031"
+      },
+      {
+        "text": "🐊 Correre una mezza maratona in Crocs",
+        "url": "https://coinunited.io/news/en/2023-03-16/stocks/cunews-credit-suisse-valuation-drops-below-crocs-amid-financial-turmoil"
+      }
+    ],
+    "readMoreUrl": "https://fortissimo.substack.com/p/ff56-il-medico-mi-ha-prescritto-una"
+  },
+  {
+    "img": "https://substackcdn.com/image/fetch/$s_!F_6Q!,w_1200,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fa573e176-c010-458c-9df5-a9095301650b_480x360.jpeg",
+    "title": "🎼 ff.55 Sopravvivere alla rivoluzione",
+    "subtitle": "Intelligenza artificiale tra ghigliottine, impotenza e perdizione",
+    "links": [
+      {
+        "text": "🧠 L'efficienza del lavoro con l'AI",
+        "url": "https://arxiv.org/pdf/2302.06590.pdf"
+      },
+      {
+        "text": "🧠 Leggere il cervello con Stable Diffusion",
+        "url": "https://sites.google.com/view/stablediffusion-with-brain/?utm_source=substack&utm_medium=email"
+      }
+    ],
+    "readMoreUrl": "https://fortissimo.substack.com/p/ff54-come-capire-una-rivoluzione"
+  }
 ]


### PR DESCRIPTION
Scheduled sync from https://fortissimo.substack.com/feed.\n\nChanges:\n- Added missing latest RSS items to  in existing front-page card format\n- Added: ff.145, ff.144, ff.143\n\nNotes:\n- No invented post data; title/description/link/image are parsed from RSS\n- Minimal scope: only front-page publications index updated