### PR TITLE
Natura 1.2: nucleare rebrand, aria padana, lusso naturale

### DIFF
--- a/book/chapter-01.html
+++ b/book/chapter-01.html
@@ -420,6 +420,17 @@
     Fuoco (3 facce)</span>).
     Dal <em>decision tree</em> alla COP, dal ramo alla fiamma: la natura non &egrave; sfondo, &egrave; grammatica. E la grammatica va letta prima di riscriverla.</p>
 
+    <!-- ===== NEW — Nucleare, aria padana e lusso elementare ===== -->
+    <p>Da settant&#39;anni disponiamo gi&agrave; di una soluzione per generare energia a emissioni quasi zero: il nucleare a fissione. Eppure basta un caso simbolo &mdash; Fukushima, le chimere di frutta fluorescente &mdash; per bollare un intero campo di ricerca. Josh Wolfe, co-fondatore di Lux Capital, propone un rebrand radicale: non pi&ugrave; &ldquo;nucleare&rdquo; ma <em>energia elementale</em>. L&#39;opinione pubblica, in effetti, sembra fare inversione a U: la notizia del primo reattore a fusione net-positive ha dato una scossa al dibattito, e ventidue nazioni alla COP28 hanno promesso di triplicare la capacit&agrave; nucleare entro il 2050. Il problema non &egrave; mai stato la fisica: &egrave; sempre stato il racconto
+    (<span class="fc">&#9762; ff.46.1
+    Nucleare: un rebrand necessario</span>).
+    Intanto, nella Pianura Padana l&#39;aria sembra uscita da Mordor. I dati, per&ograve;, raccontano una storia pi&ugrave; sfumata: la media mobile annuale delle concentrazioni di PM2,5 a Milano mostra un leggerissimo calo, nessuna accelerazione catastrofica. Resta il fatto che vivere a Milano equivale a fumare due sigarette al giorno &mdash; ogni dieci microgrammi per metro cubo di PM2,5 in pi&ugrave; aumentano del cinque per cento la probabilit&agrave; di morire. A New Delhi va molto peggio: un Air Quality Index di 450 corrisponde a trenta sigarette quotidiane. L&#39;aria che respiriamo &egrave; un indicatore brutale di disuguaglianza: il privilegio pi&ugrave; grande non &egrave; un gadget, &egrave; un polmone sano
+    (<span class="fc">&#127788; ff.87.2
+    Quanto &egrave; inquinata l&#39;aria in Italia?</span>).
+    Ed eccoci al paradosso finale: quando elettricit&agrave; e servizi smettono di essere invisibili, capisci che la vera ricchezza &egrave; l&#39;ecosistema &mdash; aria pulita, sole visibile, acqua usabile. Non la natura <em>hipster</em> da citt&agrave;, ma una natura chimica, elementale, che sta sotto l&#39;Io. Il lusso del futuro non &egrave; un orologio: &egrave; respirare senza filtro
+    (<span class="fc">&#127807; ff.143.1
+    Lusso naturale</span>).</p>
+
     <div class="sep"></div>
 
     <!-- ===== 1.3 ===== -->

--- a/book/chapter-02.html
+++ b/book/chapter-02.html
@@ -490,6 +490,18 @@
     L'AI con il coltellino svizzero</span>; <span class="fc">&#127793; ff.129
     Singolarit&agrave; gentile</span>).</p>
 
+    <p>Il primo vero terremoto &egrave; arrivato dal sottosuolo della biologia strutturale. Per mezzo secolo, determinare la forma tridimensionale di una proteina richiedeva mesi di cristallografia a raggi X e milioni di dollari. Poi DeepMind ha rilasciato AlphaFold e in pochi mesi ha predetto la struttura dell&apos;intero <mark class="note-highlight">proteoma umano</mark> &mdash; circa ventimila proteine &mdash; estendendo poi il catalogo a oltre trecentocinquantamila proteine di altri organismi. Da cinquant&apos;anni di tentativi a un database universale in un anno: non un miglioramento incrementale, ma un cambio di paradigma nel modo in cui la scienza interroga la materia vivente. La farmacologia, la bioingegneria e persino l&apos;agricoltura ne sono state ridisegnate
+    (<span class="fc">&#129516; ff.4.1
+    La struttura delle proteine</span>).</p>
+
+    <p>Se AlphaFold ha dato occhi molecolari alla biologia, la visione artificiale ha dato occhi letterali alle macchine. Da quando GPT ha integrato input visivi, l&apos;intelligenza artificiale non si limita pi&ugrave; a leggere testo: interpreta immagini, decifra grafie illeggibili, localizza oggetti nascosti in una scena. Cognizione e vista &mdash; i due pilastri del nostro successo evoluzionistico &mdash; convergono ora in un sistema artificiale che, in molti compiti percettivi, <mark class="note-highlight">supera la mediana umana</mark>. La domanda non &egrave; pi&ugrave; se le macchine vedranno: &egrave; cosa faranno con ci&ograve; che vedono, e chi decider&agrave; i confini di quello sguardo
+    (<span class="fc">&#129302; ff.71.2
+    ChatGPT (ti) vede</span>).</p>
+
+    <p>E quando la macchina non si limita a vedere o a predire, ma inizia a <em>inventare</em> matematica, il confine si sposta ancora. AlphaEvolve di DeepMind non gioca pi&ugrave; a Go: esplora frontiere matematiche irrisolte, stabilendo un nuovo record nel &ldquo;problema dei baci&rdquo; in undici dimensioni con <mark class="note-highlight">593 sfere</mark>. Contemporaneamente, il suo stesso algoritmo ha ridotto dell&apos;uno per cento il consumo energetico dei data center di Google, migliorando l&apos;algoritmo di Strassen rimasto imbattuto dal 1969. Un&apos;AI che scopre teoremi e poi li applica per ridurre il proprio costo operativo: la ricorsivit&agrave; &egrave; il tratto pi&ugrave; inquietante e promettente di questa fase
+    (<span class="fc">&#127312; ff.126.4
+    AlphaEvolve</span>).</p>
+
     </article>
 
     <!-- Newsletter CTA -->
@@ -569,6 +581,9 @@
         <li><span class="fc">ff.124.2 Longa manus</span></li>
         <li><span class="fc">ff.123 L'AI con il coltellino svizzero</span></li>
         <li><span class="fc">ff.129 Singolarit&agrave; gentile</span></li>
+        <li><span class="fc">ff.4.1 La struttura delle proteine</span></li>
+        <li><span class="fc">ff.71.2 ChatGPT (ti) vede</span></li>
+        <li><span class="fc">ff.126.4 AlphaEvolve</span></li>
       </ul>
       <h3 class="text-lg font-semibold mt-8 mb-3">Fonti esterne</h3>
       <ol class="list-decimal pl-6 space-y-2 text-sm text-zinc-700">


### PR DESCRIPTION
## Summary
- **ff.46.1** (old) — Nucleare: rebrand a "energia elementale", Wolfe, fusione net-positive
- **ff.87.2** (medium) — Aria in Italia: PM2.5 Milano vs New Delhi, 2 vs 30 sigarette/giorno
- **ff.143.1** (recent) — Lusso naturale: ecosistema come vera ricchezza

~270 words, riformulated, temporally distributed. End of section 1.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)