### PR TITLE
Natura 1.2: scooter, budget CO2, vita da spremere

### DIFF
--- a/book/chapter-01.html
+++ b/book/chapter-01.html
@@ -452,6 +452,17 @@
     (<span class="fc">&#9874; ff.113.3
     Una dieta mineraria?</span>).</p>
 
+    <!-- ===== NEW — Scooter, budget di CO2 e vita da spremere ===== -->
+    <p>C&rsquo;&egrave; un numero che riassume l&rsquo;assurdit&agrave; della mobilit&agrave; urbana: <mark class="note-highlight">l&rsquo;80% degli spostamenti negli Stati Uniti copre meno di 16 chilometri</mark>. Sedici chilometri &mdash; la distanza che un ciclista mediocre percorre in quaranta minuti, che uno scooter elettrico divora in un quarto d&rsquo;ora. Eppure per quei sedici chilometri mettiamo in moto una tonnellata e mezza di acciaio, plastica e vetro, bruciando carburante fossile come se stessimo attraversando il continente. La distribuzione di Pareto governa anche il traffico: una minoranza di tragitti lunghi giustifica l&rsquo;automobile, ma la stragrande maggioranza degli spostamenti quotidiani &egrave; un&rsquo;anomalia motorizzata. E-bike, monopattini e scooter elettrici non sono giocattoli da hipster metropolitano: sono la risposta proporzionata a un problema di scala, il mezzo giusto per la distanza giusta, la scarpa che calza il piede invece del SUV che schiaccia la formica
+    (<span class="fc">&#128756; ff.1.3
+    Gli scooter elettrici ci salveranno?</span>).
+    Ma quanto costa, in tempo di vita, ogni gesto quotidiano? Mike Berners-Lee propone un&rsquo;aritmetica spietata: <mark class="note-highlight">10 tonnellate di CO&#8322; annue pro capite</mark> significano 27 chilogrammi al giorno, un chilogrammo all&rsquo;ora, venti grammi al minuto. Una banana equivale a quattro minuti di inquinamento. Se un&rsquo;attivit&agrave; occupa pi&ugrave; tempo della sua conversione CO&#8322;-tempo, &egrave; ecologica; se ne occupa meno, stai vivendo a credito col pianeta. &Egrave; un metro brutale ma onesto: traduce l&rsquo;astrazione delle tonnellate in minuti del tuo orologio biologico, trasforma il bilancio carbonico in bilancio esistenziale. Ogni espresso, ogni doccia, ogni chilometro in auto ha un prezzo che non si paga in euro ma in respiri futuri sottratti alla biosfera
+    (<span class="fc">&#9878; ff.61.1
+    Misurare l&rsquo;inquinamento in ore di vita</span>).
+    E forse &egrave; proprio qui che il cerchio si chiude: se il tempo &egrave; la vera valuta, allora il problema non &egrave; solo quanto inquiniamo ma quanto viviamo davvero. Il fine anno arriva puntuale con la sua domanda muta &mdash; che cosa hai fatto di questi trecentosessantacinque giorni? &mdash; e la risposta onesta &egrave; quasi sempre deludente. Il tempo va fermato, afferrato con le mani, poi trasformato in vita spericolata, ricordata, raccontata. Non si tratta di rallentare: si tratta di convertire le energie vitali in vita vissuta, di spremere ogni giornata come un&rsquo;arancia fino all&rsquo;ultima goccia di succo, rifiutando la tentazione di lasciar scorrere le ore in automatico. Chi misura il carbonio in minuti di vita finisce inevitabilmente per misurare anche la vita in minuti di senso &mdash; e scopre che le due contabilit&agrave; convergono: vivere con intensit&agrave; e vivere con leggerezza ecologica sono, alla fine, lo stesso gesto
+    (<span class="fc">&#127818; ff.111.1
+    Una vita da spremere</span>).</p>
+
     <div class="sep"></div>
 
     <!-- ===== 1.3 ===== -->


### PR DESCRIPTION
## Summary
- Inject 3 temporally diverse unused notes into chapter-01.html (Natura), section 1.2
- **ff.1.3** (OLD) — Scooter elettrici e micromobilità: 80% spostamenti USA < 16 km, distribuzione di Pareto
- **ff.61.1** (MID) — Budget CO2 in ore di vita: 10 ton/anno = 1 kg/h = 20 g/min, banana = 4 min
- **ff.111.1** (RECENT) — Vita da spremere: convertire tempo in vita vissuta, riflessione esistenziale

## Details
- Dense editorial prose (≥200 words), Einaudi style, Italian
- Inserted before `<div class="sep"></div>` preceding section 1.3
- HTML entities for accents, `<mark class="note-highlight">` for key data points
- All 3 notes woven into one cohesive paragraph with natural transitions

## Test plan
- [ ] Verify chapter-01.html renders correctly in browser
- [ ] Confirm all 3 `ff.X.Y` references display with correct emoji and formatting
- [ ] Check `note-highlight` marks render visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)