### PR TITLE
editorial: Natura 1.2 — investimenti energia pulita, pompe di calore, trade-off dieta

### DIFF
--- a/book/chapter-01.html
+++ b/book/chapter-01.html
@@ -300,6 +300,23 @@
     </a>).
     &Egrave; il tipo di feedback loop che rende la governance climatica cos&igrave; vertiginosa: ogni soluzione genera un nuovo problema, e l'unica strategia robusta &egrave; quella che tiene insieme decarbonizzazione, adattamento e monitoraggio degli effetti collaterali.</p>
 
+    <p>Eppure, dentro questo labirinto di feedback, il capitale ha gi&agrave; scelto la direzione. L'Agenzia Internazionale dell'Energia stima che gli investimenti globali in energia pulita supereranno i <mark class="note-highlight">3 trilioni di dollari</mark> nel 2024 &mdash; il doppio di quanto destinato ai combustibili fossili
+    (<a href="https://www.iea.org/news/investment-in-clean-energy-this-year-is-set-to-be-twice-the-amount-going-to-fossil-fuels" target="_blank" rel="noopener"
+       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
+      &#128206; Investimenti in energia pulita: il doppio dei combustibili fossili
+    </a>).
+    Non &egrave; pi&ugrave; una scommessa ideologica: &egrave; arbitraggio finanziario. Il solare costa meno del carbone in quasi ogni mercato del mondo, e la curva di apprendimento continua a scendere. Ma la transizione non si gioca solo sui tetti e nei deserti. Nelle case europee, la pompa di calore sta riscrivendo il bilancio energetico domestico: una singola unit&agrave; riduce le emissioni di quasi <mark class="note-highlight">3.000 kg di CO&#8322; all'anno</mark>, eliminando la caldaia a gas senza sacrificare il comfort
+    (<a href="https://x.com/ElectrifyNow/status/1750216223722070397" target="_blank" rel="noopener"
+       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
+      &#128206; Pompa di calore: quasi 3000 kg CO2 in meno all'anno
+    </a>).
+    E c'&egrave; un'altra conversione che nessuno vuole fare: sostituire il manzo con il pollo riduce l'impronta carbonica dell'<mark class="note-highlight">80%</mark>, ma richiede duecento volte pi&ugrave; animali
+    (<a href="https://x.com/ATabarrok/status/1704496361692000336" target="_blank" rel="noopener"
+       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
+      &#128206; Manzo vs pollo: -80% CO2 ma 200x pi&ugrave; animali
+    </a>).
+    Il dilemma &egrave; matematicamente perfetto e moralmente irrisolvibile &mdash; esattamente il tipo di trade-off che la transizione energetica impone a ogni livello, dal piatto alla centrale elettrica.</p>
+
     <p>Se il costo del clima &egrave; sottostimato, quello dell'intelligenza artificiale &egrave; sovrastimato &mdash; almeno sul piano energetico. Il dibattito pubblico dipinge l'AI come una voragine elettrica, ma i dati raccontano un'altra storia: una singola ricerca su ChatGPT equivale allo <mark class="note-highlight">0,00007% dell'impronta elettrica annuale</mark> pro capite nel Regno Unito
     (<a href="https://www.sustainabilitybynumbers.com/p/carbon-footprint-chatgpt" target="_blank" rel="noopener"
        style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">


### PR DESCRIPTION
## Summary
- Integra 3 note non ancora nel libro nella sezione **Ambiente ed Energia** (cap.1)
- Nota 654: investimenti globali energia pulita $3T (IEA) — doppio dei fossili
- Nota 682: pompe di calore riducono 3.000 kg CO2/anno per unità domestica
- Nota 686: trade-off manzo→pollo — -80% CO2 ma 200x più animali

## Test plan
- [ ] Verifica formattazione HTML (mark highlights, link 📎, paragrafi)
- [ ] Smoke check locale con `npm run check:book-editorial`
- [ ] Conferma continuità narrativa con paragrafi precedenti e successivi

🤖 Generated with [Claude Code](https://claude.com/claude-code)