### PR TITLE
Fix emojis, font, toggle content, cover images

### DIFF
--- a/book/chapter-01.html
+++ b/book/chapter-01.html
@@ -44,7 +44,7 @@
         .chapter-num{font-family:'Press Start 2P',monospace;font-size:clamp(0.45rem,1vw,0.55rem);letter-spacing:0.3em}
         .drop-cap::first-letter{font-family:'IBM Plex Mono',monospace;font-size:clamp(2.8em,5vw,3.4em);float:left;line-height:0.8;padding-right:10px;padding-top:4px;font-weight:700;color:var(--accent)}
         .prose p{margin-bottom:1.2em;font-size:clamp(1rem,2.5vw,1.05rem);line-height:1.75;max-width:72ch}
-        .prose .fc{font-family:'IBM Plex Mono',monospace;font-size:0.8rem;font-weight:700;color:var(--accent);cursor:pointer;text-decoration:none;transition:color 0.15s;display:inline}
+        .prose .fc{font-family:'Inter',sans-serif;font-size:0.92rem;font-weight:600;color:var(--accent);cursor:pointer;text-decoration:none;transition:color 0.15s;display:inline}
         .prose .fc:hover{text-decoration:underline}
         .toc-link{border-left:3px solid transparent;transition:all 0.2s;min-height:44px;display:flex;align-items:center}.toc-link:hover,.toc-link:focus{border-left-color:var(--accent);padding-left:12px}
         blockquote{border-left:4px solid var(--accent);padding:12px 20px;margin:1.5em 0;background:#f0fdf4;font-style:italic}
@@ -191,10 +191,8 @@
     </blockquote>
 
     <figure style="margin:1.5rem auto;max-width:180px;text-align:center;">
-      <a href="https://amzn.to/4ouHFKs" target="_blank" rel="noopener">
-        <img src="https://covers.openlibrary.org/b/isbn/9781788169363/M.jpg" alt="Copertina: La natura che cura &mdash; Kathy Willis"
-             style="width:100%;box-shadow:2px 4px 12px rgba(0,0,0,0.15);"/>
-      </a>
+      <a href="https://amzn.to/4ouHFKs" target="_blank" rel="noopener"
+         style="display:block;width:100%;height:80px;background:linear-gradient(135deg,#e8f5e9,#c8e6c9);border-radius:6px;box-shadow:2px 4px 12px rgba(0,0,0,0.10);display:flex;align-items:center;justify-content:center;font-size:2rem;">&#128218;</a>
       <figcaption style="margin-top:0.5rem;font-size:0.8rem;">
         <a href="https://amzn.to/4ouHFKs" target="_blank" rel="noopener"
            style="color:var(--accent);text-decoration:none;font-weight:600;">
@@ -324,10 +322,8 @@
     Tutto scorre anche Skyrim</span>).</p>
 
     <figure style="margin:1.5rem auto;max-width:180px;text-align:center;">
-      <a href="https://amzn.to/3XnTRP1" target="_blank" rel="noopener">
-        <img src="https://covers.openlibrary.org/b/isbn/9788806234980/M.jpg" alt="Copertina: Le otto montagne &mdash; Paolo Cognetti"
-             style="width:100%;box-shadow:2px 4px 12px rgba(0,0,0,0.15);"/>
-      </a>
+      <a href="https://amzn.to/3XnTRP1" target="_blank" rel="noopener"
+         style="display:block;width:100%;height:80px;background:linear-gradient(135deg,#e3f2fd,#bbdefb);border-radius:6px;box-shadow:2px 4px 12px rgba(0,0,0,0.10);display:flex;align-items:center;justify-content:center;font-size:2rem;">&#128218;</a>
       <figcaption style="margin-top:0.5rem;font-size:0.8rem;">
         <a href="https://amzn.to/3XnTRP1" target="_blank" rel="noopener"
            style="color:var(--accent);text-decoration:none;font-weight:600;">
@@ -376,10 +372,8 @@
     Essere acqua</span>).</p>
 
     <figure style="margin:1.5rem auto;max-width:180px;text-align:center;">
-      <a href="https://amzn.to/3A2r5ha" target="_blank" rel="noopener">
-        <img src="https://covers.openlibrary.org/b/isbn/9788863808087/M.jpg" alt="Copertina: La saggezza del Tao &mdash; Wayne Dyer"
-             style="width:100%;box-shadow:2px 4px 12px rgba(0,0,0,0.15);"/>
-      </a>
+      <a href="https://amzn.to/3A2r5ha" target="_blank" rel="noopener"
+         style="display:block;width:100%;height:80px;background:linear-gradient(135deg,#f3e5f5,#e1bee7);border-radius:6px;box-shadow:2px 4px 12px rgba(0,0,0,0.10);display:flex;align-items:center;justify-content:center;font-size:2rem;">&#128218;</a>
       <figcaption style="margin-top:0.5rem;font-size:0.8rem;">
         <a href="https://amzn.to/3A2r5ha" target="_blank" rel="noopener"
            style="color:var(--accent);text-decoration:none;font-weight:600;">
@@ -661,10 +655,8 @@
     L&rsquo;obesit&agrave; non &egrave; pigrizia: &egrave; il risultato di un sistema alimentare che ha cambiato le regole del gioco senza avvisare i giocatori.</p>
 
     <figure style="margin:1.5rem auto;max-width:180px;text-align:center;">
-      <a href="https://www.amazon.it/Good-Energy-Bestseller-groundbreaking-connection/dp/0008604282?_encoding=UTF8&dib_tag=se&linkCode=sl1&tag=micmeramazon-21&language=it_IT&ref_=as_li_ss_tl" target="_blank" rel="noopener">
-        <img src="https://covers.openlibrary.org/b/isbn/9780593712641/M.jpg" alt="Copertina: Good Energy &mdash; Casey Means"
-             style="width:100%;box-shadow:2px 4px 12px rgba(0,0,0,0.15);"/>
-      </a>
+      <a href="https://www.amazon.it/Good-Energy-Bestseller-groundbreaking-connection/dp/0008604282?_encoding=UTF8&dib_tag=se&linkCode=sl1&tag=micmeramazon-21&language=it_IT&ref_=as_li_ss_tl" target="_blank" rel="noopener"
+         style="display:block;width:100%;height:80px;background:linear-gradient(135deg,#fff3e0,#ffe0b2);border-radius:6px;box-shadow:2px 4px 12px rgba(0,0,0,0.10);display:flex;align-items:center;justify-content:center;font-size:2rem;">&#128218;</a>
       <figcaption style="margin-top:0.5rem;font-size:0.8rem;">
         <a href="https://www.amazon.it/Good-Energy-Bestseller-groundbreaking-connection/dp/0008604282?_encoding=UTF8&dib_tag=se&linkCode=sl1&tag=micmeramazon-21&language=it_IT&ref_=as_li_ss_tl" target="_blank" rel="noopener"
            style="color:var(--accent);text-decoration:none;font-weight:600;">
@@ -829,10 +821,8 @@
     Ninna nanna neurale</span>).</p>
 
     <figure style="margin:1.5rem auto;max-width:180px;text-align:center;">
-      <a href="https://amzn.to/3SVM4sy" target="_blank" rel="noopener">
-        <img src="https://covers.openlibrary.org/b/isbn/9780306826627/M.jpg" alt="Copertina: We Are Electric &mdash; Sally Adee"
-             style="width:100%;box-shadow:2px 4px 12px rgba(0,0,0,0.15);"/>
-      </a>
+      <a href="https://amzn.to/3SVM4sy" target="_blank" rel="noopener"
+         style="display:block;width:100%;height:80px;background:linear-gradient(135deg,#e0f7fa,#b2ebf2);border-radius:6px;box-shadow:2px 4px 12px rgba(0,0,0,0.10);display:flex;align-items:center;justify-content:center;font-size:2rem;">&#128218;</a>
       <figcaption style="margin-top:0.5rem;font-size:0.8rem;">
         <a href="https://amzn.to/3SVM4sy" target="_blank" rel="noopener"
            style="color:var(--accent);text-decoration:none;font-weight:600;">
@@ -955,12 +945,15 @@ document.querySelectorAll('.fc').forEach(el => {
     const rawText = el.textContent || '';
     const ffMatch = rawText.match(/ff\.\d+(?:\.\d+)?/);
     const ffToken = ffMatch ? ffMatch[0] : `ff.${m[1]}`;
+    // Extract emoji (everything before "ff.")
+    const emojiMatch = rawText.match(/^([\s\S]*?)(?=ff\.)/);
+    const emoji = emojiMatch ? emojiMatch[1].trim() : '';
     const titlePart = rawText
       .replace(/^[\s\S]*?(ff\.\d+(?:\.\d+)?)/, '')
       .replace(/\s+/g, ' ')
       .trim();
     const compactTitle = compactClaimLabel(titlePart, 15);
-    a.textContent = compactTitle ? `${ffToken} ${compactTitle}` : ffToken;
+    a.textContent = emoji ? `${emoji} ${ffToken} ${compactTitle}`.trim() : (compactTitle ? `${ffToken} ${compactTitle}` : ffToken);
 
     el.replaceWith(a);
   }

--- a/book/chapter-02.html
+++ b/book/chapter-02.html
@@ -42,7 +42,7 @@
         .chapter-num{font-family:'Press Start 2P',monospace;font-size:clamp(0.45rem,1vw,0.55rem);letter-spacing:0.3em}
         .drop-cap::first-letter{font-family:'IBM Plex Mono',monospace;font-size:clamp(2.8em,5vw,3.4em);float:left;line-height:0.8;padding-right:10px;padding-top:4px;font-weight:700;color:var(--accent)}
         .prose p{margin-bottom:1.2em;font-size:clamp(1rem,2.5vw,1.05rem);line-height:1.75;max-width:72ch}
-        .prose .fc{font-family:'IBM Plex Mono',monospace;font-size:0.8rem;font-weight:700;color:var(--accent);cursor:pointer;text-decoration:none;transition:color 0.15s;display:inline}
+        .prose .fc{font-family:'Inter',sans-serif;font-size:0.92rem;font-weight:600;color:var(--accent);cursor:pointer;text-decoration:none;transition:color 0.15s;display:inline}
         .prose .fc:hover{text-decoration:underline}
         .toc-link{border-left:3px solid transparent;transition:all 0.2s;min-height:44px;display:flex;align-items:center}.toc-link:hover,.toc-link:focus{border-left-color:var(--accent);padding-left:12px}
         blockquote{border-left:4px solid var(--accent);padding:12px 20px;margin:1.5em 0;background:#f0f6ff;font-style:italic}
@@ -739,9 +739,20 @@ document.querySelectorAll('.fc').forEach(el => {
     const a = document.createElement('a');
     a.href = url;
     a.className = el.className;
-    a.innerHTML = el.innerHTML;
     a.target = '_blank';
     a.rel = 'noopener noreferrer';
+    const rawText = el.textContent || '';
+    const ffMatch = rawText.match(/ff\.\d+(?:\.\d+)?/);
+    const ffToken = ffMatch ? ffMatch[0] : `ff.${m[1]}`;
+    // Extract emoji (everything before "ff.")
+    const emojiMatch = rawText.match(/^([\s\S]*?)(?=ff\.)/);
+    const emoji = emojiMatch ? emojiMatch[1].trim() : '';
+    const titlePart = rawText
+      .replace(/^[\s\S]*?(ff\.\d+(?:\.\d+)?)/, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+    const compactTitle = titlePart.split(' ').filter(Boolean).slice(0, 15).join(' ');
+    a.textContent = emoji ? `${emoji} ${ffToken} ${compactTitle}`.trim() : (compactTitle ? `${ffToken} ${compactTitle}` : ffToken);
     el.replaceWith(a);
   }
 });

--- a/book/chapter-03.html
+++ b/book/chapter-03.html
@@ -33,7 +33,7 @@
         .chapter-num{font-family:'Press Start 2P',monospace;font-size:clamp(0.45rem,1vw,0.55rem);letter-spacing:0.3em}
         .drop-cap::first-letter{font-family:'IBM Plex Mono',monospace;font-size:clamp(2.8em,5vw,3.4em);float:left;line-height:0.8;padding-right:10px;padding-top:4px;font-weight:700;color:var(--accent)}
         .prose p{margin-bottom:1.2em;font-size:clamp(1rem,2.5vw,1.05rem);line-height:1.75;max-width:72ch}
-        .prose .fc{font-family:'IBM Plex Mono',monospace;font-size:0.8rem;font-weight:700;color:var(--accent);cursor:pointer;text-decoration:none;transition:color 0.15s;display:inline}
+        .prose .fc{font-family:'Inter',sans-serif;font-size:0.92rem;font-weight:600;color:var(--accent);cursor:pointer;text-decoration:none;transition:color 0.15s;display:inline}
         .prose .fc:hover{text-decoration:underline}
         .toc-link{border-left:3px solid transparent;transition:all 0.2s;min-height:44px;display:flex;align-items:center}.toc-link:hover,.toc-link:focus{border-left-color:var(--accent);padding-left:12px}
         blockquote{border-left:4px solid var(--accent);padding:12px 20px;margin:1.5em 0;background:#fff0f0;font-style:italic}
@@ -164,8 +164,8 @@
     (<span class="fc">&#128171; ff.121.2
     Flow negli sport estremi</span>).</p>
 <figure style="margin:1.5rem auto;max-width:180px;text-align:center;">
-  <img src="https://covers.openlibrary.org/b/isbn/9788832105681/M.jpg" alt="Copertina: L'era della dopamina"
-       style="width:100%;box-shadow:2px 4px 12px rgba(0,0,0,0.15);"/>
+  <a href="https://amzn.to/3HmBA20" target="_blank" rel="noopener"
+     style="display:block;width:100%;height:80px;background:linear-gradient(135deg,#fce4ec,#f8bbd0);border-radius:6px;box-shadow:2px 4px 12px rgba(0,0,0,0.10);display:flex;align-items:center;justify-content:center;font-size:2rem;">&#128218;</a>
   <figcaption style="margin-top:0.5rem;font-size:0.8rem;">
     <a href="https://amzn.to/3HmBA20" target="_blank" rel="noopener"
        style="color:var(--accent);text-decoration:none;font-weight:600;">L'era della dopamina &mdash; Anna Lembke</a>
@@ -194,8 +194,8 @@
     (<span class="fc">&#128142; ff.137.3
     Cristalli e Bach</span>). Uno <a href="https://x.com/emollick/status/1762567635873440173" target="_blank" rel="noopener" style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">studio su Nature dimostra che ridurre l'uso di Twitter migliora il benessere</a>.</p>
 <figure style="margin:1.5rem auto;max-width:180px;text-align:center;">
-  <img src="https://covers.openlibrary.org/b/isbn/9788830107571/M.jpg" alt="Copertina: Four Thousand Weeks"
-       style="width:100%;box-shadow:2px 4px 12px rgba(0,0,0,0.15);"/>
+  <a href="https://amzn.to/4mHEPRU" target="_blank" rel="noopener"
+     style="display:block;width:100%;height:80px;background:linear-gradient(135deg,#e8eaf6,#c5cae9);border-radius:6px;box-shadow:2px 4px 12px rgba(0,0,0,0.10);display:flex;align-items:center;justify-content:center;font-size:2rem;">&#128218;</a>
   <figcaption style="margin-top:0.5rem;font-size:0.8rem;">
     <a href="https://amzn.to/4mHEPRU" target="_blank" rel="noopener"
        style="color:var(--accent);text-decoration:none;font-weight:600;">Four Thousand Weeks &mdash; Oliver Burkeman</a>
@@ -203,8 +203,8 @@
 </figure>
 
 <figure style="margin:1.5rem auto;max-width:180px;text-align:center;">
-  <img src="https://covers.openlibrary.org/b/isbn/9780358567097/M.jpg" alt="Copertina: Die with Zero"
-       style="width:100%;box-shadow:2px 4px 12px rgba(0,0,0,0.15);"/>
+  <a href="https://amzn.to/4l23DTd" target="_blank" rel="noopener"
+     style="display:block;width:100%;height:80px;background:linear-gradient(135deg,#fff8e1,#ffecb3);border-radius:6px;box-shadow:2px 4px 12px rgba(0,0,0,0.10);display:flex;align-items:center;justify-content:center;font-size:2rem;">&#128218;</a>
   <figcaption style="margin-top:0.5rem;font-size:0.8rem;">
     <a href="https://amzn.to/4l23DTd" target="_blank" rel="noopener"
        style="color:var(--accent);text-decoration:none;font-weight:600;">Die with Zero &mdash; Bill Perkins</a>
@@ -323,8 +323,8 @@
     (<span class="fc">&#9999; ff.141.3
     Done-List e compiti per le vacanze</span>).</p>
 <figure style="margin:1.5rem auto;max-width:180px;text-align:center;">
-  <img src="https://covers.openlibrary.org/b/isbn/9780262046527/M.jpg" alt="Copertina: Out of Touch"
-       style="width:100%;box-shadow:2px 4px 12px rgba(0,0,0,0.15);"/>
+  <a href="https://amzn.to/3R5XWXN" target="_blank" rel="noopener"
+     style="display:block;width:100%;height:80px;background:linear-gradient(135deg,#e0f2f1,#b2dfdb);border-radius:6px;box-shadow:2px 4px 12px rgba(0,0,0,0.10);display:flex;align-items:center;justify-content:center;font-size:2rem;">&#128218;</a>
   <figcaption style="margin-top:0.5rem;font-size:0.8rem;">
     <a href="https://amzn.to/3R5XWXN" target="_blank" rel="noopener"
        style="color:var(--accent);text-decoration:none;font-weight:600;">Out of Touch &mdash; Michelle Drouin</a>
@@ -332,8 +332,8 @@
 </figure>
 
 <figure style="margin:1.5rem auto;max-width:180px;text-align:center;">
-  <img src="https://covers.openlibrary.org/b/isbn/9781623367930/M.jpg" alt="Copertina: Peak Performance"
-       style="width:100%;box-shadow:2px 4px 12px rgba(0,0,0,0.15);"/>
+  <a href="https://amzn.to/3M9DBhO" target="_blank" rel="noopener"
+     style="display:block;width:100%;height:80px;background:linear-gradient(135deg,#f1f8e9,#dcedc8);border-radius:6px;box-shadow:2px 4px 12px rgba(0,0,0,0.10);display:flex;align-items:center;justify-content:center;font-size:2rem;">&#128218;</a>
   <figcaption style="margin-top:0.5rem;font-size:0.8rem;">
     <a href="https://amzn.to/3M9DBhO" target="_blank" rel="noopener"
        style="color:var(--accent);text-decoration:none;font-weight:600;">Peak Performance &mdash; Brad Stulberg</a>
@@ -434,8 +434,8 @@
     (<span class="fc">&#128314; ff.122.4
     Piramidi in 4 minuti?</span>). La <a href="https://faseb.onlinelibrary.wiley.com/doi/epdf/10.1096/fj.05-5568com" target="_blank" rel="noopener" style="font-family:'IBM Plex Mono',monospace;font-size:0.78rem;font-weight:bold;color:var(--accent);text-decoration:none;">restrizione della metionina migliora la funzione mitocondriale e la longevit&agrave;</a>.</p>
 <figure style="margin:1.5rem auto;max-width:180px;text-align:center;">
-  <img src="https://covers.openlibrary.org/b/isbn/9780544286061/M.jpg" alt="Copertina: The Rise of Superman"
-       style="width:100%;box-shadow:2px 4px 12px rgba(0,0,0,0.15);"/>
+  <a href="https://amzn.to/3DVYHzh" target="_blank" rel="noopener"
+     style="display:block;width:100%;height:80px;background:linear-gradient(135deg,#ede7f6,#d1c4e9);border-radius:6px;box-shadow:2px 4px 12px rgba(0,0,0,0.10);display:flex;align-items:center;justify-content:center;font-size:2rem;">&#128218;</a>
   <figcaption style="margin-top:0.5rem;font-size:0.8rem;">
     <a href="https://amzn.to/3DVYHzh" target="_blank" rel="noopener"
        style="color:var(--accent);text-decoration:none;font-weight:600;">The Rise of Superman &mdash; Steven Kotler</a>
@@ -514,8 +514,8 @@
     (<span class="fc">&#128142; ff.62.4
     Maslow nel 2024</span>).</p>
 <figure style="margin:1.5rem auto;max-width:180px;text-align:center;">
-  <img src="https://covers.openlibrary.org/b/isbn/9798986684000/M.jpg" alt="Copertina: The Pathless Path"
-       style="width:100%;box-shadow:2px 4px 12px rgba(0,0,0,0.15);"/>
+  <a href="https://amzn.to/40LSU4A" target="_blank" rel="noopener"
+     style="display:block;width:100%;height:80px;background:linear-gradient(135deg,#e8f5e9,#c8e6c9);border-radius:6px;box-shadow:2px 4px 12px rgba(0,0,0,0.10);display:flex;align-items:center;justify-content:center;font-size:2rem;">&#128218;</a>
   <figcaption style="margin-top:0.5rem;font-size:0.8rem;">
     <a href="https://amzn.to/40LSU4A" target="_blank" rel="noopener"
        style="color:var(--accent);text-decoration:none;font-weight:600;">The Pathless Path &mdash; Paul Millerd</a>
@@ -837,17 +837,20 @@ document.querySelectorAll('.fc').forEach(el=>{
   if(m){
     const url=substackMap[m[1]]||('https://fortissimo.substack.com/p/ff'+m[1]);
     const ffMatch = rawText.match(/ff\.\d+(?:\.\d+)?/);
+    const ffToken = ffMatch ? ffMatch[0] : `ff.${m[1]}`;
+    // Extract emoji (everything before "ff.")
+    const emojiMatch = rawText.match(/^([\s\S]*?)(?=ff\.)/);
+    const emoji = emojiMatch ? emojiMatch[1].trim() : '';
     const titlePart = rawText
       .replace(/^[^\w\d]*(?:ff\.\d+(?:\.\d+)?)?/i, '')
       .replace(/\s+/g, ' ')
       .trim();
     const compactTitle = compactClaimLabel(titlePart, 15);
-    const label = ffMatch ? `${ffMatch[0]} ${compactTitle}`.trim() : compactTitle;
 
     const a=document.createElement('a');
     a.href=url;
     a.className=el.className;
-    a.textContent=label;
+    a.textContent = emoji ? `${emoji} ${ffToken} ${compactTitle}`.trim() : (compactTitle ? `${ffToken} ${compactTitle}` : ffToken);
     a.target='_blank';
     a.rel='noopener noreferrer';
     el.replaceWith(a);

--- a/book/index.html
+++ b/book/index.html
@@ -514,37 +514,43 @@
           details summary::-webkit-details-marker { display: none; }
         </style>
 
-        <p class="ff-body-sm mt-3" style="color:#555;">Cinque nuove iniezioni tematiche e cinque revisioni stilistiche integrate il 24 marzo 2026.</p>
+        <p class="ff-body-sm mt-3" style="color:#555;">Cinque nuove iniezioni tematiche integrate il 24 marzo 2026. Ecco cosa &egrave; stato aggiunto:</p>
 
-        <div class="grid gap-4 mt-4" style="grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));">
+        <div style="display:flex;flex-direction:column;gap:1.2rem;margin-top:1rem;">
 
-          <!-- Block 1: Natura 1.2 — energia e piante CRISPR -->
+          <!-- ff.33.3 -->
           <div style="border-left:4px solid var(--ff-green);padding-left:12px;">
-            <div class="ff-caption" style="color:var(--ff-green);">Natura 1.2 &mdash; Energia e piante</div>
-            <ul class="mt-2 text-sm" style="color:#444;list-style:none;padding:0;margin:0;">
-              <li><strong>ff.33.3</strong> &mdash; Piante modificate CRISPR per catturare CO2</li>
-              <li><strong>ff.115.1</strong> &mdash; A lezione con un miliardario (Lowercarbon Capital)</li>
-            </ul>
-            <div class="mt-2"><a class="ff-button underline text-xs" href="/book/chapter-01.html#s2-3">Vai a 1.2 &rarr;</a></div>
+            <div style="font-weight:700;color:var(--ff-green);font-size:0.95rem;">&#127981; ff.33.3 &mdash; Piante modificate per catturare CO2</div>
+            <p class="ff-body-sm mt-1" style="color:#444;">Le piante non sono solo alleate passive: possono essere riprogrammate. Alcuni ricercatori stanno usando CRISPR per aumentare la conversione da CO&#8322; a carbonio stabilizzato nel suolo, aggirando i freni biologici che la selezione naturale ha imposto in milioni di anni. Se il solare converte la luce in elettroni e le piante convertono la luce in biomassa, la prossima frontiera &egrave; una pianta che fa entrambe le cose.</p>
+            <a class="ff-button underline text-xs" href="/book/chapter-01.html#s2-3">Leggi in Cap. 1 &sect;2.3 &rarr;</a>
           </div>
 
-          <!-- Block 2: Tecnologia 2.1/2.3 — AI energia e co-evoluzione -->
+          <!-- ff.115.1 -->
+          <div style="border-left:4px solid var(--ff-green);padding-left:12px;">
+            <div style="font-weight:700;color:var(--ff-green);font-size:0.95rem;">&#128104;&#8205;&#127979; ff.115.1 &mdash; A lezione con un miliardario</div>
+            <p class="ff-body-sm mt-1" style="color:#444;">Chris Sacca, 2.378esima persona pi&ugrave; ricca al mondo secondo Forbes, ha fondato Lowercarbon Capital, un fondo che investe esclusivamente in soluzioni al cambiamento climatico. Nel suo portfolio: Carbon Engineering (cattura CO&#8322; a 100$/tonnellata), Lilac Solutions (litio dalla brina 3x pi&ugrave; efficiente), Solugen (enzimi per chimica verde). La transizione energetica non avanza per decreto, avanza per venture capital con la pazienza di aspettare un ritorno a vent&rsquo;anni.</p>
+            <a class="ff-button underline text-xs" href="/book/chapter-01.html#s2-2">Leggi in Cap. 1 &sect;2.2 &rarr;</a>
+          </div>
+
+          <!-- ff.82.1 -->
           <div style="border-left:4px solid var(--ff-blue);padding-left:12px;">
-            <div class="ff-caption" style="color:var(--ff-blue);">Tecnologia 2.1/2.3 &mdash; AI e co-evoluzione</div>
-            <ul class="mt-2 text-sm" style="color:#444;list-style:none;padding:0;margin:0;">
-              <li><strong>ff.82.1</strong> &mdash; Estinzione di massa? (esplosione cambriana e AI)</li>
-              <li><strong>ff.59.2</strong> &mdash; Pressioni sociali e burocrazia (co-evoluzione tech)</li>
-            </ul>
-            <div class="mt-2"><a class="ff-button underline text-xs" href="/book/chapter-02.html#s1-1">Vai a 2.1 &rarr;</a></div>
+            <div style="font-weight:700;color:var(--ff-blue);font-size:0.95rem;">&#129430; ff.82.1 &mdash; Estinzione di massa?</div>
+            <p class="ff-body-sm mt-1" style="color:#444;">500 milioni di anni fa, l&rsquo;esplosione cambriana: un nuovo organismo capace di produrre ossigeno ha probabilmente &ldquo;soffocato&rdquo; le forme di vita che respiravano CO&#8322;. Oggi la CO&#8322; torna protagonista, ma dalla parte sbagliata. Uno scambio con ChatGPT equivale a un&rsquo;ora di luce LED, un&rsquo;immagine DALL-E a una ricarica di smartphone. L&rsquo;esplosione cambriana non ha estinto la vita: l&rsquo;ha diversificata. Forse l&rsquo;esplosione del compute far&agrave; lo stesso con l&rsquo;energia.</p>
+            <a class="ff-button underline text-xs" href="/book/chapter-02.html#s1-1">Leggi in Cap. 2 &sect;1.1 &rarr;</a>
           </div>
 
-          <!-- Block 3: Società 3.2 — zucchero e chimica del corpo -->
+          <!-- ff.59.2 -->
+          <div style="border-left:4px solid var(--ff-blue);padding-left:12px;">
+            <div style="font-weight:700;color:var(--ff-blue);font-size:0.95rem;">&#128451;&#65039; ff.59.2 &mdash; Pressioni sociali e burocrazia</div>
+            <p class="ff-body-sm mt-1" style="color:#444;">La tecnologia non evolve nel vuoto: si co-evolve con la societ&agrave; che la adotta, la resiste, la deforma. Il caso QWERTY &egrave; l&rsquo;esempio pi&ugrave; noto: ci siamo adattati a tal punto che cambiarla &egrave; economicamente impossibile &mdash; un lock-in tecnologico che Darwin riconoscerebbe come nicchia occupata. La co-evoluzione non &egrave; lineare: procede a scatti, come la speciazione per equilibri punteggiati di Gould ed Eldredge.</p>
+            <a class="ff-button underline text-xs" href="/book/chapter-02.html#s3-4">Leggi in Cap. 2 &sect;3.4 &rarr;</a>
+          </div>
+
+          <!-- ff.145.2 -->
           <div style="border-left:4px solid var(--ff-red);padding-left:12px;">
-            <div class="ff-caption" style="color:var(--ff-red);">Societ&agrave; 3.2 &mdash; Chimica del corpo</div>
-            <ul class="mt-2 text-sm" style="color:#444;list-style:none;padding:0;margin:0;">
-              <li><strong>ff.145.2</strong> &mdash; Caramelle e sconosciuti (zucchero e picchi glicemici)</li>
-            </ul>
-            <div class="mt-2"><a class="ff-button underline text-xs" href="/book/chapter-03.html#s2-3">Vai a 3.2 &rarr;</a></div>
+            <div style="font-weight:700;color:var(--ff-red);font-size:0.95rem;">&#127852; ff.145.2 &mdash; Caramelle e sconosciuti</div>
+            <p class="ff-body-sm mt-1" style="color:#444;">Lo zucchero accelera gli AGEs, ma non &egrave; intrinsecamente il male: &egrave; fondamentale per il cervello e per Poga&#269;ar quando vince il Tour de France. La metafora &egrave; pi&ugrave; precisa di quanto sembri: le ossa invecchiano per glicazione esattamente come lo zucchero caramella, e la reazione di Maillard che rende croccante la cr&egrave;me br&ucirc;l&eacute;e &egrave; la stessa che irrigidisce le nostre arterie. La via d&rsquo;uscita non &egrave; eliminare lo zucchero: &egrave; costruire il motore muscolare che lo brucia.</p>
+            <a class="ff-button underline text-xs" href="/book/chapter-03.html#s2-3">Leggi in Cap. 3 &sect;2.3 &rarr;</a>
           </div>
 
         </div>


### PR DESCRIPTION
## Summary
- **JS emoji preservation**: fc-to-anchor conversion now extracts and preserves emoji prefix in all 3 chapter scripts
- **CSS font**: `.fc` refs use Inter body font (0.92rem, semibold) instead of IBM Plex Mono monospace
- **Index toggle**: "Ultime aggiunte" now shows full injected paragraph excerpts (2-3 sentences each) instead of bullet-point subchapter links
- **Cover images**: replaced 12 broken OpenLibrary cover URLs (5 in ch01, 7 in ch03) with styled placeholder links that always render

## Test plan
- [ ] Open each chapter and verify fc links show emoji prefix (e.g. airplane emoji before ff.59)
- [ ] Verify fc links use Inter font, not monospace
- [ ] Open index.html and expand "Ultime aggiunte" toggle — should show full text excerpts
- [ ] Check all book figure blocks — no broken images

🤖 Generated with [Claude Code](https://claude.com/claude-code)