### PR TITLE
Editorial: inline 📎 references in ch01-03

### DIFF
--- a/book/chapter-01.html
+++ b/book/chapter-01.html
@@ -258,13 +258,11 @@
     Le 72 stagioni giapponesi</span>).
     Le mezze stagioni, nel frattempo, stanno davvero scomparendo: l&rsquo;allungamento dell&rsquo;estate per effetto del riscaldamento globale sta alterando i cicli fenologici e comprimendo autunno e primavera in finestre sempre pi&ugrave; strette (
       <a href="https://heatmap.news/climate/fall-colors-are-getting-weird" target="_blank" rel="noopener"
-         style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
-        &#128206; Le mezze stagioni stanno scomparendo a causa dell&rsquo;allungamento dell&rsquo;estate
+         style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;"> Le mezze stagioni stanno scomparendo a causa dell&rsquo;allungamento dell&rsquo;estate
       </a>),
     mentre la riflessione sul vivere lentamente e sulla ricerca di una vita bella suggerisce che la lentezza non &egrave; pigrizia ma percezione intensificata (
       <a href="https://www.wildbarethoughts.com/p/what-i-mean-when-i-say-i-want-a-beautiful" target="_blank" rel="noopener"
-         style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
-        &#128206; Vivere lentamente e la ricerca di una vita bella
+         style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;"> Vivere lentamente e la ricerca di una vita bella
       </a>).
     Se la natura parla settantadue lingue in un anno, il problema non &egrave; che le stagioni scompaiono: &egrave; che abbiamo smesso di ascoltarle.</p>
 
@@ -308,37 +306,31 @@
 
     <p>Ma se il bilancio quotidiano &egrave; eloquente, quello macroeconomico &egrave; devastante. Un documento di lavoro del National Bureau of Economic Research ha ricalcolato l'impatto reale del riscaldamento globale e il risultato &egrave; sei volte peggiore delle stime precedenti: ogni grado centigrado di aumento cancella il <mark class="note-highlight">12% del PIL globale</mark>, un ordine di grandezza che rende il cambiamento climatico non solo una crisi ecologica ma la pi&ugrave; grande minaccia economica della storia moderna
     (<a href="https://x.com/DrSimEvans/status/1790055336289677368" target="_blank" rel="noopener"
-       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
-      &#128206; Danni climatici 6 volte maggiori del previsto: ogni 1&deg;C cancella il 12% del PIL globale
+       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;"> Danni climatici 6 volte maggiori del previsto: ogni 1&deg;C cancella il 12% del PIL globale
     </a>).
     La sproporzione tra il costo dell'azione e il costo dell'inerzia &egrave; ormai misurabile: investire un euro nella transizione oggi risparmia tra tre e sette euro di danni futuri, eppure il sistema finanziario continua a scontare il rischio climatico come se fosse lineare, quando ogni evidenza mostra che &egrave; esponenziale. C'&egrave; poi un paradosso della pulizia che pochi considerano: man mano che riduciamo l'inquinamento atmosferico &mdash; obiettivo sacrosanto per la salute pubblica &mdash; eliminiamo anche gli aerosol che riflettono parte della <mark class="note-highlight">radiazione solare</mark>, aumentando l'esposizione UV e accelerando il riscaldamento di superficie
     (<a href="https://x.com/LeonSimons8/status/1791828099048382668" target="_blank" rel="noopener"
-       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
-      &#128206; Meno inquinamento e aerosol: pi&ugrave; radiazione solare ed esposizione UV
+       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;"> Meno inquinamento e aerosol: pi&ugrave; radiazione solare ed esposizione UV
     </a>).
     &Egrave; il tipo di feedback loop che rende la governance climatica cos&igrave; vertiginosa: ogni soluzione genera un nuovo problema, e l'unica strategia robusta &egrave; quella che tiene insieme decarbonizzazione, adattamento e monitoraggio degli effetti collaterali.</p>
 
     <p>Eppure, dentro questo labirinto di feedback, il capitale ha gi&agrave; scelto la direzione. L'Agenzia Internazionale dell'Energia stima che gli investimenti globali in energia pulita supereranno i <mark class="note-highlight">3 trilioni di dollari</mark> nel 2024 &mdash; il doppio di quanto destinato ai combustibili fossili
     (<a href="https://www.iea.org/news/investment-in-clean-energy-this-year-is-set-to-be-twice-the-amount-going-to-fossil-fuels" target="_blank" rel="noopener"
-       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
-      &#128206; Investimenti in energia pulita: il doppio dei combustibili fossili
+       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;"> Investimenti in energia pulita: il doppio dei combustibili fossili
     </a>).
     Non &egrave; pi&ugrave; una scommessa ideologica: &egrave; arbitraggio finanziario. Il solare costa meno del carbone in quasi ogni mercato del mondo, e la curva di apprendimento continua a scendere. Ma la transizione non si gioca solo sui tetti e nei deserti. Nelle case europee, la pompa di calore sta riscrivendo il bilancio energetico domestico: una singola unit&agrave; riduce le emissioni di quasi <mark class="note-highlight">3.000 kg di CO&#8322; all'anno</mark>, eliminando la caldaia a gas senza sacrificare il comfort
     (<a href="https://x.com/ElectrifyNow/status/1750216223722070397" target="_blank" rel="noopener"
-       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
-      &#128206; Pompa di calore: quasi 3000 kg CO2 in meno all'anno
+       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;"> Pompa di calore: quasi 3000 kg CO2 in meno all'anno
     </a>).
     E c'&egrave; un'altra conversione che nessuno vuole fare: sostituire il manzo con il pollo riduce l'impronta carbonica dell'<mark class="note-highlight">80%</mark>, ma richiede duecento volte pi&ugrave; animali
     (<a href="https://x.com/ATabarrok/status/1704496361692000336" target="_blank" rel="noopener"
-       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
-      &#128206; Manzo vs pollo: -80% CO2 ma 200x pi&ugrave; animali
+       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;"> Manzo vs pollo: -80% CO2 ma 200x pi&ugrave; animali
     </a>).
     Il dilemma &egrave; matematicamente perfetto e moralmente irrisolvibile &mdash; esattamente il tipo di trade-off che la transizione energetica impone a ogni livello, dal piatto alla centrale elettrica.</p>
 
     <p>Se il costo del clima &egrave; sottostimato, quello dell'intelligenza artificiale &egrave; sovrastimato &mdash; almeno sul piano energetico. Il dibattito pubblico dipinge l'AI come una voragine elettrica, ma i dati raccontano un'altra storia: una singola ricerca su ChatGPT equivale allo <mark class="note-highlight">0,00007% dell'impronta elettrica annuale</mark> pro capite nel Regno Unito
     (<a href="https://www.sustainabilitybynumbers.com/p/carbon-footprint-chatgpt" target="_blank" rel="noopener"
-       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
-      &#128206; Una ricerca su ChatGPT equivale a solo lo 0,00007% dell'impronta elettrica annuale pro capite nel Regno Unito
+       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;"> Una ricerca su ChatGPT equivale a solo lo 0,00007% dell'impronta elettrica annuale pro capite nel Regno Unito
     </a>).
     Il dato non assolve l'industria &mdash; 50 milioni di GPU H100 a pieno regime consumerebbero 35 GW, circa il 2% del consumo elettrico mondiale &mdash; ma ridimensiona la retorica apocalittica: il problema non &egrave; la singola query, &egrave; la scala infrastrutturale, ed &egrave; un problema di pianificazione energetica, non di rinuncia tecnologica. Il vero rischio &egrave; che la narrazione distorta dell'AI energivora distolga l'attenzione dalle fonti di consumo realmente massive e strutturalmente pi&ugrave; difficili da decarbonizzare, come il riscaldamento domestico e il trasporto merci.</p>
 
@@ -381,13 +373,11 @@
     <!-- ===== NEW — Batterie e stoccaggio energetico ===== -->
     <p>La transizione energetica ha un problema che nessun pannello solare pu&ograve; risolvere da solo: il tempo. Il sole splende di giorno, il vento soffia a intermittenza, ma la domanda di elettricit&agrave; &egrave; costante &mdash; e nelle ore di punta serale raggiunge il picco proprio quando le rinnovabili si spengono. Senza stoccaggio, ogni gigawatt installato resta ostaggio della meteorologia. La IEA stima che serva un <mark class="note-highlight">aumento di sei volte della capacit&agrave; globale di accumulo a batteria entro il 2030</mark> per rispettare gli obiettivi climatici fissati alla COP28 (
       <a href="https://www.iea.org/news/rapid-expansion-of-batteries-will-be-crucial-to-meet-climate-and-energy-security-goals-set-at-cop28" target="_blank" rel="noopener"
-         style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
-        &#128206; Aumento di sei volte dell'accumulo di energia da batterie necessario entro il 2030
+         style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;"> Aumento di sei volte dell'accumulo di energia da batterie necessario entro il 2030
       </a>
     ). &Egrave; una cifra che traduce un concetto astratto in ingegneria concreta: non basta produrre elettroni puliti, bisogna parcheggiarli da qualche parte e rilasciarli quando servono. Il litio domina il mercato attuale, ma &egrave; costoso, concentrato geograficamente e inadatto allo stoccaggio di lunga durata. La frontiera pi&ugrave; promettente arriva da una chimica sorprendentemente primitiva. A Delft, nei Paesi Bassi, Ore Energy ha collegato alla rete la prima batteria ferro-aria al mondo: un sistema che usa solo <mark class="note-highlight">ferro, aria e acqua</mark> per offrire fino a 100 ore di stoccaggio energetico pulito (
       <a href="https://tech.eu/2025/07/30/ore-energy-connects-worlds-first-grid-connected-iron-air-battery-in-delft/" target="_blank" rel="noopener"
-         style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
-        &#128206; Ore Energy connette la prima batteria ferro-aria: 100 ore di stoccaggio
+         style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;"> Ore Energy connette la prima batteria ferro-aria: 100 ore di stoccaggio
       </a>
     ). Cento ore significano quattro giorni interi di autonomia &mdash; abbastanza per coprire una settimana nuvolosa o un'ondata di calore senza vento. Il ferro &egrave; il quarto elemento pi&ugrave; abbondante sulla crosta terrestre, non richiede miniere in Congo n&eacute; raffinerie in Cina, e il suo costo al chilo &egrave; una frazione di quello del litio. &Egrave; la stessa logica della fotosintesi: la natura non usa materiali rari, usa quelli disponibili ovunque e li combina con eleganza. Se la batteria ferro-aria scaler&agrave;, il collo di bottiglia della transizione energetica non sar&agrave; pi&ugrave; la generazione ma la volont&agrave; politica di installarla. E la domanda vera diventa un'altra: perch&eacute; il mondo investe ancora miliardi in infrastrutture fossili quando la soluzione &egrave; letteralmente fatta di ruggine e aria?</p>
 
@@ -505,13 +495,11 @@
     Diete e inquinanti</span>).
     Il tasso di obesit&agrave; italiano si attesta al 24,12% &mdash; quasi il doppio di quello francese (
       <a href="https://en.m.wikipedia.org/wiki/List_of_countries_by_obesity_rate" target="_blank" rel="noopener"
-         style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
-        &#128206; L'Italia ha un tasso di obesit&agrave; del 24,12% vs 12,36% Francia
+         style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;"> L'Italia ha un tasso di obesit&agrave; del 24,12% vs 12,36% Francia
       </a>),
     e le risposte glicemiche individuali confermano che la stessa caloria produce effetti radicalmente diversi in corpi diversi (
       <a href="https://www.instagram.com/p/DMyD9cauETY/" target="_blank" rel="noopener"
-         style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
-        &#128206; Il 35% delle persone ha un picco glicemico maggiore con il riso
+         style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;"> Il 35% delle persone ha un picco glicemico maggiore con il riso
       </a>).
     L&rsquo;obesit&agrave; non &egrave; pigrizia: &egrave; il risultato di un sistema alimentare che ha cambiato le regole del gioco senza avvisare i giocatori.</p>
 
@@ -565,13 +553,11 @@
     Cosa mangiare per non invecchiare?</span>).
     Un&rsquo;analisi temporale dell&rsquo;invecchiamento tissutale pubblicata su <em>Cell</em> conferma un&rsquo;inflessione intorno ai cinquant&rsquo;anni, con i vasi sanguigni che invecchiano pi&ugrave; precocemente di tutti gli altri tessuti (
       <a href="https://www.cell.com/cell/abstract/S0092-8674(25)00749-4" target="_blank" rel="noopener"
-         style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
-        &#128206; Inflessione nell&rsquo;invecchiamento tissutale intorno ai 50 anni
+         style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;"> Inflessione nell&rsquo;invecchiamento tissutale intorno ai 50 anni
       </a>),
     mentre l&rsquo;AI generativa sta accelerando la ricerca sulla longevit&agrave; riducendo un lavoro di 150 anni a un mese e a un miliardesimo del costo (
       <a href="https://x.com/davidasinclair/status/1951310208778539340" target="_blank" rel="noopener"
-         style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
-        &#128206; L&rsquo;AI generativa riduce 150 anni di ricerca sulla longevit&agrave; a un mese
+         style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;"> L&rsquo;AI generativa riduce 150 anni di ricerca sulla longevit&agrave; a un mese
       </a>).
     La convergenza tra scienza dell&rsquo;alimentazione e intelligenza artificiale suggerisce che il prossimo decennio porter&agrave; risposte personalizzate su scala mai vista &mdash; ma il punto di partenza rester&agrave; sempre un piatto di legumi.</p>
 

--- a/book/chapter-02.html
+++ b/book/chapter-02.html
@@ -225,18 +225,15 @@
 
     <p>Ma la robotica pi&ugrave; profonda non imita l'umano &mdash; imita l'insetto. NeuroMechFly v2 &egrave; il primo sistema che integra <mark class="note-highlight">4 canali embodied</mark> &mdash; visione, olfatto, feedback ascendente e terreni complessi &mdash; in un unico stack dove neuroscienze computazionali e controller robotici sono verificabili e trasferibili, non pi&ugrave; demo isolate di locomozione
     (<a href="https://pubmed.ncbi.nlm.nih.gov/39533006/" target="_blank" rel="noopener"
-       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
-      &#128206; NeuroMechFly v2: 4 canali embodied e controller bio-ispirati
+       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;"> NeuroMechFly v2: 4 canali embodied e controller bio-ispirati
     </a>).
     Il progetto dimostra due controller bio-ispirati e due task avanzati di reinforcement learning basati sul connectome &mdash; la mappa neurale completa della <em>Drosophila</em>. &Egrave; un ponte inedito tra la biologia e il silicio: se un cervello da centomila neuroni pu&ograve; produrre comportamento adattivo sofisticato, la domanda non &egrave; quanti parametri servano, ma quanta architettura sia sufficiente. Nel frattempo, l'impatto economico dell'AI non &egrave; pi&ugrave; teorico. Block &mdash; la societ&agrave; di Jack Dorsey &mdash; ha licenziato <mark class="note-highlight">4.000 persone</mark> e il titolo &egrave; salito del 24% in un giorno: Wall Street premia chi taglia teste
     (<a href="https://youtu.be/toE56X2h0wk" target="_blank" rel="noopener"
-       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
-      &#128206; Block licenzia 4.000, titolo +24% &mdash; disoccupazione neolaureati 50%
+       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;"> Block licenzia 4.000, titolo +24% &mdash; disoccupazione neolaureati 50%
     </a>).
     Il tasso di disoccupazione tra neolaureati americani supera il 50%, e la promessa &ldquo;studia, laureati, lavora&rdquo; si dissolve davanti a modelli che svolgono compiti junior meglio e gratis. Stanley Druckenmiller aveva visto il segnale gi&agrave; nel 2022: ha comprato NVIDIA prima di ChatGPT osservando che gli studenti di Stanford stavano migrando in massa da crypto a AI
     (<a href="https://youtu.be/toE56X2h0wk" target="_blank" rel="noopener"
-       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
-      &#128206; Druckenmiller ha comprato NVIDIA osservando la migrazione Stanford da crypto a AI
+       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;"> Druckenmiller ha comprato NVIDIA osservando la migrazione Stanford da crypto a AI
     </a>).
     Non &egrave; solo un trade finanziario: &egrave; una lettura della direzione del talento. Quando i migliori cervelli cambiano campo, il capitale segue &mdash; e il mercato del lavoro si riorganizza prima che le universit&agrave; aggiornino i curricula.</p>
 
@@ -283,13 +280,11 @@
 
     <p>C'&egrave; per&ograve; un risvolto che sfugge alla narrativa dominante sull'AI: la macchina non guarda solo avanti, guarda anche indietro. DeepMind ha rilasciato <em>Aeneas</em>, un modello addestrato su <mark class="note-highlight">circa 140.000 iscrizioni greche e latine</mark> che aiuta gli storici a restaurare, datare e geolocalizzare testi incisi nella pietra duemila anni fa
     <a href="https://deepmind.google/discover/blog/aeneas-transforms-how-historians-connect-the-past/" target="_blank" rel="noopener"
-       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
-      &#128206; DeepMind ha rilasciato Aeneas un modello AI che aiuta gli storici
+       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;"> DeepMind ha rilasciato Aeneas un modello AI che aiuta gli storici
     </a>.
     Un frammento illeggibile di un'epigrafe romana diventa un puzzle risolvibile: la rete neurale confronta pattern di lettere mancanti con l'intero corpus epigrafico conosciuto, suggerendo completamenti che a un epigrafista esperto richiederebbero settimane. In parallelo, un altro studio pubblicato su <em>Nature</em> dimostra che le reti neurali generative sanno contestualizzare testi antichi, migliorando compiti epigrafici tradizionali &mdash; dalla datazione alla classificazione geografica &mdash; con una <mark class="note-highlight">precisione superiore ai metodi manuali</mark>
     <a href="https://www.nature.com/articles/s41586-025-09292-5" target="_blank" rel="noopener"
-       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
-      &#128206; Le reti neurali generative contestualizzano testi antichi
+       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;"> Le reti neurali generative contestualizzano testi antichi
     </a>.
     Il paradosso &egrave; sottile e profondo: l'AI pi&ugrave; avanzata, quella che brucia gigawatt di calcolo e spaventa il mercato del lavoro, trova uno dei suoi impieghi pi&ugrave; eleganti nel decifrare ci&ograve; che fu scritto a mano su marmo, prima dell'elettricit&agrave;, prima della stampa, prima persino della carta. Non &egrave; nostalgia: &egrave; una forma di ricorsivit&agrave; culturale. La macchina che impara dal passato per prevedere il futuro si rivela, forse, pi&ugrave; utile quando ricostruisce il passato stesso. Ogni iscrizione restaurata &egrave; un frammento di governance, di diritto, di quotidianit&agrave; che ritorna leggibile &mdash; e che costringe a ripensare l'idea stessa di &ldquo;intelligenza&rdquo;: non solo calcolo e previsione, ma anche ascolto, pazienza, ricomposizione. Se l'AI pu&ograve; restituirci le parole dei romani, forse la domanda giusta non &egrave; <em>cosa far&agrave;</em> l'AI, ma <em>cosa ci far&agrave; ricordare</em>
     (<span class="fc">&#128218; ff.102.3

--- a/book/chapter-03.html
+++ b/book/chapter-03.html
@@ -255,8 +255,7 @@
     Misurare l'ossigeno bruciato</span>).
     Apple Watch, Garmin, WHOOP e Oura Ring misurano ormai il VO&#8322;max stimato al polso; la democratizzazione dei dati fisiologici &egrave; in corso. Uno studio recente rileva che <mark class="note-highlight">4.000 passi al giorno riducono il rischio di morte e malattie dal 9% al 39%</mark> &mdash; non servono maratone, bastano passeggiate
     (<a href="https://x.com/foundmyfitness/status/1953119953822822745" target="_blank" rel="noopener"
-       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
-      &#128206; Uno studio rileva che 4000 passi al giorno riducono il rischio di morte e malattie dal 9% al 39%
+       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;"> Uno studio rileva che 4000 passi al giorno riducono il rischio di morte e malattie dal 9% al 39%
     </a>). Il wellness market vale 1.500 miliardi di dollari globali
     (<span class="fc">&#9201; ff.35
     Sto bene, sono Super Sapiens</span>). <a href="https://www.nature.com/articles/s41598-025-08098-9" target="_blank" rel="noopener" style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">Uno studio analizza 5 milioni di piatti e le loro correlazioni nutrizionali</a> (nature.com)</p>
@@ -334,8 +333,7 @@
     (<span class="fc">&#128142; ff.62.4
     Maslow nel 2024</span>)
     (<a href="https://www.wealest.com/articles/barbell-strategy" target="_blank" rel="noopener"
-       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
-      &#128206; Sempre pi&ugrave; giovani scelgono tra lavori manuali o 'all-in' digitali abbandonando l'universit&agrave;
+       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;"> Sempre pi&ugrave; giovani scelgono tra lavori manuali o 'all-in' digitali abbandonando l'universit&agrave;
     </a>).</p>
 
     <p>Bill Perkins, ingegnere prestato alla compravendita del gas, ha costruito un&#39;intera filosofia su un paradosso fiscale: morire con <mark class="note-highlight">10.000 euro in banca</mark> significa aver lavorato tre mesi per niente &mdash; tre mesi convertibili in cinque viaggi, cinquanta cene o tre anni di pensione in pi&ugrave;. Il suo libro <em>Die with Zero</em> introduce la nozione di &ldquo;ricordi come dividendi&rdquo;: un viaggio in Italia a 20 anni genera vent&#39;anni di memoria, conoscenze e relazioni; lo stesso investimento a 40 anni produce meno della met&agrave;. C&#39;&egrave; anche l&#39;&ldquo;inflazione fisica&rdquo;: a 60 anni, sugli sci, facciamo meno discese. Perkins tira la conclusione scomoda: le eredit&agrave; che i figli ricevono a 60 anni, quando sono gi&agrave; economicamente stabili, avrebbero prodotto <mark class="note-highlight">dieci volte pi&ugrave; valore</mark> se donate tra i 25 e i 35 anni, quando possono servire per casa, impresa o pi&ugrave; esperienze
@@ -366,18 +364,15 @@
 
     <p>I numeri confermano l'accelerazione della frattura. I giovani americani socializzano il <mark class="note-highlight">50% in meno</mark> rispetto alla generazione precedente, e il <mark class="note-highlight">64% dei teenager</mark> dichiara di usare chatbot AI come interlocutore abituale &mdash; non per curiosit&agrave; tecnologica, ma per colmare un vuoto relazionale che il mondo fisico non riesce pi&ugrave; a riempire
     (<a href="https://youtu.be/toE56X2h0wk" target="_blank" rel="noopener"
-       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
-      &#128206; Giovani socializzano 50% in meno &mdash; 64% teenager usa chatbot AI
+       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;"> Giovani socializzano 50% in meno &mdash; 64% teenager usa chatbot AI
     </a>).
     Andrew Yang ha raccontato che suo figlio scherza sulla fidanzata virtuale come se fosse la cosa pi&ugrave; naturale del mondo. Non &egrave; distopia: &egrave; adattamento. Quando la frizione interpersonale &mdash; quella che i terapeuti considerano essenziale per la crescita emotiva &mdash; diventa opzionale, il peso non processato si accumula altrove. Il parallelo economico &egrave; altrettanto brutale: negli ultimi settant'anni la percentuale di americani che sono contemporaneamente proprietari di casa e sposati &egrave; crollata dal <mark class="note-highlight">50% al 15%</mark>
     (<a href="https://x.com/APompliano/status/1951989381775958388" target="_blank" rel="noopener"
-       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
-      &#128206; Proprietari di casa sposati: dal 50% al 15% in 70 anni
+       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;"> Proprietari di casa sposati: dal 50% al 15% in 70 anni
     </a>).
     Non sono due crisi separate: sono la stessa. Chi non pu&ograve; permettersi una casa non costruisce una famiglia; chi non costruisce una famiglia cerca compagnia altrove &mdash; e l'AI offre un surrogato infinitamente paziente, disponibile, privo di giudizio. Yang propone una risposta radicale: un'economia &ldquo;Star Trek&rdquo; fondata su <em>wellness bucks</em>, crediti comunitari e valute multiple progettate per incentivare la fioritura umana invece del consumo
     (<a href="https://youtu.be/toE56X2h0wk" target="_blank" rel="noopener"
-       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
-      &#128206; Yang: wellness bucks e crediti comunitari per la fioritura umana
+       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;"> Yang: wellness bucks e crediti comunitari per la fioritura umana
     </a>).
     Se i punti Amex costano zero ma cambiano il comportamento al 100%, perch&eacute; non applicare lo stesso principio al volontariato e alla salute? La domanda non &egrave; utopica &mdash; &egrave; ingegneristica.</p>
 
@@ -452,18 +447,15 @@
 
     <p>C&apos;&egrave; un paradosso generazionale che nessun algoritmo ha ancora risolto. I giovani americani socializzano il <mark class="note-highlight">50% in meno</mark> rispetto a vent&apos;anni fa, eppure non sono mai stati cos&igrave; connessi: il 64% dei teenager dichiara di usare regolarmente chatbot AI, e Andrew Yang racconta che suo figlio scherza sulla fidanzata virtuale come se fosse la cosa pi&ugrave; naturale del mondo
     (<a href="https://youtu.be/toE56X2h0wk" target="_blank" rel="noopener"
-       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
-      &#128206; I giovani socializzano il 50% in meno &mdash; il 64% dei teenager usa chatbot AI
+       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;"> I giovani socializzano il 50% in meno &mdash; il 64% dei teenager usa chatbot AI
     </a>).
     Il punto non &egrave; tecnofobico. Il punto &egrave; strutturale: l&apos;<mark class="note-highlight">85% degli utenti dell&apos;app ChatGPT sono uomini</mark> &mdash; le donne percepiscono l&apos;AI come &ldquo;barare&rdquo;, un dato che rivela quanto la relazione con l&apos;intelligenza artificiale sia gi&agrave; segmentata per genere
     (<a href="https://www.profgmarkets.com/p/openai-is-on-track-to-become-the-world-s-most-valuable-startup" target="_blank" rel="noopener"
-       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
-      &#128206; L'85% degli utenti dell'app ChatGPT sono uomini le donne percepiscono l'AI come 'barare'
+       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;"> L'85% degli utenti dell'app ChatGPT sono uomini le donne percepiscono l'AI come 'barare'
     </a>).
     Se il matrimonio, come sostiene la terapia di coppia pi&ugrave; seria, funziona perch&eacute; obbliga due persone a elaborare i traumi attraverso la frizione quotidiana, e se l&apos;AI elimina ogni frizione &mdash; ogni conflitto, ogni silenzio imbarazzante, ogni compromesso &mdash; allora tutto quel peso emotivo non processato finisce da qualche parte. E di solito finisce dentro. Intanto, il mercato del lavoro conferma la frattura. Block licenzia 4.000 dipendenti e il titolo sale del 24% in un giorno: Wall Street premia chi taglia teste. Il tasso di disoccupazione tra i neolaureati USA supera il <mark class="note-highlight">50%</mark>, il pi&ugrave; alto da quando si raccolgono dati
     (<a href="https://youtu.be/toE56X2h0wk" target="_blank" rel="noopener"
-       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">
-      &#128206; Block licenzia 4.000 persone e il titolo sale del 24%
+       style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;"> Block licenzia 4.000 persone e il titolo sale del 24%
     </a>).
     La promessa &ldquo;studia, laureati, lavora&rdquo; si sgretola proprio nel momento in cui l&apos;AI elimina la necessit&agrave; di profili junior: chi entra nel mercato senza esperienza compete contro un modello che non dorme, non chiede ferie e non negozia lo stipendio. Il risultato &egrave; una generazione stretta in una tenaglia inedita &mdash; troppo qualificata per i lavori manuali, troppo inesperta per quelli cognitivi, e troppo sola per elaborare la frustrazione in compagnia. Quando il figlio di Yang ride della fidanzata AI, ride di una sostituzione che &egrave; gi&agrave; avvenuta: non della persona, ma dello spazio relazionale in cui le persone imparavano a diventare adulte
     (<span class="fc">&#128107; ff.89


### PR DESCRIPTION
## Summary
- Remove all standalone `📎` (`&#128206;`) link blocks from chapters 1 (Natura), 2 (Tecnologia), 3 (Società)
- Fix broken HTML where the 📎 entity leaked into `style` attributes (e.g., `style="..."&#128206;`)
- All external source links are now properly inline with clean HTML attributes

## Changes
- **chapter-01.html**: 14 📎 references fixed
- **chapter-02.html**: 5 📎 references fixed  
- **chapter-03.html**: 8 📎 references fixed

## Test plan
- [ ] Verify all 3 chapters render correctly in browser
- [ ] Check that inline links are clickable and open in new tab
- [ ] Confirm no broken `style` attributes remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)