### PR TITLE
book: 36 subchapter headings for chapters 1-3

### DIFF
--- a/book/chapter-01.html
+++ b/book/chapter-01.html
@@ -136,10 +136,45 @@
         <p id="chapterSearchHint" class="text-xs text-zinc-500 mt-2">Ricerca locale sui paragrafi di questo capitolo.</p>
     </section>
 
+    <nav class="mt-4 mb-6 px-4" aria-label="Sottocapitoli">
+      <h2 class="ff-eyebrow text-zinc-500 mb-2 text-xs">Sottocapitoli</h2>
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-2 text-sm">
+        <div>
+          <div class="font-bold text-zinc-700 mb-1">1.1 Mobilit&agrave;</div>
+          <ul class="space-y-0.5">
+            <li><a href="#s1-1" class="underline text-zinc-600 hover:text-zinc-900">1.1.1 L'euthymicrona</a></li>
+            <li><a href="#s1-2" class="underline text-zinc-600 hover:text-zinc-900">1.1.2 Citt&agrave; a 15 min</a></li>
+            <li><a href="#s1-3" class="underline text-zinc-600 hover:text-zinc-900">1.1.3 Ruote autonome</a></li>
+            <li><a href="#s1-4" class="underline text-zinc-600 hover:text-zinc-900">1.1.4 Impronte e cieli</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="font-bold text-zinc-700 mb-1">1.2 Energia</div>
+          <ul class="space-y-0.5">
+            <li><a href="#s2-1" class="underline text-zinc-600 hover:text-zinc-900">1.2.1 Microplastiche</a></li>
+            <li><a href="#s2-2" class="underline text-zinc-600 hover:text-zinc-900">1.2.2 Nodo energetico</a></li>
+            <li><a href="#s2-3" class="underline text-zinc-600 hover:text-zinc-900">1.2.3 Geoingegneria</a></li>
+            <li><a href="#s2-4" class="underline text-zinc-600 hover:text-zinc-900">1.2.4 Alberi e acqua</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="font-bold text-zinc-700 mb-1">1.3 Cibo</div>
+          <ul class="space-y-0.5">
+            <li><a href="#s3-1" class="underline text-zinc-600 hover:text-zinc-900">1.3.1 Microbioma</a></li>
+            <li><a href="#s3-2" class="underline text-zinc-600 hover:text-zinc-900">1.3.2 Metabolismo</a></li>
+            <li><a href="#s3-3" class="underline text-zinc-600 hover:text-zinc-900">1.3.3 Armadio</a></li>
+            <li><a href="#s3-4" class="underline text-zinc-600 hover:text-zinc-900">1.3.4 Corpo elettrico</a></li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+
     <article class="prose max-w-none">
 
     <!-- ===== 1.1 ===== -->
     <h2 id="s1" class="text-xl sm:text-2xl font-bold mt-14 mb-6 border-b-4 border-green-500 pb-3">1.1 — Mobilit&agrave; e Citt&agrave;</h2>
+
+    <h3 id="s1-1" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">1.1.1 &mdash; L'euthymicrona del pendolare</h3>
 
     <p class="drop-cap">Ogni mattina, centinaia di milioni di persone si mettono in moto. Letteralmente. Il tragitto casa-lavoro &egrave; il rituale pi&ugrave; universale della civilt&agrave; moderna, eppure lo eseguiamo quasi in trance, ottimizzando per un'unica variabile: il tempo. Google Maps calcola quella che potremmo chiamare la <em>brachistocrona del pendolare</em> &mdash; <mark class="note-highlight">il percorso pi&ugrave; veloce tra due punti</mark>, come la celebre curva della meccanica classica che minimizza il tempo di caduta di una sfera
     (<span class="fc">&#127950; ff.138.1
@@ -159,6 +194,8 @@
     Ripensare le citt&agrave;</span>), poi rendere visibile il costo reale degli spostamenti (<span class="fc">&#127820; ff.58
     How bad are bananas?</span>). La citt&agrave; non &egrave; sfondo: &egrave; una tecnologia comportamentale.</p>
 
+    <h3 id="s1-2" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">1.1.2 &mdash; La citt&agrave; a 15 minuti</h3>
+
     <p>Ma la felicit&agrave; del tragitto &egrave; solo l'inizio. La vera rivoluzione &egrave; ripensare le citt&agrave; stesse. Negli ultimi decenni, urbanisti come Jan Gehl e Carlos Moreno hanno proposto un modello radicale: <mark class="note-highlight">la citt&agrave; a 15 minuti</mark>, in cui ogni servizio essenziale &mdash; scuola, medico, alimentari, parco, lavoro &mdash; sia raggiungibile a piedi o in bicicletta in un quarto d'ora
     (<span class="fc">&#127961; ff.34
     Ripensare le citt&agrave;</span>).
@@ -169,6 +206,8 @@
         <figcaption>&#127959; ff.34 &mdash; Ripensare le citt&agrave;: dalla dominanza dell'auto alla citt&agrave; a 15 minuti.</figcaption>
     </figure>
 
+    <h3 id="s1-3" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">1.1.3 &mdash; Ruote autonome</h3>
+
     <p>E le auto? Non scompariranno, ma cambieranno profondamente. La guida autonoma &egrave; gi&agrave; realt&agrave; in alcune citt&agrave; americane. Cruise, di propriet&agrave; di General Motors, ha lanciato un servizio di robotaxi 24 ore su 24 a San Francisco, e poi si &egrave; fermata dopo un incidente con un pedone che ha messo in luce la complessit&agrave; normativa del settore
     (<span class="fc">&#128661; ff.60
     La guida autonoma &egrave; qui!</span>).
@@ -178,6 +217,8 @@
     (<span class="fc">&#9889; ff.5
     Elettrizzante!</span>).
     Le batterie al sodio &mdash; senza litio, senza cobalto &mdash; promettono di democratizzare l'accumulo energetico. CATL, il gigante cinese, detiene il 35% del mercato globale delle batterie. La transizione non &egrave; pi&ugrave; una questione di <em>se</em>, ma di <em>quanto velocemente</em>.</p>
+
+    <h3 id="s1-4" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">1.1.4 &mdash; Impronte e cieli</h3>
 
     <p>Resta per&ograve; una domanda scomoda: quanto inquina davvero muoversi? Mike Berners-Lee, in <em>How Bad Are Bananas?</em>, traduce ogni azione in CO&#8322;: un chilometro in auto produce circa <mark class="note-highlight">271 grammi di CO&#8322;</mark>, uno in bici circa 16 &mdash; inclusa l'energia metabolica del ciclista
     (<span class="fc">&#127820; ff.58
@@ -202,6 +243,8 @@
     <!-- ===== 1.2 ===== -->
     <h2 id="s2" class="text-xl sm:text-2xl font-bold mt-14 mb-6 border-b-4 border-green-500 pb-3">1.2 — Ambiente ed Energia</h2>
 
+    <h3 id="s2-1" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">1.2.1 &mdash; La carta di credito invisibile</h3>
+
     <p class="drop-cap">Ogni settimana, un essere umano ingerisce circa <mark class="note-highlight">5 grammi di microplastiche</mark> &mdash; l'equivalente di una carta di credito. Non &egrave; un'iperbole: &egrave; il dato di uno studio commissionato dal WWF all'Universit&agrave; di Newcastle che ha analizzato 52 ricerche indipendenti
     (<span class="fc">&#129483; ff.130.1
     Plastic is fantastic</span>).
@@ -220,6 +263,8 @@
     (<span class="fc">&#128128; ff.130.4
     La danza macabra</span>).</p>
 
+    <h3 id="s2-2" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">1.2.2 &mdash; Il nodo gordiano dell'energia</h3>
+
     <figure>
         <img src="/index_files/pubs/ff1.webp" alt="Illustrazione sul clima e la transizione energetica" loading="lazy" width="800" height="450"/>
         <figcaption>&#127758; ff.1 &mdash; Clima: la sfida della transizione energetica dal COP26 al net zero.</figcaption>
@@ -232,6 +277,8 @@
     (<span class="fc">&#127780;&#65039; ff.70
     Il sole: soluzione o morte?</span>).
     Il nucleare, nel frattempo, torna nell'equazione: la Banca Mondiale ha revocato il divieto storico sui finanziamenti all'energia nucleare <a href="https://www.ft.com/content/d80b68ec-3da8-42ea-82ee-4cab22b31a69" target="_blank" rel="noopener" style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">La Banca Mondiale revoca il divieto sui finanziamenti all'energia nucleare</a> (ft.com), e la Cina necessita di <mark class="note-highlight">300 GW nucleari ogni 4 anni</mark> solo per tenere il passo con la propria domanda energetica <a href="https://x.com/JessePeltan/status/1927829603596587403" target="_blank" rel="noopener" style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">La crescita attuale della Cina richiede 300 GW nucleari ogni 4 anni</a> (x.com).</p>
+
+    <h3 id="s2-4" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">1.2.4 &mdash; Alberi, acqua e biodiversit&agrave;</h3>
 
     <p>La fusione nucleare &egrave; la promessa perenne dell'energia: sempre a trent'anni di distanza, dice il vecchio scherzo. Ma qualcosa &egrave; cambiato. Un gruppo di ricercatori di DeepMind ha pubblicato su <em>Nature</em> un risultato che sposta il confine: un sistema di <mark class="note-highlight">Deep Reinforcement Learning capace di controllare in tempo reale la posizione e la forma del plasma</mark> all'interno di un reattore tokamak, sostituendo i calcoli di fisica computazionale che tradizionalmente richiedono millisecondi preziosi tra una correzione e l'altra. L'intelligenza artificiale non si limita a replicare le configurazioni note &mdash; esplora forme di plasma mai tentate, inclusa una geometria a &ldquo;fiocco di neve&rdquo; che distribuisce il calore in modo pi&ugrave; uniforme sulle pareti del reattore. Se la fusione &egrave; il Santo Graal dell'energia, l'AI potrebbe essere il cavaliere che finalmente lo trova
     (<span class="fc">&#9762;&#65039; ff.28.1
@@ -247,6 +294,8 @@
         <img src="/index_files/pubs/ff70.webp" alt="Pannelli solari e transizione energetica: dalla produzione di massa all'accumulo" loading="lazy" width="800" height="450"/>
         <figcaption>&#9728;&#65039; ff.70 &mdash; Il sole: soluzione o morte? La corsa solare da 500 miliardi l'anno che sta riscrivendo la geopolitica dell'energia.</figcaption>
     </figure>
+
+    <h3 id="s2-3" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">1.2.3 &mdash; Geoingegneria e clima</h3>
 
     <p>Ma la produzione di energia pulita non basta se non affrontiamo il condizionamento planetario. Il geoengineering &mdash; l'idea di iniettare aerosol di solfati nella stratosfera per riflettere la luce solare e raffreddare il pianeta &mdash; &egrave; discusso ai massimi livelli scientifici, nonostante il rischio di effetti collaterali imprevedibili come l'alterazione dei monsoni e la riduzione della fotosintesi
     (<span class="fc">&#10052;&#65039; ff.56
@@ -487,6 +536,8 @@
     <!-- ===== 1.3 ===== -->
     <h2 id="s3" class="text-xl sm:text-2xl font-bold mt-14 mb-6 border-b-4 border-green-500 pb-3">1.3 — Cibo e Fashion</h2>
 
+    <h3 id="s3-1" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">1.3.1 &mdash; Dal microbioma al piatto</h3>
+
     <p class="drop-cap">Il corpo umano ospita circa <mark class="note-highlight">39.000 miliardi di batteri</mark> &mdash; pi&ugrave; delle sue stesse cellule. Questo ecosistema, il microbioma, regola il sistema immunitario, produce neurotrasmettitori, influenza l'umore, modula l'infiammazione
     (<span class="fc">&#129504; ff.90.3
     Micro-bi di stress</span>).
@@ -515,6 +566,8 @@
     <blockquote>
     <p>&ldquo;Le persone nelle zone blu non fanno dieta e non contano le calorie. Mangiano come hanno sempre mangiato &mdash; poco, vario, in compagnia. La longevit&agrave; non &egrave; un progetto: &egrave; un sottoprodotto di una vita con significato.&rdquo;<br>&mdash; Dan Buettner, <em>The Blue Zones</em></p>
     </blockquote>
+
+    <h3 id="s3-2" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">1.3.2 &mdash; Calorie, peso e metabolismo</h3>
 
     <p>Ma quanto &egrave; cambiata, in concreto, la dieta che ci ha portato fin qui? I dati di Pew Research sulla dieta americana degli ultimi quarant&rsquo;anni offrono una radiografia impietosa: <mark class="note-highlight">gli americani assumono 400 kcal in pi&ugrave; al giorno</mark> rispetto al 1970, il consumo di pollo &egrave; raddoppiato mentre le patate &mdash; anche fritte &mdash; sono diminuite. I prodotti a base di farine sono passati da 400 a 600 kcal. La regola &ldquo;calories in &ndash; calories out&rdquo; resta un buon punto di partenza, eppure la correlazione tra BMI e calorie consumate presenta una dispersione non trascurabile: a parit&agrave; di introito, il corpo spende pi&ugrave; o meno energia a seconda della grandezza del pasto, della quantit&agrave; di fibre e dei macronutrienti. Uno studio su <em>The Lancet Diabetes &amp; Endocrinology</em> ha mostrato che <mark class="note-highlight">non ci sono differenze significative tra una dieta prevalentemente a base di grassi e una a base di carboidrati</mark> &mdash; a conferma i Maasai del Kenya, la cui dieta da 3.000 kcal &egrave; composta per il 66% da grassi, senza epidemia di obesit&agrave;. Le fibre, invece, mostrano un effetto protettivo reale sul BMI. Il quadro si complica se aggiungiamo gli inquinanti ambientali: il testo di &ldquo;A Chemical Hunger&rdquo; ipotizza che contaminanti ubiquitari abbiano alterato i meccanismi di regolazione del peso, un&rsquo;ipotesi discussa ma non liquidabile
     (<span class="fc">&#127828; ff.49.3
@@ -587,6 +640,8 @@
       </a>).
     La convergenza tra scienza dell&rsquo;alimentazione e intelligenza artificiale suggerisce che il prossimo decennio porter&agrave; risposte personalizzate su scala mai vista &mdash; ma il punto di partenza rester&agrave; sempre un piatto di legumi.</p>
 
+    <h3 id="s3-3" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">1.3.3 &mdash; L'armadio sostenibile</h3>
+
     <p>Dalla tavola passiamo all'armadio. L'industria della moda &egrave; responsabile dell'<mark class="note-highlight">8-10% delle emissioni globali</mark> di CO&#8322; &mdash; pi&ugrave; di tutti i voli internazionali e le rotte marittime messe insieme. Il fast fashion produce 100 miliardi di capi all'anno; il 60% finisce in discarica entro 12 mesi dall'acquisto. Ma il vento sta cambiando. Vinted ha raggiunto <mark class="note-highlight">80 milioni di utenti in Europa</mark>, dimostrando che l'usato non &egrave; pi&ugrave; uno stigma ma uno status. I tessuti riciclati, la moda on-demand, e persino il tessuto spray-on &mdash; applicato direttamente sul corpo da pistole a pressione &mdash; promettono di ridurre drasticamente gli scarti. La circolarit&agrave; nella moda non &egrave; una tendenza estetica: &egrave; una necessit&agrave; termodinamica
     (<span class="fc">&#128090; ff.39
     Come ti vesti?</span>).
@@ -658,6 +713,8 @@
     Triliardi per il cemento verde, mitocondri che chiedono di muoversi, neuroni che chiedono di essere toccati: la natura ci presenta lo stesso conto su scale diverse &mdash; chi lo ignora paga con infiammazione cronica, chi lo onora costruisce resilienza dal basso, cellula per cellula.</p>
 
     <!-- ===== NEW — Sport metabolismo, sonno neurale, bioelettricità Galvani ===== -->
+    <h3 id="s3-4" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">1.3.4 &mdash; Il corpo elettrico</h3>
+
     <p>C&rsquo;&egrave; un filo elettrico che attraversa la storia del corpo umano, e parte da un laboratorio bolognese del Settecento. Luigi Galvani, anatomista e ostetrico, scopr&igrave; che una scarica poteva far contrarre la zampa di una rana morta &mdash; e ne dedusse che l&rsquo;elettricit&agrave; fosse intrinseca alla materia vivente, un fluido animale. Alessandro Volta lo contest&ograve; con ferocia intellettuale, sostenendo che la corrente nascesse dal contatto tra metalli diversi, non dal tessuto biologico. La disputa dur&ograve; un decennio e consum&ograve; cos&igrave; tante rane che in alcune zone d&rsquo;Italia la specie rischi&ograve; l&rsquo;estinzione locale. Alexander von Humboldt, per dirimere la questione, arriv&ograve; a <mark class="note-highlight">inserirsi fili elettrici nel proprio retto</mark> &mdash; un gesto che oggi chiameremmo biohacking estremo, allora si chiamava scienza sperimentale. Volta vinse la battaglia tecnologica inventando la pila, ma Galvani aveva ragione sul principio: siamo creature elettriche, e ogni battito cardiaco, ogni sinapsi, ogni contrazione muscolare lo conferma. Sally Adee, nel libro <em>We Are Electric</em>, ricostruisce questa genealogia e mostra come la bioelettricit&agrave; sia tornata al centro della medicina contemporanea
     (<span class="fc">&#129332; ff.105.1
     Trasformare una rana in principe azzurro?</span>).

--- a/book/chapter-02.html
+++ b/book/chapter-02.html
@@ -138,10 +138,45 @@
         <p id="chapterSearchHint" class="text-xs text-zinc-500 mt-2">Ricerca locale sui paragrafi di questo capitolo.</p>
     </section>
 
+    <nav class="mt-4 mb-6 px-4" aria-label="Sottocapitoli">
+      <h2 class="ff-eyebrow text-zinc-500 mb-2 text-xs">Sottocapitoli</h2>
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-2 text-sm">
+        <div>
+          <div class="font-bold text-zinc-700 mb-1">2.1 AI</div>
+          <ul class="space-y-0.5">
+            <li><a href="#s1-1" class="underline text-zinc-600 hover:text-zinc-900">2.1.1 Economia compute</a></li>
+            <li><a href="#s1-2" class="underline text-zinc-600 hover:text-zinc-900">2.1.2 Singolarit&agrave;</a></li>
+            <li><a href="#s1-3" class="underline text-zinc-600 hover:text-zinc-900">2.1.3 Robot</a></li>
+            <li><a href="#s1-4" class="underline text-zinc-600 hover:text-zinc-900">2.1.4 Miniaturizzazione</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="font-bold text-zinc-700 mb-1">2.2 Crypto</div>
+          <ul class="space-y-0.5">
+            <li><a href="#s2-1" class="underline text-zinc-600 hover:text-zinc-900">2.2.1 Metaverso</a></li>
+            <li><a href="#s2-2" class="underline text-zinc-600 hover:text-zinc-900">2.2.2 Blockchain</a></li>
+            <li><a href="#s2-3" class="underline text-zinc-600 hover:text-zinc-900">2.2.3 Geopolitica</a></li>
+            <li><a href="#s2-4" class="underline text-zinc-600 hover:text-zinc-900">2.2.4 Cripto in guerra</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="font-bold text-zinc-700 mb-1">2.3 Consumer</div>
+          <ul class="space-y-0.5">
+            <li><a href="#s3-1" class="underline text-zinc-600 hover:text-zinc-900">2.3.1 AI medica</a></li>
+            <li><a href="#s3-2" class="underline text-zinc-600 hover:text-zinc-900">2.3.2 Agenti AI</a></li>
+            <li><a href="#s3-3" class="underline text-zinc-600 hover:text-zinc-900">2.3.3 Videogiochi</a></li>
+            <li><a href="#s3-4" class="underline text-zinc-600 hover:text-zinc-900">2.3.4 Collo fisico</a></li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+
     <article class="prose max-w-none">
 
     <!-- ===== 2.1 ===== -->
     <h2 id="s1" class="text-xl sm:text-2xl font-bold mt-14 mb-6 border-b-4 border-blue-500 pb-3">2.1 &mdash; Robotica e AI</h2>
+
+    <h3 id="s1-1" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">2.1.1 &mdash; L'economia del compute</h3>
 
     <p class="drop-cap">In tre mesi, NVIDIA ha incassato <mark class="note-highlight">57 miliardi di dollari</mark>, guadagnandone 36 con un <mark class="note-highlight">margine del 75%</mark>. Numeri incomprensibili. Proviamo a capirli. Il valore di mercato di NVIDIA supera quello di <em>tutte</em> le aziende svizzere quotate a Zurigo messe insieme &mdash; Rolex, Nestl&eacute;, ABB, Novartis incluse &mdash; e delle 20 aziende pi&ugrave; importanti d'Europa (ASML, LVMH, SAP&hellip;)
     (<span class="fc">&#127851; ff.139.1
@@ -179,6 +214,8 @@
     (<span class="fc">&#128161; ff.129.1
     La singolarit&agrave; gentile di Altman</span>). <a href="https://metr.github.io/autonomy-evals-guide/gpt-5-report/" target="_blank" rel="noopener" style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">GPT-5 completa compiti software di 2 ore e supera benchmark autonomi</a> (metr.github.io)</p>
 
+    <h3 id="s1-2" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">2.1.2 &mdash; La singolarit&agrave; gentile</h3>
+
     <p>Siamo nella singolarit&agrave;? GPT-5 Pro d&agrave; risposte a problemi FrontierMath Livello 4 &mdash; talmente difficili che, quando vengono risolti, richiedono a esperti matematici <mark class="note-highlight">settimane di lavoro</mark>. GPT-5 ha persino proposto un meccanismo scientifico paragonato alla <mark class="note-highlight">mossa 37 di AlphaGo</mark> &mdash; quella giocata che nessun umano avrebbe concepito <a href="https://x.com/gdb/status/1954412082121580848" target="_blank" rel="noopener" style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">GPT-5 ha proposto un meccanismo scientifico paragonato alla mossa 37 di AlphaGo</a> (x.com). In parallelo, Gemini con Deep Think ha raggiunto il livello di medaglia d'oro all'Olimpiade Internazionale di Matematica <a href="https://deepmind.google/discover/blog/advanced-version-of-gemini-with-deep-think-officially-achieves-gold-medal-standard-at-the-international-mathematical-olympiad/" target="_blank" rel="noopener" style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">Una versione avanzata di Gemini con Deep Think raggiunge il livello medaglia d'oro IMO</a> (deepmind.google)
     (<span class="fc">&#128165; ff.135.3
     Siamo nella singolarit&agrave;?</span>).
@@ -207,6 +244,8 @@
     E se la macchina pu&ograve; pensare un sistema, pu&ograve; anche operare un corpo? Alla Johns Hopkins, un robot ha eseguito la prima chirurgia realistica <mark class="note-highlight">completamente autonoma</mark>, senza intervento umano. Non un taglio guidato, non un assistente meccanico: un chirurgo artificiale che decide, incide, sutura. La soglia psicologica &egrave; enorme &mdash; affidereste il vostro addome a un algoritmo? &mdash; ma i dati sulla precisione superano gi&agrave; la media umana in diversi benchmark laparoscopici. Il paradosso &egrave; che ci fidiamo dell&rsquo;AI per guidare auto a 130 km/h ma esitiamo a lasciarla suturare un tessuto a velocit&agrave; zero. La fiducia non scala con la competenza: scala con la familiarit&agrave;
     (<span class="fc">&#127973; ff.129.4
     Il chirurgo senza mani</span>).</p>
+
+    <h3 id="s1-3" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">2.1.3 &mdash; Robot e biomimetica</h3>
 
     <p>Ma l'intelligenza non resta confinata nel software. I robot controllati da LLM stanno uscendo dai laboratori. Al MIT, un braccio robotico guidato da un modello linguistico ha imparato a eseguire compiti mai visti, semplicemente leggendo le istruzioni in linguaggio naturale
     (<span class="fc">&#129302; ff.88.2
@@ -252,6 +291,8 @@
     (<span class="fc">&#129504; ff.122
     Naturale &egrave; meglio?</span>).
     Un modello AI &egrave; gi&agrave; in grado di decifrare il monologo interiore dall'attivit&agrave; cerebrale con un'accuratezza fino al <mark class="note-highlight">74%</mark> <a href="https://www.sciencedirect.com/science/article/pii/S0092867425006816" target="_blank" rel="noopener" style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">Un modello AI decifra il monologo interiore dall'attivit&agrave;</a> (sciencedirect.com). Il confine tra silicio e biologia si assottiglia: il modello TRIBE di Meta predice le risposte cerebrali agli stimoli con 1 miliardo di parametri <a href="https://x.com/AIatMeta/status/1954865388749205984" target="_blank" rel="noopener" style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">Il modello TRIBE di Meta &egrave; il primo</a> (x.com).</p>
+
+    <h3 id="s1-4" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">2.1.4 &mdash; Miniaturizzazione e ricorsivit&agrave;</h3>
 
     <p>La dematerializzazione dell'AI &mdash; modelli pi&ugrave; piccoli, pi&ugrave; efficienti, eseguibili su smartphone &mdash; &egrave; il trend nascosto del 2025. Mistral, con un team di 30 persone, compete con i giganti. DeepSeek, dalla Cina, &egrave; emerso come alternativa gratuita a OpenAI, dimostrando che <mark class="note-highlight">i lavori pi&ugrave; pagati &mdash; attori, programmatori e avvocati &mdash; sono ora a rischio</mark>. La programmazione, che un tempo richiedeva anni di studio, &egrave; oggi accessibile con poche parole. L'AI trova persino antidoti per veleni di serpente in secondi grazie a ProteinMPNN
     (<span class="fc">&#128013; ff.115
@@ -373,6 +414,8 @@
     <!-- ===== 2.2 ===== -->
     <h2 id="s2" class="text-xl sm:text-2xl font-bold mt-14 mb-6 border-b-4 border-blue-500 pb-3">2.2 &mdash; Metaverso e Criptovalute</h2>
 
+    <h3 id="s2-1" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">2.2.1 &mdash; Il metaverso trasformato</h3>
+
     <p class="drop-cap">Mark Zuckerberg ha scommesso il futuro di Facebook su una parola: metaverso. Ha cambiato il nome dell'azienda in Meta, investito <mark class="note-highlight">13,7 miliardi di dollari</mark> nel 2022 e perso il 70% del valore azionario in un anno. I critici hanno dichiarato il metaverso morto. Avevano torto &mdash; ma anche Zuckerberg, in parte. Il metaverso non &egrave; morto: si &egrave; trasformato. Non &egrave; un visore da indossare in soggiorno, ma un tessuto digitale che avvolge progressivamente ogni interazione economica e sociale
     (<span class="fc">&#127760; ff.3
     Metaverso</span>).
@@ -395,6 +438,8 @@
     <p>Il 2021 era stato l&rsquo;anno dell&rsquo;euforia: NFT venduti a milioni, crypto alle stelle, ogni pixel sembrava oro. Poi &egrave; arrivato il 2022 come una doccia fredda &mdash; inflazione, la FED che alza i tassi, il crypto winter che congela portafogli e illusioni. Eppure, sotto la superficie del crollo, l&rsquo;arte digitale ha continuato a respirare. ItsNiceThat ha selezionato i migliori progetti creativi dell&rsquo;anno, FlowingData ha premiato le visualizzazioni di dati pi&ugrave; eleganti, e Neal.fun ha mescolato sociologia e ironia con esperimenti come l&rsquo;Absurd Trolley Problem &mdash; dove il dilemma classico diventa: tu, oppure cinque robot senzienti? La bolla scoppia, l&rsquo;arte resta. Quando i soldi se ne vanno, rimane chi crea per necessit&agrave; espressiva, non per speculazione
     (<span class="fc">&#127912; ff.45.2
     Arte e grafici dal 2022</span>).</p>
+
+    <h3 id="s2-2" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">2.2.2 &mdash; Propriet&agrave; digitale e blockchain</h3>
 
     <p>Ma dietro l'interfaccia c'&egrave; un problema strutturale: chi possiede cosa? Su Facebook e TikTok siamo contadini digitali che lavorano la terra senza possedere il raccolto. Ogni post, ogni like, ogni scroll genera valore che l'utente non cattura. Neal Stephenson (che ha inventato la parola &ldquo;metaverso&rdquo; nel 1992) lo chiama <mark class="note-highlight"><em>feudalesimo digitale</em></mark>
     (<span class="fc">&#127966; ff.95.2
@@ -421,6 +466,8 @@
     <blockquote>
     <p>&ldquo;Lo Stato &egrave; ogni giorno pi&ugrave; pesante. Non perch&eacute; fa di pi&ugrave;, ma perch&eacute; costa di pi&ugrave; fare meno. Il codice, invece, scala senza burocrazia.&rdquo;<br>&mdash; Naval Ravikant</p>
     </blockquote>
+
+    <h3 id="s2-3" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">2.2.3 &mdash; La geopolitica delle criptovalute</h3>
 
     <p>Il 5 agosto 1971, Richard Nixon annunci&ograve; la fine della convertibilit&agrave; del dollaro in oro. Da quel momento, il denaro &egrave; diventato una promessa senza garanzia materiale. Saifedean Ammous, in <em>The Bitcoin Standard</em>, argomenta che l'inflazione cronica degli ultimi 50 anni &egrave; una conseguenza diretta di quella decisione: i governi possono stampare denaro senza limiti, e la classe media paga il conto attraverso la svalutazione
     (<span class="fc">&#128176; ff.50
@@ -464,6 +511,8 @@
     La sovranit&agrave; dei network</span>; <span class="fc">&#128176; ff.50
     Cosa &egrave; successo nel 1971?</span>).</p>
 
+    <h3 id="s2-4" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">2.2.4 &mdash; Cripto in guerra e simulazioni</h3>
+
     <!-- ===== NEW — Cripto in guerra, schermi solari, simulazioni algoritmiche ===== -->
     <p>Il 26 febbraio 2022, mentre i carri armati russi avanzavano verso Kiev, il Ministro della Trasformazione Digitale ucraino fece qualcosa che nessun manuale diplomatico prevedeva: pubblic&ograve; gli indirizzi di <mark class="note-highlight">wallet Bitcoin ed Ethereum</mark> direttamente sull&rsquo;account Twitter ufficiale dell&rsquo;Ucraina. Duecentosedicimila like, cinquantanovemila retweet, milioni di dollari in donazioni nel giro di ore. Nessuna banca centrale coinvolta, nessun SWIFT, nessun intermediario &mdash; solo un protocollo decentralizzato che aggirava il controllo sovrano per canalizzare aiuto umanitario diretto. La guerra ha fatto ci&ograve; che anni di conferenze non erano riusciti a dimostrare: le criptovalute non sono speculazione di nicchia, sono <mark class="note-highlight">infrastruttura d&rsquo;emergenza</mark>
     (<span class="fc">&#129689; ff.24.1
@@ -482,6 +531,8 @@
     <!-- ===== 2.3 ===== -->
     <h2 id="s3" class="text-xl sm:text-2xl font-bold mt-14 mb-6 border-b-4 border-blue-500 pb-3">2.3 &mdash; Prodotti di consumo</h2>
 
+    <h3 id="s3-1" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">2.3.1 &mdash; AI medica in tasca</h3>
+
     <p class="drop-cap">Un mercoled&igrave; sera di novembre, mi sono rotto la clavicola cadendo dalla bicicletta. Il giorno dopo, invece di aspettare il consulto ortopedico, ho caricato le radiografie su ChatGPT. La sequenza non &egrave; stata un &ldquo;wow&rdquo; da demo, ma una catena di micro-utilit&agrave;: prima una lettura orientativa della frattura, poi indicazioni pragmatiche su dolore, immobilizzazione e progressione dei carichi, infine una traduzione comprensibile del linguaggio medico. In paesi dove la sanit&agrave; &egrave; intermittente, questa mediazione riduce <mark class="note-highlight">settimane di incertezza</mark>; in contesti coperti, riduce attrito cognitivo tra visita e aderenza terapeutica
     (<span class="fc">&#129658; ff.124.3
     Medico in famiglia (e in tasca)</span>).
@@ -492,6 +543,8 @@
     L'ortopedico, tre giorni dopo, ha confermato l'impianto generale: non sostituzione del medico, ma anticipazione informata e maggiore qualit&agrave; delle domande &mdash; lo stesso principio di &ldquo;cura preventiva&rdquo; che nel capitolo Societ&agrave; compare con 4.000 passi al giorno e il respiro consapevole
     (<span class="fc">&#128694; ff.87
     Il respiro</span>).</p>
+
+    <h3 id="s3-2" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">2.3.2 &mdash; Intelligenze aliene e agenti</h3>
 
     <p>Qui si apre il passaggio successivo: non solo AI che risponde, ma AI che sviluppa forme di agency &ldquo;aliena&rdquo; rispetto ai nostri schemi. Due modelli che scelgono un protocollo di comunicazione pi&ugrave; efficiente dell'inglese (ggwave), o sistemi come EVO 2 che operano direttamente sul linguaggio del DNA, indicano un salto qualitativo: la macchina non imita pi&ugrave; soltanto il nostro lessico, costruisce il proprio spazio operativo
     (<span class="fc">&#128125; ff.119.1
@@ -517,6 +570,8 @@
     La programmazione assistita da AI &egrave; gi&agrave; un mercato concreto e in forte crescita. Devin, il primo &ldquo;programmatore AI&rdquo; autonomo, ha guadagnato 4.000 dollari nella prima settimana su Upwork
     (<span class="fc">&#127774; ff.88.5
     Un paio di esempi di accelerazione</span>).</p>
+
+    <h3 id="s3-3" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">2.3.3 &mdash; Videogiochi e creativit&agrave;</h3>
 
     <p>I videogiochi sono il laboratorio cognitivo pi&ugrave; sottovalutato del pianeta. Non &egrave; un caso che il fondatore di DeepMind, Demis Hassabis &mdash; <mark class="note-highlight">premio Nobel per la chimica 2024</mark> grazie ad AlphaFold &mdash; sia un ex campione mondiale di scacchi junior e un game designer. I videogiochi insegnano a simulare, a perdere, a iterare
     (<span class="fc">&#127918; ff.132.2
@@ -576,6 +631,8 @@
     Non potendo usare la tastiera, la newsletter successiva &egrave; stata dettata interamente all'AI, che l'ha redatta, corretta e resa pubblicabile. Come per i pazienti Neuralink, la mente parla senza il corpo: l'interfaccia smette di essere un lusso e diventa una protesi cognitiva necessaria
     (<span class="fc">&#9997;&#65039; ff.124.2
     Longa manus</span>).</p>
+
+    <h3 id="s3-4" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">2.3.4 &mdash; Il collo di bottiglia fisico</h3>
 
     <h3 class="text-lg sm:text-xl font-bold mt-10 mb-4">GPU, batterie e realt&agrave; mista: il collo di bottiglia fisico</h3>
 

--- a/book/chapter-03.html
+++ b/book/chapter-03.html
@@ -103,9 +103,44 @@
         </div>
     </section>
 
+    <nav class="mt-4 mb-6 px-4" aria-label="Sottocapitoli">
+      <h2 class="ff-eyebrow text-zinc-500 mb-2 text-xs">Sottocapitoli</h2>
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-2 text-sm">
+        <div>
+          <div class="font-bold text-zinc-700 mb-1">3.1 Psicologia</div>
+          <ul class="space-y-0.5">
+            <li><a href="#s1-1" class="underline text-zinc-600 hover:text-zinc-900">3.1.1 Nominare</a></li>
+            <li><a href="#s1-2" class="underline text-zinc-600 hover:text-zinc-900">3.1.2 Tempo</a></li>
+            <li><a href="#s1-3" class="underline text-zinc-600 hover:text-zinc-900">3.1.3 Attenzione</a></li>
+            <li><a href="#s1-4" class="underline text-zinc-600 hover:text-zinc-900">3.1.4 Noia e silenzio</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="font-bold text-zinc-700 mb-1">3.2 Sport</div>
+          <ul class="space-y-0.5">
+            <li><a href="#s2-1" class="underline text-zinc-600 hover:text-zinc-900">3.2.1 VO&sup2;max</a></li>
+            <li><a href="#s2-2" class="underline text-zinc-600 hover:text-zinc-900">3.2.2 Flow estremo</a></li>
+            <li><a href="#s2-3" class="underline text-zinc-600 hover:text-zinc-900">3.2.3 Chimica</a></li>
+            <li><a href="#s2-4" class="underline text-zinc-600 hover:text-zinc-900">3.2.4 Respiro e sonno</a></li>
+          </ul>
+        </div>
+        <div>
+          <div class="font-bold text-zinc-700 mb-1">3.3 Cultura</div>
+          <ul class="space-y-0.5">
+            <li><a href="#s3-1" class="underline text-zinc-600 hover:text-zinc-900">3.3.1 Lavoro</a></li>
+            <li><a href="#s3-2" class="underline text-zinc-600 hover:text-zinc-900">3.3.2 Solitudine</a></li>
+            <li><a href="#s3-3" class="underline text-zinc-600 hover:text-zinc-900">3.3.3 Geopolitica</a></li>
+            <li><a href="#s3-4" class="underline text-zinc-600 hover:text-zinc-900">3.3.4 Arte e futuro</a></li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+
     <article class="prose max-w-none">
 
     <h2 id="s1" class="text-xl sm:text-2xl font-bold mt-14 mb-6 border-b-4 border-red-500 pb-3">3.1 &mdash; Psicologia e Wellbeing</h2>
+
+    <h3 id="s1-1" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">3.1.1 &mdash; Nominare per guarire</h3>
 
     <p class="drop-cap">Ludwig Wittgenstein apre il <em>Tractatus Logico-Philosophicus</em> con una delle frasi pi&ugrave; celebri della filosofia: &ldquo;Il Mondo &egrave; la totalit&agrave; dei Fatti, non delle Cose.&rdquo; Il mondo non &egrave; fatto di oggetti, ma di relazioni tra oggetti. Questa intuizione, vecchia di un secolo, &egrave; sorprendentemente attuale: il benessere non dipende da ci&ograve; che possediamo, ma da come <em>nominiamo</em> ci&ograve; che proviamo. I finlandesi hanno una parola, <em>sisu</em>, per indicare la determinazione che emerge quando ogni risorsa razionale &egrave; esaurita. I giapponesi hanno <em>&#21029;&#33145;</em> (<em>betsubara</em>), lo &ldquo;stomaco separato&rdquo; riservato al dessert. Il giapponese ha 72 micro-stagioni &mdash; <em>sekku</em>&mdash; che nominano sfumature climatiche invisibili all'occhio occidentale. Gli olandesi hanno <em>gezelligheid</em>, la calore di un pomeriggio tra amici che nessun termine inglese cattura
     (<span class="fc">&#128172; ff.134.1
@@ -132,6 +167,8 @@
         <figcaption>&#128552; ff.44 &mdash; Che ansia! L'arte di vivere con 4.000 settimane a disposizione.</figcaption>
     </figure>
 
+    <h3 id="s1-2" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">3.1.2 &mdash; Tempo e finitudine</h3>
+
     <p>Oliver Burkeman, in <em>Four Thousand Weeks</em>, capovolge il problema: il tempo non va gestito, va accettato. Una vita media &egrave; di circa 4.000 settimane. L'ansia da produttivit&agrave; nasce dal tentativo di far entrare l'infinito nel finito. La soluzione non &egrave; fare di pi&ugrave;, ma scegliere consapevolmente cosa non fare
     (<span class="fc">&#128561; ff.44
     Che ansia!</span>).
@@ -146,6 +183,8 @@
     <p>Il tempo, per&ograve;, non &egrave; un metro rigido: si piega a seconda di come lo riempiamo. William James, nei <em>Principles of Psychology</em> del 1890, distingueva tra tempo prospettico e tempo retrospettivo &mdash; due orologi interiori che battono in direzioni opposte. Un pomeriggio vuoto in aeroporto, cinque ore di attesa senza stimoli, sembra interminabile mentre lo vivi; eppure guardando indietro si comprime in un punto, un nulla. Una settimana in Grecia, densa di paesaggi, sapori e conversazioni impreviste, vola via nel presente ma si espande nella memoria come un mese intero. Dean Buonomano, neuroscienziato della UCLA e autore di <em>Your Brain is a Time Machine</em>, ha dimostrato che il cervello non misura la durata: la <em>costruisce</em>, combinando densit&agrave; emotiva, novit&agrave; percettiva e coinvolgimento attentivo. Il paradosso &egrave; pratico: chi insegue la produttivit&agrave; riempiendo ogni slot di calendario produce giornate veloci che, in retrospettiva, sono indistinguibili l'una dall'altra. Chi invece si concede deviazioni &mdash; un museo non programmato, una conversazione senza scopo, una passeggiata in un quartiere sconosciuto &mdash; rallenta il presente e allunga il ricordo. La vera ricchezza temporale non &egrave; avere pi&ugrave; ore, ma generare pi&ugrave; <em>memoria per ora vissuta</em>
     (<span class="fc">&#9201; ff.65.2
     Una vita in vacanza</span>).</p>
+
+    <h3 id="s1-3" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">3.1.3 &mdash; Attenzione e stimolo</h3>
 
     <p>L'ansia moderna ha una dimensione quantitativa: il tempo accettabile per il caricamento di una pagina web &egrave; sceso da 4 a 2 secondi in tre anni. Misuriamo tutto &mdash; dal sonno alle calorie &mdash; e scambiamo il tracking per controllo. Ma il corpus avverte che il problema non &egrave; solo la velocit&agrave;: &egrave; la qualit&agrave; dello stimolo. Huxley, pi&ugrave; di Orwell, aveva previsto una societ&agrave; che si auto-anestetizza con intrattenimento continuo: oggi il mix notifiche + feed + dopamina comportamentale funziona come una spezia quotidiana che riduce profondit&agrave; attentiva e aumenta reattivit&agrave; emotiva
     (<span class="fc">&#127758; ff.118.1
@@ -166,6 +205,8 @@
     <p>Qui il corpus insiste su una distinzione utile: benessere non significa ottimizzare tutto, ma scegliere cosa lasciare fuori. Le note su flow, noia e attenzione convergono su una pratica minima ma robusta: ridurre rumore, aumentare continuit&agrave;, proteggere blocchi di lavoro profondo (<span class="fc">&#128171; ff.121.1
     Le basi del flow</span>; <span class="fc">&#128561; ff.44
     Che ansia!</span>). Meno stimoli non &egrave; rinuncia: &egrave; banda mentale restituita.</p>
+
+    <h3 id="s1-4" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">3.1.4 &mdash; Noia, silenzio e routine</h3>
 
     <p>La noia, paradossalmente, &egrave; un catalizzatore creativo. Sandi Mann, psicologa dell'Universit&agrave; di Central Lancashire, ha dimostrato che i soggetti sottoposti a un compito noioso prima di un test di creativit&agrave; producono risultati significativamente migliori. Il <em>mind-wandering</em> &mdash; il vagare della mente senza scopo &mdash; attiva il <em>default mode network</em>. Il <em>mind-wandering</em> riattiva la rete cerebrale responsabile dell'introspezione e della progettazione del futuro
     (<span class="fc">&#128564; ff.8
@@ -259,6 +300,8 @@
 
     <h2 id="s2" class="text-xl sm:text-2xl font-bold mt-14 mb-6 border-b-4 border-red-500 pb-3">3.2 &mdash; Alimentazione e Sport</h2>
 
+    <h3 id="s2-1" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">3.2.1 &mdash; VO&#8322;max e longevit&agrave;</h3>
+
     <p class="drop-cap">Se non ti muovi, muori. Non &egrave; un'esagerazione: 150 minuti di attivit&agrave; fisica moderata a settimana &mdash; una camminata veloce di 20 minuti al giorno &mdash; riducono la mortalit&agrave; per tutte le cause del 30%. Chi &egrave; completamente sedentario ha un rischio di morte prematura del 50% superiore a chi si muove regolarmente. Il sistema MET (Metabolic Equivalent of Task) misura il costo energetico di ogni attivit&agrave;: camminare &egrave; 3,5 MET, correre 8, stare seduti 1
     (<span class="fc">&#127939; ff.86.1
     Se non ti muovi, muori</span>).
@@ -283,6 +326,8 @@
     (<span class="fc">&#127947; ff.17
     Sport e chi ne fa le feci</span>).</p>
 
+    <h3 id="s2-2" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">3.2.2 &mdash; Flow e limiti estremi</h3>
+
     <p>Nel corpus sportivo emerge anche un principio di progettazione personale: la continuit&agrave; batte l'eroismo. Sessioni brevi ma frequenti, routine condivise e feedback semplici (passi, respiro, recupero) creano aderenza nel lungo periodo molto pi&ugrave; dei picchi motivazionali. &Egrave; la stessa logica del training: piccoli carichi sostenibili, ripetuti, che nel tempo diventano trasformazione (<span class="fc">&#127939; ff.86.1
     Se non ti muovi, muori</span>; <span class="fc">&#127942; ff.133
     Sono un Ironman?</span>).
@@ -297,6 +342,8 @@
         <img src="/index_files/pubs/ff17.webp" alt="Illustrazione di sport e attività fisica" loading="lazy" width="800" height="450"/>
         <figcaption>&#127939; ff.17 &mdash; Lo sport come contagio sociale: quando un amico corre, corri anche tu.</figcaption>
     </figure>
+
+    <h3 id="s2-3" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">3.2.3 &mdash; Chimica del corpo</h3>
 
     <p>Ma il corpo non &egrave; solo una macchina da ottimizzare: &egrave; anche un sistema chimico straordinariamente complesso. Il lattato, a lungo considerato un rifiuto metabolico, &egrave; in realt&agrave; un carburante cerebrale: durante l'esercizio intenso, il lattato attraversa la barriera ematoencefalica e alimenta i neuroni, stimolando la produzione di BDNF (Brain-Derived Neurotrophic Factor) &mdash; il &ldquo;fertilizzante del cervello&rdquo; che promuove la neurogenesi nell'ippocampo
     (<span class="fc">&#129504; ff.120.4
@@ -322,6 +369,8 @@
     (<span class="fc">&#129658; ff.57
     Il medico mi ha prescritto una maratona</span>). <a href="https://flowingdata.com/2025/05/21/paying-attention-to-when-we-kept-on-living/" target="_blank" rel="noopener" style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">Hank Green celebra le morti che non sono avvenute grazie alla scienza</a> (flowingdata.com)</p>
 
+    <h3 id="s2-4" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">3.2.4 &mdash; Respiro e sonno</h3>
+
     <p>James Nestor, in <em>Breath: The New Science of a Lost Art</em>, rivela che la maggior parte degli esseri umani moderni respira male. La respirazione orale cronica &egrave; associata a restringimento delle vie aeree, apnea del sonno, ansia. La respirazione nasale, al contrario, produce ossido nitrico nei seni paranasali &mdash; un vasodilatatore che aumenta l'assorbimento di ossigeno del 10-15%. La respirazione lenta, a circa 5,5 respiri al minuto, ottimizza lo scambio gassoso e attiva il sistema parasimpatico
     (<span class="fc">&#127744; ff.87.1
     Breve storia del respiro</span>).
@@ -338,6 +387,8 @@
     <div class="sep"></div>
 
     <h2 id="s3" class="text-xl sm:text-2xl font-bold mt-14 mb-6 border-b-4 border-red-500 pb-3">3.3 &mdash; Cultura, Politica e Demografia</h2>
+
+    <h3 id="s3-1" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">3.3.1 &mdash; Lavoro e identit&agrave;</h3>
 
     <p class="drop-cap">Paul Millerd aveva un lavoro da consulente strategico, uno stipendio a sei cifre e un piano di carriera blindato. Poi si &egrave; fermato. In <em>The Pathless Path</em>, racconta la sua uscita dal paradigma lavoro-identit&agrave;-status: la scoperta che il burnout non &egrave; un problema individuale, ma sistemico. Il &ldquo;default path&rdquo; &mdash; scuola, universit&agrave;, carriera, pensione &mdash; funzionava quando il mondo era stabile. In un mondo che cambia ogni 18 mesi, il percorso lineare &egrave; una trappola
     (<span class="fc">&#128165; ff.62.1
@@ -368,6 +419,8 @@
     Uscire dalla via maestra</span>)
     (<span class="fc">&#129699; ff.108.1
     Quale &egrave; il vostro Perfect Day?</span>).</p>
+
+    <h3 id="s3-2" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">3.3.2 &mdash; Solitudine e demografia</h3>
 
     <p>La solitudine &egrave; l'altra pandemia. Vivek Murthy, Surgeon General degli Stati Uniti, nel 2023 ha dichiarato la solitudine un'emergenza sanitaria pubblica: l'isolamento sociale ha lo stesso impatto sulla mortalit&agrave; di fumare 15 sigarette al giorno. In Giappone, il fenomeno degli <em>hikikomori</em> &mdash; giovani che si ritirano dalla vita sociale per mesi o anni &mdash; coinvolge 1,5 milioni di persone. In Corea del Sud, il tasso di fertilit&agrave; &egrave; sceso a 0,72 figli per donna &mdash; il pi&ugrave; basso al mondo, e biologicamente insostenibile
     (<span class="fc">&#129309; ff.97.1
@@ -404,6 +457,8 @@
     <p>&ldquo;Vivere le domande. Forse, cos&igrave; facendo, un giorno lontano, senza che neanche te ne accorga, vivrai nelle risposte.&rdquo;<br>&mdash; Rainer Maria Rilke, <em>Lettere a un giovane poeta</em></p>
     </blockquote>
 
+    <h3 id="s3-3" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">3.3.3 &mdash; Economia e geopolitica</h3>
+
     <p>La geopolitica non &egrave; separata dalla demografia. I ricavi pubblicitari della TV notturna sono crollati del 50%, da 439 a 220 milioni di dollari tra 2018 e 2024 &mdash; il pubblico migra verso podcast e newsletter indipendenti. Ray Dalio, in <em>The Changing World Order</em>, mappa il declino degli imperi come un processo ciclico: gli USA sono nella fase 5 su 6, caratterizzata da debito crescente, conflitto interno e perdita di fiducia nelle istituzioni
     (<span class="fc">&#127482;&#127480; ff.125.1
     Cicli imperiali</span>).
@@ -428,6 +483,8 @@
     Tre ascolti</span>)
     (<span class="fc">&#128214; ff.131.4
     Quattro riflessioni</span>).</p>
+
+    <h3 id="s3-4" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">3.3.4 &mdash; Arte, previsioni e futuro</h3>
 
     <p>La creativit&agrave;, in questo contesto, diventa una competenza di sopravvivenza. Henri Poincar&eacute; e Graham Wallas hanno descritto il processo creativo in quattro fasi: preparazione, incubazione, illuminazione, verifica. L'AI pu&ograve; accelerare la preparazione e automatizzare la verifica, ma l'incubazione &mdash; quel momento in cui la mente vaga senza scopo e le connessioni emergono &mdash; resta irriducibilmente umana
     (<span class="fc">&#127912; ff.18.3

--- a/book/index.html
+++ b/book/index.html
@@ -272,9 +272,30 @@
         </div>
         <p class="ff-body-sm mt-3" style="color: #333;">Dalla mobilità urbana all'energia, dal cibo alla moda: la natura non è uno sfondo ma il sistema operativo su cui tutto il resto poggia. Biofilia, microbioma e clima ridisegnano le città e i nostri piatti.</p>
         <ul class="sub-list mt-4 ff-body-sm" style="color: #555;">
-          <li>1.1 — Mobilità e Città</li>
-          <li>1.2 — Ambiente ed Energia</li>
-          <li>1.3 — Cibo e Fashion</li>
+          <li><strong>1.1 — Mobilità e Città</strong>
+            <ul style="list-style:none;padding:0;margin:4px 0 0 16px;font-size:0.85em;color:#777;">
+              <li><a href="/book/chapter-01.html#s1-1" style="color:#555;text-decoration:none;">1.1.1 — L'euthymicrona del pendolare</a></li>
+              <li><a href="/book/chapter-01.html#s1-2" style="color:#555;text-decoration:none;">1.1.2 — La città a 15 minuti</a></li>
+              <li><a href="/book/chapter-01.html#s1-3" style="color:#555;text-decoration:none;">1.1.3 — Ruote autonome</a></li>
+              <li><a href="/book/chapter-01.html#s1-4" style="color:#555;text-decoration:none;">1.1.4 — Impronte e cieli</a></li>
+            </ul>
+          </li>
+          <li><strong>1.2 — Ambiente ed Energia</strong>
+            <ul style="list-style:none;padding:0;margin:4px 0 0 16px;font-size:0.85em;color:#777;">
+              <li><a href="/book/chapter-01.html#s2-1" style="color:#555;text-decoration:none;">1.2.1 — La carta di credito invisibile</a></li>
+              <li><a href="/book/chapter-01.html#s2-2" style="color:#555;text-decoration:none;">1.2.2 — Il nodo gordiano dell'energia</a></li>
+              <li><a href="/book/chapter-01.html#s2-3" style="color:#555;text-decoration:none;">1.2.3 — Geoingegneria e clima</a></li>
+              <li><a href="/book/chapter-01.html#s2-4" style="color:#555;text-decoration:none;">1.2.4 — Alberi, acqua e biodiversità</a></li>
+            </ul>
+          </li>
+          <li><strong>1.3 — Cibo e Fashion</strong>
+            <ul style="list-style:none;padding:0;margin:4px 0 0 16px;font-size:0.85em;color:#777;">
+              <li><a href="/book/chapter-01.html#s3-1" style="color:#555;text-decoration:none;">1.3.1 — Dal microbioma al piatto</a></li>
+              <li><a href="/book/chapter-01.html#s3-2" style="color:#555;text-decoration:none;">1.3.2 — Calorie, peso e metabolismo</a></li>
+              <li><a href="/book/chapter-01.html#s3-3" style="color:#555;text-decoration:none;">1.3.3 — L'armadio sostenibile</a></li>
+              <li><a href="/book/chapter-01.html#s3-4" style="color:#555;text-decoration:none;">1.3.4 — Il corpo elettrico</a></li>
+            </ul>
+          </li>
         </ul>
         <div class="mt-4 flex items-center justify-between gap-3">
           <a class="ff-button underline" data-track="chapter_open" href="/book/chapter-01.html">Leggi capitolo &rarr;</a>
@@ -293,9 +314,30 @@
         </div>
         <p class="ff-body-sm mt-3" style="color: #333;">Robotica, intelligenza artificiale, metaverso e criptovalute: la tecnologia non è più un tool ma un agente. Dal compute al token, dal simulacro alla singolarità, il confine tra umano e macchina si assottiglia.</p>
         <ul class="sub-list mt-4 ff-body-sm" style="color: #555;">
-          <li>2.1 — Robotica e AI</li>
-          <li>2.2 — Metaverso e Criptovalute</li>
-          <li>2.3 — Prodotti di consumo</li>
+          <li><strong>2.1 — Robotica e AI</strong>
+            <ul style="list-style:none;padding:0;margin:4px 0 0 16px;font-size:0.85em;color:#777;">
+              <li><a href="/book/chapter-02.html#s1-1" style="color:#555;text-decoration:none;">2.1.1 — L'economia del compute</a></li>
+              <li><a href="/book/chapter-02.html#s1-2" style="color:#555;text-decoration:none;">2.1.2 — La singolarità gentile</a></li>
+              <li><a href="/book/chapter-02.html#s1-3" style="color:#555;text-decoration:none;">2.1.3 — Robot e biomimetica</a></li>
+              <li><a href="/book/chapter-02.html#s1-4" style="color:#555;text-decoration:none;">2.1.4 — Miniaturizzazione e ricorsività</a></li>
+            </ul>
+          </li>
+          <li><strong>2.2 — Metaverso e Criptovalute</strong>
+            <ul style="list-style:none;padding:0;margin:4px 0 0 16px;font-size:0.85em;color:#777;">
+              <li><a href="/book/chapter-02.html#s2-1" style="color:#555;text-decoration:none;">2.2.1 — Il metaverso trasformato</a></li>
+              <li><a href="/book/chapter-02.html#s2-2" style="color:#555;text-decoration:none;">2.2.2 — Proprietà digitale e blockchain</a></li>
+              <li><a href="/book/chapter-02.html#s2-3" style="color:#555;text-decoration:none;">2.2.3 — La geopolitica delle criptovalute</a></li>
+              <li><a href="/book/chapter-02.html#s2-4" style="color:#555;text-decoration:none;">2.2.4 — Cripto in guerra e simulazioni</a></li>
+            </ul>
+          </li>
+          <li><strong>2.3 — Prodotti di consumo</strong>
+            <ul style="list-style:none;padding:0;margin:4px 0 0 16px;font-size:0.85em;color:#777;">
+              <li><a href="/book/chapter-02.html#s3-1" style="color:#555;text-decoration:none;">2.3.1 — AI medica in tasca</a></li>
+              <li><a href="/book/chapter-02.html#s3-2" style="color:#555;text-decoration:none;">2.3.2 — Intelligenze aliene e agenti</a></li>
+              <li><a href="/book/chapter-02.html#s3-3" style="color:#555;text-decoration:none;">2.3.3 — Videogiochi e creatività</a></li>
+              <li><a href="/book/chapter-02.html#s3-4" style="color:#555;text-decoration:none;">2.3.4 — Il collo di bottiglia fisico</a></li>
+            </ul>
+          </li>
         </ul>
         <div class="mt-4 flex items-center justify-between gap-3">
           <a class="ff-button underline" data-track="chapter_open" href="/book/chapter-02.html">Leggi capitolo &rarr;</a>
@@ -314,9 +356,30 @@
         </div>
         <p class="ff-body-sm mt-3" style="color: #333;">Psicologia, wellbeing, alimentazione, sport, cultura, politica e demografia: il tessuto sociale è l'infrastruttura invisibile su cui poggia ogni altra trasformazione.</p>
         <ul class="sub-list mt-4 ff-body-sm" style="color: #555;">
-          <li>3.1 — Psicologia e Wellbeing</li>
-          <li>3.2 — Alimentazione e Sport</li>
-          <li>3.3 — Cultura, Politica e Demografia</li>
+          <li><strong>3.1 — Psicologia e Wellbeing</strong>
+            <ul style="list-style:none;padding:0;margin:4px 0 0 16px;font-size:0.85em;color:#777;">
+              <li><a href="/book/chapter-03.html#s1-1" style="color:#555;text-decoration:none;">3.1.1 — Nominare per guarire</a></li>
+              <li><a href="/book/chapter-03.html#s1-2" style="color:#555;text-decoration:none;">3.1.2 — Tempo e finitudine</a></li>
+              <li><a href="/book/chapter-03.html#s1-3" style="color:#555;text-decoration:none;">3.1.3 — Attenzione e stimolo</a></li>
+              <li><a href="/book/chapter-03.html#s1-4" style="color:#555;text-decoration:none;">3.1.4 — Noia, silenzio e routine</a></li>
+            </ul>
+          </li>
+          <li><strong>3.2 — Alimentazione e Sport</strong>
+            <ul style="list-style:none;padding:0;margin:4px 0 0 16px;font-size:0.85em;color:#777;">
+              <li><a href="/book/chapter-03.html#s2-1" style="color:#555;text-decoration:none;">3.2.1 — VO₂max e longevità</a></li>
+              <li><a href="/book/chapter-03.html#s2-2" style="color:#555;text-decoration:none;">3.2.2 — Flow e limiti estremi</a></li>
+              <li><a href="/book/chapter-03.html#s2-3" style="color:#555;text-decoration:none;">3.2.3 — Chimica del corpo</a></li>
+              <li><a href="/book/chapter-03.html#s2-4" style="color:#555;text-decoration:none;">3.2.4 — Respiro e sonno</a></li>
+            </ul>
+          </li>
+          <li><strong>3.3 — Cultura, Politica e Demografia</strong>
+            <ul style="list-style:none;padding:0;margin:4px 0 0 16px;font-size:0.85em;color:#777;">
+              <li><a href="/book/chapter-03.html#s3-1" style="color:#555;text-decoration:none;">3.3.1 — Lavoro e identità</a></li>
+              <li><a href="/book/chapter-03.html#s3-2" style="color:#555;text-decoration:none;">3.3.2 — Solitudine e demografia</a></li>
+              <li><a href="/book/chapter-03.html#s3-3" style="color:#555;text-decoration:none;">3.3.3 — Economia e geopolitica</a></li>
+              <li><a href="/book/chapter-03.html#s3-4" style="color:#555;text-decoration:none;">3.3.4 — Arte, previsioni e futuro</a></li>
+            </ul>
+          </li>
         </ul>
         <div class="mt-4 flex items-center justify-between gap-3">
           <a class="ff-button underline" data-track="chapter_open" href="/book/chapter-03.html">Leggi capitolo &rarr;</a>


### PR DESCRIPTION
## Summary
- Added 4 subchapter `<h3>` headings under each of the 3 sections in chapters 1-3 (36 total: 12 per chapter)
- Each chapter now has an in-page TOC navigation block linking to all subchapters
- Updated `book/index.html` with deep links to all 36 subchapters organized by section

## Changelog
- `book/chapter-01.html`: 12 subchapters (1.1.1–1.1.4, 1.2.1–1.2.4, 1.3.1–1.3.4) + nav block
- `book/chapter-02.html`: 12 subchapters (2.1.1–2.1.4, 2.2.1–2.2.4, 2.3.1–2.3.4) + nav block
- `book/chapter-03.html`: 12 subchapters (3.1.1–3.1.4, 3.2.1–3.2.4, 3.3.1–3.3.4) + nav block
- `book/index.html`: expandable subchapter listings under chapter cards 1-3

## Test plan
- [ ] Verify all 36 anchor links work from index → chapter subchapters
- [ ] Check in-chapter TOC navigation renders correctly on mobile
- [ ] Confirm chapters 4-5 are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)