### PR TITLE
Book maintenance: RSS sync, books integration, inline-link style, color coherence

### DIFF
--- a/book/chapter-04.html
+++ b/book/chapter-04.html
@@ -176,6 +176,27 @@
 
     </article>
 
+
+
+<section id="atlante-libri" class="brutal-card mt-12" aria-label="Atlante libri dal corpus">
+  <p class="ff-eyebrow" style="color:var(--ff-purple)">Integrazione editoriale books.json + books_en.json</p>
+  <h2 class="text-xl font-bold mt-2" style="text-transform:none">Atlante narrativo delle letture</h2>
+  <p class="mt-3">Per evitare una bibliografia-appendice, ogni titolo viene cucito dentro un claim leggibile: il link è sulla frase stessa, così il passaggio resta narrativo ma verificabile. In questa revisione sono stati integrati tutti i libri presenti nei dataset locali.</p>
+  <h3 class="text-lg font-bold mt-8">Tecnologia</h3><ul class="mt-3 space-y-2" style="line-height:1.55"></ul>
+<h3 class="text-lg font-bold mt-8">Società</h3><ul class="mt-3 space-y-2" style="line-height:1.55"><li><a href="https://amzn.to/4jnzSe3" target="_blank" rel="noopener">Ecstasis è lo stato di coscienza non ordinaria in cui l&#x27;ego svanisce, lasciando spazio a euforia, connessione e prestazioni potenziate. Flusso, med…</a> <span style='color:#666'>— Stealing Fire, Steven Kotler, Jamie Wheal</span></li>
+<li><a href="https://amzn.to/450ZolV" target="_blank" rel="noopener">L&#x27;agenzia è la capacità di scegliere e agire. Quando l&#x27;IA potenzia milioni di individui, nasce la &#x27;superagenzia&#x27;: impatti che si propagano anche a…</a> <span style='color:#666'>— Superagency, Reid Hoffman, Greg Beato</span></li>
+<li><a href="https://amzn.to/3Sso1R2" target="_blank" rel="noopener">Le DAO sono &#x27;una chat di gruppo con un conto in banca&#x27;: strutture decentralizzate, senza gerarchie, che abilitano decisioni collettive, accesso glo…</a> <span style='color:#666'>— How to DAO, Kevin Owocki, Puncar</span></li></ul>
+<h3 class="text-lg font-bold mt-8">Natura</h3><ul class="mt-3 space-y-2" style="line-height:1.55"><li><a href="https://amzn.to/3HmBA20" target="_blank" rel="noopener">La dopamina è un neurotrasmettitore fondamentale per il circuito della ricompensa. La sua liberazione è direttamente correlata al piacere e alla mo…</a> <span style='color:#666'>— L&#x27;era della dopamina, Anna Lembke, M.D</span></li></ul>
+<h3 class="text-lg font-bold mt-8">Letture</h3><ul class="mt-3 space-y-2" style="line-height:1.55"><li><a href="https://amzn.to/457FKVp" target="_blank" rel="noopener">La respirazione nasale è superiore a quella orale, filtrando l&#x27;aria, riscaldandola e umidificandola, oltre a produrre ossido nitrico che dilata i v…</a> <span style='color:#666'>— Breath: The New Science of a Lost Art, James Nestor</span></li>
+<li><a href="https://amzn.to/4mHEPRU" target="_blank" rel="noopener">L&#x27;esistenza umana è intrinsecamente finita, con una vita media di circa 4.000 settimane. Questo concetto, spesso eluso, è centrale per una gestione…</a> <span style='color:#666'>— Four Thousand Weeks, Time Management for Mortals, Oliver Burkeman</span></li>
+<li><a href="https://amzn.to/4mGtKAB" target="_blank" rel="noopener">La specie umana si è evoluta per essere costantemente attiva, non per &quot;fare esercizio&quot; nel senso moderno. I cacciatori-raccoglitori camminavano cir…</a> <span style='color:#666'>— Exercised, Daniel Lieberman</span></li>
+<li><a href="https://amzn.to/4kjXRMr" target="_blank" rel="noopener">L&#x27;infiammazione cronica di basso grado accelera l&#x27;invecchiamento e promuove malattie cardiovascolari. Marker come la CRP sono predittivi di mortali…</a> <span style='color:#666'>— Come non invecchiare, Michael Greger</span></li>
+<li><a href="https://amzn.to/4mIfwiM" target="_blank" rel="noopener">Contrariamente alle linee guida dietetiche standard, il sodio è fondamentale per l&#x27;equilibrio idro-elettrolitico, la funzione nervosa e la regolazi…</a> <span style='color:#666'>— The Mineral Fix: How to Optimize Your Mineral Intake for Energy, Longevity, Immunity, Sleep and More, James DiNicolantonio, Siim Land</span></li>
+<li><a href="" target="_blank" rel="noopener">La quantità di informazioni disponibili è esplosa, superando di gran lunga ciò che possiamo consumare. La chiave è trasformare i “Big Data” in “Big…</a> <span style='color:#666'>— Superagenzia &amp; IA, —</span></li>
+<li><a href="https://amzn.to/4l23DTd" target="_blank" rel="noopener">L&#x27;obiettivo di “morire con zero” significa non lasciare un’eredità finanziaria significativa, ma massimizzare le esperienze di vita con un “dividen…</a> <span style='color:#666'>— Die with Zero: Getting All You Can from Your Money and Your Life, Bill Perkins</span></li></ul>
+  <p class="mt-6 text-sm" style="color:#666">Totale integrazioni: 11 libri (IT+EN deduplicati).</p>
+</section>
+
     <section class="newsletter-cta mt-14 mb-10" role="complementary" aria-label="Iscrizione newsletter">
         <p class="ff-eyebrow text-xs mb-2" style="color:var(--ff-black)">Non perderti il prossimo numero</p>
         <h2 class="text-xl sm:text-2xl font-bold mb-3" style="font-family:'IBM Plex Mono',monospace">Ricevi Futuro Fortissimo</h2>

--- a/book/index.html
+++ b/book/index.html
@@ -41,6 +41,8 @@
       --ff-blue: #4a90e2;
       --ff-red: #d0021b;
       --ff-yellow: #f5a623;
+      --ff-purple: #7c3aed;
+      --ff-pink: #ec4899;
       --ff-green: #2ecc71;
       --ff-black: #0a0a0a;
       --ff-grid: rgba(0, 0, 0, 0.03);
@@ -94,6 +96,8 @@
     .accent-red::before { background: var(--ff-red); }
     .accent-yellow::before { background: var(--ff-yellow); }
     .accent-green::before { background: var(--ff-green); }
+    .accent-purple::before { background: var(--ff-purple); }
+    .accent-pink::before { background: var(--ff-pink); }
     .accent-black::before { background: var(--ff-black); }
     .ff-eyebrow {
       font-family: 'IBM Plex Mono', monospace;
@@ -201,7 +205,16 @@
     <!-- Intro card -->
     <section class="brutal-card accent-bar">
       <p class="ff-body">Cinque saggi su <strong>Natura</strong>, <strong>Tecnologia</strong>, <strong>Società</strong>, <strong>Letture</strong> e <strong>Note</strong>: un percorso di lettura che unisce verde, AI, corpo, attenzione e geopolitica a partire dal corpus di Futuro Fortissimo.</p>
-      <div class="ff-caption mt-4" style="color: var(--ff-blue);">Aggiornato 2026-02-12</div>
+      <div class="ff-caption mt-4" style="color: var(--ff-blue);">Aggiornato 2026-03-10</div>
+    </section>
+
+
+
+    <section class="mt-6 brutal-card accent-bar accent-purple">
+      <div class="ff-eyebrow" style="color: var(--ff-purple);">Nuovo dal feed</div>
+      <h2 class="text-lg font-bold mt-2" style="text-transform:none;">🎼 ff.146 Cicatrici silenziose</h2>
+      <p class="ff-body-sm mt-2" style="color:#333;">Pubblicato il Tue, 10 Mar 2026 10:10:08 GMT. Integrato nel flusso editoriale del libro e nel dataset locale.</p>
+      <a class="ff-button underline mt-3 inline-block" href="https://fortissimo.substack.com/p/ff146-cicatrici-silenziose" target="_blank" rel="noopener">Apri articolo &rarr;</a>
     </section>
 
     <!-- Chapters grid -->
@@ -228,12 +241,12 @@
         </div>
       </article>
 
-      <!-- Chapter 02 — Tecnologia (blue) -->
-      <article class="brutal-card accent-bar">
+      <!-- Chapter 02 — Tecnologia (blue→purple) -->
+      <article class="brutal-card accent-bar accent-purple">
         <div class="flex items-center gap-3">
           <span class="text-3xl">💻</span>
           <div>
-            <div class="ff-eyebrow" style="color: var(--ff-blue);">Capitolo 02</div>
+            <div class="ff-eyebrow" style="color: var(--ff-purple);">Capitolo 02</div>
             <h2 class="text-lg font-bold uppercase mt-1">Tecnologia — Dalla Macchina all'Agente</h2>
           </div>
         </div>
@@ -249,12 +262,12 @@
         </div>
       </article>
 
-      <!-- Chapter 03 — Società (red) -->
-      <article class="brutal-card accent-bar accent-red">
+      <!-- Chapter 03 — Società (red→pink) -->
+      <article class="brutal-card accent-bar accent-pink">
         <div class="flex items-center gap-3">
           <span class="text-3xl">❤️</span>
           <div>
-            <div class="ff-eyebrow" style="color: var(--ff-red);">Capitolo 03</div>
+            <div class="ff-eyebrow" style="color: var(--ff-pink);">Capitolo 03</div>
             <h2 class="text-lg font-bold uppercase mt-1">Società — Noi, Insieme</h2>
           </div>
         </div>
@@ -270,12 +283,12 @@
         </div>
       </article>
 
-      <!-- Chapter 04 — Letture e Riassunti (yellow) -->
-      <article class="brutal-card accent-bar accent-yellow">
+      <!-- Chapter 04 — Letture e Riassunti (purple) -->
+      <article class="brutal-card accent-bar accent-purple">
         <div class="flex items-center gap-3">
           <span class="text-3xl">📚</span>
           <div>
-            <div class="ff-eyebrow" style="color: var(--ff-yellow);">Capitolo 04</div>
+            <div class="ff-eyebrow" style="color: var(--ff-purple);">Capitolo 04</div>
             <h2 class="text-lg font-bold uppercase mt-1">Letture e Riassunti — Spunti e Riflessioni</h2>
           </div>
         </div>


### PR DESCRIPTION
## Summary
Monthly FF maintenance run (10/20/30):

- Added latest RSS issue card in `book/index.html` for **ff.146 Cicatrici silenziose**
- Updated book home timestamp to 2026-03-10
- Integrated books dataset (`books.json` + `books_en.json`, deduped by title/url) into `book/chapter-04.html` as inline clickable claims in a narrative section (`Atlante narrativo delle letture`)
- Reviewed external-note style in book chapters (no `[source: ...]` / `[ref: ...]` leftovers found)
- Aligned chapter card color system in index:
  - Tecnologia: blue→purple
  - Società: red→pink
  - Natura: green (kept)
  - Letture: purple

## Notes
- RSS artifact files were updated in workspace (outside this repo) as part of cron flow:
  - `work/futurofortissimo/last_rss_item.txt`
  - `work/futurofortissimo/posts/ff146-cicatrici-silenziose.md`
  - `work/futurofortissimo/futuro_fortissimo_full_data.txt`
