### PR TITLE
Natura 1.2: cascata solare, spermidina, dieta vs esercizio

### DIFF
--- a/book/chapter-01.html
+++ b/book/chapter-01.html
@@ -451,6 +451,18 @@
     Dalla torbiera all&rsquo;abete addobbato, il filo &egrave; lo stesso: ogni volta che ignoriamo il ciclo del carbonio negli oggetti quotidiani, trasformiamo un gesto innocuo in debito ambientale silenzioso. E lo stesso principio vale a tavola: le patate contengono venticinque volte il potassio della pasta, e raddoppiare l&rsquo;assunzione giornaliera di potassio &mdash; da duemiladuecento a quattromilatrecento milligrammi &mdash; abbassa del quaranta per cento il rischio cardiovascolare. Il rame &egrave; due volte pi&ugrave; concentrato in una dieta vegetariana che in una onnivora, e il fegato batte la bistecca su quasi tutti i micronutrienti. Persino il nome &ldquo;SPA&rdquo; viene da <em>Salut Per Aqua</em>, omaggio romano ai minerali disciolti nell&rsquo;acqua termale. Il corpo non chiede calorie: chiede equilibri
     (<span class="fc">&#9874; ff.113.3
     Una dieta mineraria?</span>).</p>
+    <!-- ===== NEW — Cascata solare, spermidina e dieta vs esercizio ===== -->
+    <p>Centosettantamila terawatt: &egrave; la radiazione solare che raggiunge la Terra ogni secondo. Per visualizzarla, immaginate una cascata alta un chilometro che percorre l&rsquo;intero equatore. Di quell&rsquo;energia, il trenta per cento &mdash; cinquantamila terawatt &mdash; viene riflesso da nuvole e ghiacci. La produzione mondiale di energia, quindici terawatt, &egrave; un diecimillesimo del totale. Basta alterare di poco la quota riflessa per spostare l&rsquo;equilibrio climatico: la geoingegneria &egrave; tecnicamente facile, ma l&rsquo;equilibrio &egrave; talmente precario che ogni intervento rischia di innescare effetti a cascata &mdash; letteralmente
+    (<span class="fc">&#127754; ff.56.3
+    Una cascata alta un chilometro</span>).
+    Dall&rsquo;energia cosmica a quella cellulare: la spermidina, una poliammina presente in piselli, grano, soia e polenta, pu&ograve; allungare la vita di quasi sei anni. La sua struttura chimica protegge il DNA dai danni ossidativi. Il nome non mente &mdash; si trova anche nello sperma umano, ma ogni eiaculazione ne contiene appena 0,1 milligrammi: di bianco, meglio il t&egrave;, che protegge il DNA al punto da poter conservare lo sperma stesso. La longevit&agrave; non &egrave; nel superfood esotico: &egrave; nella polenta della nonna
+    (<span class="fc">&#127798; ff.99.2
+    Polenta e spermidina</span>).
+    E se doveste scegliere tra dieta perfetta e movimento? Uno studio risponde in modo controintuitivo: chi si muove pu&ograve; permettersi di mangiare male, mentre chi mangia bene ma non si muove perde gran parte del vantaggio. Il movimento &egrave; talmente benefico da compensare scelte alimentari discutibili. Non &egrave; un invito al junk food, ma una gerarchia chiara: prima muoviti, poi ottimizza il piatto
+    (<span class="fc">&#129367; ff.120.2
+    Dieta o esercizio?</span>).</p>
+
+
 
     <div class="sep"></div>
 


### PR DESCRIPTION
## Changelog
- **ff.56.3** (old) — Una cascata alta un chilometro. 170k TW radiazione, geoingegneria precaria
- **ff.99.2** (medium) — Polenta e spermidina. Poliammina +6 anni vita, protezione DNA
- **ff.120.2** (high) — Dieta o esercizio? Il movimento compensa una dieta scadente

## Checklist FF Inject
- [x] 3 ff.X.Y mai usati nel ciclo corrente
- [x] Testo riformulato (non verbatim)
- [x] Distribuzione temporale (old/medium/high)
- [x] Formato ref corretto
- [x] Wordcount ≥200 parole

🤖 Generated with [Claude Code](https://claude.com/claude-code)