### PR TITLE
editorial: entry Natura 1.2 — batterie ferro-aria e stoccaggio

### DIFF
--- a/book/chapter-01.html
+++ b/book/chapter-01.html
@@ -360,6 +360,19 @@
         <figcaption>ff.4 &mdash; Mammut resuscitati: dalla biologia sintetica alla tundra del futuro.</figcaption>
     </figure>
 
+    <!-- ===== NEW — Batterie e stoccaggio energetico ===== -->
+    <p>La transizione energetica ha un problema che nessun pannello solare pu&ograve; risolvere da solo: il tempo. Il sole splende di giorno, il vento soffia a intermittenza, ma la domanda di elettricit&agrave; &egrave; costante &mdash; e nelle ore di punta serale raggiunge il picco proprio quando le rinnovabili si spengono. Senza stoccaggio, ogni gigawatt installato resta ostaggio della meteorologia. La IEA stima che serva un <mark class="note-highlight">aumento di sei volte della capacit&agrave; globale di accumulo a batteria entro il 2030</mark> per rispettare gli obiettivi climatici fissati alla COP28 (
+      <a href="https://www.iea.org/news/rapid-expansion-of-batteries-will-be-crucial-to-meet-climate-and-energy-security-goals-set-at-cop28" target="_blank" rel="noopener"
+         style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
+        &#128206; Aumento di sei volte dell'accumulo di energia da batterie necessario entro il 2030
+      </a>
+    ). &Egrave; una cifra che traduce un concetto astratto in ingegneria concreta: non basta produrre elettroni puliti, bisogna parcheggiarli da qualche parte e rilasciarli quando servono. Il litio domina il mercato attuale, ma &egrave; costoso, concentrato geograficamente e inadatto allo stoccaggio di lunga durata. La frontiera pi&ugrave; promettente arriva da una chimica sorprendentemente primitiva. A Delft, nei Paesi Bassi, Ore Energy ha collegato alla rete la prima batteria ferro-aria al mondo: un sistema che usa solo <mark class="note-highlight">ferro, aria e acqua</mark> per offrire fino a 100 ore di stoccaggio energetico pulito (
+      <a href="https://tech.eu/2025/07/30/ore-energy-connects-worlds-first-grid-connected-iron-air-battery-in-delft/" target="_blank" rel="noopener"
+         style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
+        &#128206; Ore Energy connette la prima batteria ferro-aria: 100 ore di stoccaggio
+      </a>
+    ). Cento ore significano quattro giorni interi di autonomia &mdash; abbastanza per coprire una settimana nuvolosa o un'ondata di calore senza vento. Il ferro &egrave; il quarto elemento pi&ugrave; abbondante sulla crosta terrestre, non richiede miniere in Congo n&eacute; raffinerie in Cina, e il suo costo al chilo &egrave; una frazione di quello del litio. &Egrave; la stessa logica della fotosintesi: la natura non usa materiali rari, usa quelli disponibili ovunque e li combina con eleganza. Se la batteria ferro-aria scaler&agrave;, il collo di bottiglia della transizione energetica non sar&agrave; pi&ugrave; la generazione ma la volont&agrave; politica di installarla. E la domanda vera diventa un'altra: perch&eacute; il mondo investe ancora miliardi in infrastrutture fossili quando la soluzione &egrave; letteralmente fatta di ruggine e aria?</p>
+
     <!-- ===== NEW FF.25 — Xenotrapianti ===== -->
     <p>Gli xenotrapianti aggiungono un capitolo ancora pi&ugrave; radicale perch&eacute; obbligano a tenere insieme biotecnologia, etica e scarsit&agrave; sanitaria. La modifica genetica del maiale ha reso possibile il primo trapianto di cuore senza rigetto immediato, segnalando che il confine tra specie pu&ograve; essere riprogettato in laboratorio prima ancora che in sala operatoria
     (<span class="fc">&#128055; ff.25.1


### PR DESCRIPTION
## Summary
- Nuova entry in Cap.01 Natura, sezione 1.2 Ambiente ed Energia (~220 parole)
- Integra 2 note non ancora utilizzate: **507** (IEA: 6x accumulo batterie entro 2030) e **1219** (Ore Energy: prima batteria ferro-aria al mondo, 100 ore di stoccaggio)
- Stile Einaudi: dati concreti (IEA, ferro-aria, 100 ore, COP28) + riflessione editoriale
- Formattazione conforme: `note-highlight` su 2 key facts, link inline con monospace

## Test plan
- [ ] Verificare rendering HTML in locale
- [ ] Controllare che i link alle fonti (IEA, tech.eu) funzionino
- [ ] Rebuild EPUB: `node scripts/build_epub.mjs`

Generated with [Claude Code](https://claude.com/claude-code)