### PR TITLE
Società 3.1: noia, vuoto e darwinismo urbano

### DIFF
--- a/book/chapter-03.html
+++ b/book/chapter-03.html
@@ -219,7 +219,16 @@
     (<span class="fc">&#127758; ff.142.1
     Siamo noi gli alieni</span>).</p>
 
-
+    <!-- ===== NEW — Noia, vuoto e darwinismo urbano ===== -->
+    <p>Ma se la normalit&agrave; &egrave; un privilegio, la noia &egrave; il suo sottoprodotto pi&ugrave; paradossale. Nelle societ&agrave; avanzate, dove i bisogni primari sono soddisfatti e il tempo libero abbonda, l&rsquo;industria dell&rsquo;intrattenimento ha costruito un impero sulla semplice promessa di riempire le ore vuote. I numeri sono eloquenti: <mark class="note-highlight">la rete PlayStation registra circa cinque miliardi di ore di gioco al mese</mark>, un volume comparabile alle prime dieci serie Netflix per tempo di visione. Tradotto in media individuale, significa un&rsquo;ora a testa al mese &mdash; poco, finch&eacute; non si considera che il catalogo completo di Netflix, sommando migliaia di titoli, eclissa i videogiochi per ore totali consumate. Il punto non &egrave; quale schermo vinca, ma che entrambi rispondono alla stessa urgenza antropologica: ammazzare la noia senza ammazzare nessuno. I videogiochi non sono l&rsquo;oppio dei popoli &mdash; sono la valvola di sfogo di una civilt&agrave; che ha eliminato la fame ma non sa cosa fare dopo cena
+    (<span class="fc">&#x1F3AE; ff.8.5
+    Ammazzare la noia (e non esseri umani)</span>).
+    Eppure, sotto la superficie dell&rsquo;intrattenimento compulsivo, si apre una questione pi&ugrave; profonda: il vuoto non &egrave; solo temporale, &egrave; ontologico. Bergamo, Capitale della Cultura 2023, ha ospitato la mostra <em>Salto nel vuoto</em> &mdash; un&rsquo;esplorazione della smaterializzazione dell&rsquo;arte nell&rsquo;era digitale. Opere che evaporano in NFT, sculture che esistono solo come coordinate nel metaverso, performance algoritmiche che nessun occhio umano vedr&agrave; mai dal vivo. &Egrave; la filosofia dell&rsquo;essere e del non-essere tradotta in pixel: l&rsquo;arte generativa pone domande che Parmenide non avrebbe saputo formulare, perch&eacute; il vuoto a cui allude non &egrave; assenza di materia ma eccesso di virtualit&agrave;. L&rsquo;umanesimo digitale, se esiste, nasce esattamente in questa frattura &mdash; nel punto in cui la cultura smette di occupare spazio fisico e inizia a occupare bandwidth
+    (<span class="fc">&#x1F526; ff.64.1
+    La mostra sul vuoto</span>).
+    Il vuoto, per&ograve;, non &egrave; solo un concetto da galleria d&rsquo;arte: in alcune citt&agrave; &egrave; una condizione ecologica. A Varanasi le scimmie operano come bande organizzate, presidiando gelaterie e bancarelle con una gerarchia territoriale che farebbe invidia a qualsiasi gang metropolitana. Attaccano bambini per un cono gelato, rubano occhiali dai turisti, negoziano il riscatto con gli sguardi. Tra il fumo delle pire funerarie e i resti dei riti, gli animali si muovono con una disinvoltura che abolisce ogni confine tra natura e citt&agrave;, tra sacro e predatorio. Non &egrave; distopia cyberpunk: &egrave; distopia biologica &mdash; il darwinismo urbano nella sua forma pi&ugrave; cruda, dove la selezione naturale non premia il pi&ugrave; forte ma il pi&ugrave; opportunista, e dove la convivenza tra specie &egrave; un compromesso quotidiano che nessun piano regolatore ha previsto
+    (<span class="fc">&#x1F412; ff.143.2
+    Darwinismo urbano</span>).</p>
 
     <div class="sep"></div>
 


### PR DESCRIPTION
## Summary
- Injected 3 unused FF notes into chapter-03.html, section 3.1, after the Urbanizzazione block
- **ff.8.5** (OLD) — PlayStation vs Netflix: 5 miliardi di ore/mese, videogiochi come valvola anti-noia
- **ff.64.1** (MID) — Mostra "Salto nel vuoto" a Bergamo 2023: smaterializzazione arte, NFT, umanesimo digitale
- **ff.143.2** (RECENT) — Darwinismo urbano a Varanasi: scimmie come bande organizzate, distopia biologica

## Changelog
- `book/chapter-03.html`: +1 new `<p>` block (~280 words) with 3 `<span class="fc">` references and 1 `<mark class="note-highlight">`

## Test plan
- [ ] Verify prose renders correctly in browser
- [ ] Confirm note-highlight and fc spans display with correct styling
- [ ] Check no duplicate ff codes in the book

🤖 Generated with [Claude Code](https://claude.com/claude-code)