### PR TITLE
Tecnologia 2.1: embargo chip, Doctor House AI, Minecraft diamanti

### DIFF
--- a/book/chapter-02.html
+++ b/book/chapter-02.html
@@ -326,6 +326,18 @@
     Intanto, dall&rsquo;altra parte dello spettro, il codice si scrive da solo. Gemini&nbsp;3 ha reso possibile creare in un solo weekend il restyling completo di un sito, un&rsquo;app nutrizionale e un&rsquo;app di lettura aumentata dall&rsquo;AI. Pieter Levels, creatore di NomadList, non ha mai scritto una riga di codice in vita sua &mdash; eppure gestisce un portafoglio di prodotti digitali da milioni di utenti. Il &ldquo;vibe coding&rdquo; &egrave; la democratizzazione finale: ogni aggiornamento di modello accorcia il tempo tra idea e prototipo. La domanda non &egrave; pi&ugrave; &ldquo;sai programmare?&rdquo; ma &ldquo;sai cosa costruire?&rdquo;
     (<span class="fc">&#128187; ff.140.2
     Vibe coding in un weekend</span>).</p>
+    <!-- ===== NEW — Embargo chip, Doctor House simulato e Minecraft AI ===== -->
+    <p>La supremazia cinese nell&rsquo;elettrificazione fa pensare a un futuro tutto orientale, ma sull&rsquo;intelligenza artificiale la partita &egrave; diversa. Il know-how per costruire GPU da training &egrave; in mano a NVIDIA e AMD, e gli Stati Uniti hanno avviato un vero embargo tecnologico per rallentare le capacit&agrave; di calcolo di Pechino. L&rsquo;effetto, per&ograve;, potrebbe essere paradossale: come l&rsquo;Europa e gli USA stanno costruendo fabbriche di semiconduttori indipendenti, la Cina potrebbe fare lo stesso sull&rsquo;AI. TSMC ha investito quaranta miliardi negli Stati Uniti nell&rsquo;ultimo anno &mdash; un campanello d&rsquo;allarme geopolitico: quando la globalizzazione smette di convenire, il commercio si contrae e il rischio di tensioni cresce
+    (<span class="fc">&#128012; ff.42.3
+    Bastoni tra le AI-ruote</span>).
+    Intanto, nell&rsquo;eterno dilemma teoria-pratica, l&rsquo;esperienza vince anche in medicina. Simulando conversazioni tra pazienti e dottori virtuali &mdash; agenti LLM che impersonano ruoli come in <em>The Sims</em> o in una puntata di <em>Doctor House</em> &mdash; un GPT generico ha fatto un &ldquo;tirocinio&rdquo; tanto efficace da battere MedAgent-Zero, un modello appositamente allenato su tutta la letteratura scientifica. Il paradosso: l&rsquo;esperienza simulata supera la conoscenza enciclopedica
+    (<span class="fc">&#129468; ff.98.2
+    Simulare Doctor House</span>).
+    E quando l&rsquo;AI smette di imitare l&rsquo;uomo, supera anche i suoi limiti. DreamerV3 di Google DeepMind, senza aver mai visto giocare Minecraft e senza conoscerne le regole, in cento milioni di passi ha imparato a rompere alberi, costruire bastoni, migliorare picconi &mdash; fino al primo blocco di diamante. David Silver e Richard Sutton, pionieri del reinforcement learning, sostengono che siamo nell&rsquo;Era dell&rsquo;Esperienza: agenti autonomi che esplorano il mondo senza bisogno di conferme umane. Dan Hendrycks, dal Center for AI Safety, avverte che lasciare evolvere l&rsquo;AI in modo indipendente potrebbe essere la nostra fine. Il diamante in Minecraft &egrave; una metafora perfetta: prezioso e pericoloso
+    (<span class="fc">&#128142; ff.123.2
+    Minecraft oltre l&rsquo;uomo</span>).</p>
+
+
 
 
 


### PR DESCRIPTION
## Changelog
- **ff.42.3** (old) — Bastoni tra le AI-ruote. Embargo chip US-Cina, TSMC $40B, deglobalizzazione
- **ff.98.2** (medium) — Simulare Doctor House. Agenti LLM battono modelli medici specializzati
- **ff.123.2** (high) — Minecraft oltre l'uomo. DreamerV3 trova diamanti senza regole, Era dell'Esperienza

## Checklist FF Inject
- [x] 3 ff.X.Y mai usati nel ciclo corrente
- [x] Testo riformulato (non verbatim)
- [x] Distribuzione temporale (old/medium/high)
- [x] Formato ref corretto
- [x] Wordcount ≥200 parole

🤖 Generated with [Claude Code](https://claude.com/claude-code)