### PR TITLE
fix: smart quotes in data.js causing blank page

### DIFF
--- a/data.js
+++ b/data.js
@@ -5230,7 +5230,7 @@ export const rawData = [
                         "url": "https://fortissimo.substack.com/i/137533647/ff-la-famiglia-tradizionale-e-passato"
                     },
                     {
-                        “text”: “👨‍👩‍👧 ff.77.1 La \”famiglia tradizionale\” è passato?”,
+                        "text": "👨‍👩‍👧 ff.77.1 La \"famiglia tradizionale\" è passato?",
                         "url": "https://fortissimo.substack.com/i/137533647/ff-la-famiglia-tradizionale-e-passato"
                     },
                     {


### PR DESCRIPTION
## Summary
- Line 5233 of `data.js` had Unicode curly quotes (U+201C/U+201D) used as JS string delimiters instead of regular ASCII double quotes
- This caused a `SyntaxError` when the browser parsed `data.js` as an ES module, preventing React from mounting
- Result: blank page with only the static language switcher (IT/EN/HI) visible
- Introduced in commit `abec0b0` (PhD revision)

## Fix
Single character replacement on one line — 6 smart quotes → 6 regular ASCII double quotes.

## Test plan
- [x] `node --input-type=module` successfully imports `data.js` (148 entries loaded)
- [ ] Verify futurofortissimo.github.io renders content after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)