### PR TITLE
Real book cover images for all cited books

### DIFF
--- a/book/chapter-03.html
+++ b/book/chapter-03.html
@@ -164,8 +164,8 @@
     (<span class="fc">&#128171; ff.121.2
     Flow negli sport estremi</span>).</p>
 <figure style="margin:1.5rem auto;max-width:180px;text-align:center;">
-  <a href="https://amzn.to/3HmBA20" target="_blank" rel="noopener"
-     style="display:block;width:100%;height:80px;background:linear-gradient(135deg,#fce4ec,#f8bbd0);border-radius:6px;box-shadow:2px 4px 12px rgba(0,0,0,0.10);display:flex;align-items:center;justify-content:center;font-size:2rem;">&#128218;</a>
+  <img src="../libri/era-della-dopamina.jpg" alt="Copertina: L'era della dopamina"
+       style="width:100%;box-shadow:2px 4px 12px rgba(0,0,0,0.15);"/>
   <figcaption style="margin-top:0.5rem;font-size:0.8rem;">
     <a href="https://amzn.to/3HmBA20" target="_blank" rel="noopener"
        style="color:var(--accent);text-decoration:none;font-weight:600;">L'era della dopamina &mdash; Anna Lembke</a>
@@ -194,8 +194,8 @@
     (<span class="fc">&#128142; ff.137.3
     Cristalli e Bach</span>). Uno <a href="https://x.com/emollick/status/1762567635873440173" target="_blank" rel="noopener" style="font-size:0.92rem;font-weight:600;color:var(--accent);text-decoration:none;">studio su Nature dimostra che ridurre l'uso di Twitter migliora il benessere</a>.</p>
 <figure style="margin:1.5rem auto;max-width:180px;text-align:center;">
-  <a href="https://amzn.to/4mHEPRU" target="_blank" rel="noopener"
-     style="display:block;width:100%;height:80px;background:linear-gradient(135deg,#e8eaf6,#c5cae9);border-radius:6px;box-shadow:2px 4px 12px rgba(0,0,0,0.10);display:flex;align-items:center;justify-content:center;font-size:2rem;">&#128218;</a>
+  <img src="../libri/four-thousand-weeks.jpg" alt="Copertina: Four Thousand Weeks"
+       style="width:100%;box-shadow:2px 4px 12px rgba(0,0,0,0.15);"/>
   <figcaption style="margin-top:0.5rem;font-size:0.8rem;">
     <a href="https://amzn.to/4mHEPRU" target="_blank" rel="noopener"
        style="color:var(--accent);text-decoration:none;font-weight:600;">Four Thousand Weeks &mdash; Oliver Burkeman</a>
@@ -203,8 +203,8 @@
 </figure>
 
 <figure style="margin:1.5rem auto;max-width:180px;text-align:center;">
-  <a href="https://amzn.to/4l23DTd" target="_blank" rel="noopener"
-     style="display:block;width:100%;height:80px;background:linear-gradient(135deg,#fff8e1,#ffecb3);border-radius:6px;box-shadow:2px 4px 12px rgba(0,0,0,0.10);display:flex;align-items:center;justify-content:center;font-size:2rem;">&#128218;</a>
+  <img src="../libri/die-with-zero.jpg" alt="Copertina: Die with Zero"
+       style="width:100%;box-shadow:2px 4px 12px rgba(0,0,0,0.15);"/>
   <figcaption style="margin-top:0.5rem;font-size:0.8rem;">
     <a href="https://amzn.to/4l23DTd" target="_blank" rel="noopener"
        style="color:var(--accent);text-decoration:none;font-weight:600;">Die with Zero &mdash; Bill Perkins</a>
@@ -323,8 +323,8 @@
     (<span class="fc">&#9999; ff.141.3
     Done-List e compiti per le vacanze</span>).</p>
 <figure style="margin:1.5rem auto;max-width:180px;text-align:center;">
-  <a href="https://amzn.to/3R5XWXN" target="_blank" rel="noopener"
-     style="display:block;width:100%;height:80px;background:linear-gradient(135deg,#e0f2f1,#b2dfdb);border-radius:6px;box-shadow:2px 4px 12px rgba(0,0,0,0.10);display:flex;align-items:center;justify-content:center;font-size:2rem;">&#128218;</a>
+  <img src="../libri/out-of-touch.jpg" alt="Copertina: Out of Touch"
+       style="width:100%;box-shadow:2px 4px 12px rgba(0,0,0,0.15);"/>
   <figcaption style="margin-top:0.5rem;font-size:0.8rem;">
     <a href="https://amzn.to/3R5XWXN" target="_blank" rel="noopener"
        style="color:var(--accent);text-decoration:none;font-weight:600;">Out of Touch &mdash; Michelle Drouin</a>
@@ -332,8 +332,8 @@
 </figure>
 
 <figure style="margin:1.5rem auto;max-width:180px;text-align:center;">
-  <a href="https://amzn.to/3M9DBhO" target="_blank" rel="noopener"
-     style="display:block;width:100%;height:80px;background:linear-gradient(135deg,#f1f8e9,#dcedc8);border-radius:6px;box-shadow:2px 4px 12px rgba(0,0,0,0.10);display:flex;align-items:center;justify-content:center;font-size:2rem;">&#128218;</a>
+  <img src="../libri/peak-performance.jpg" alt="Copertina: Peak Performance"
+       style="width:100%;box-shadow:2px 4px 12px rgba(0,0,0,0.15);"/>
   <figcaption style="margin-top:0.5rem;font-size:0.8rem;">
     <a href="https://amzn.to/3M9DBhO" target="_blank" rel="noopener"
        style="color:var(--accent);text-decoration:none;font-weight:600;">Peak Performance &mdash; Brad Stulberg</a>
@@ -434,8 +434,8 @@
     (<span class="fc">&#128314; ff.122.4
     Piramidi in 4 minuti?</span>). La <a href="https://faseb.onlinelibrary.wiley.com/doi/epdf/10.1096/fj.05-5568com" target="_blank" rel="noopener" style="font-size:0.92rem;font-weight:600;color:var(--accent);text-decoration:none;">restrizione della metionina migliora la funzione mitocondriale e la longevit&agrave;</a>.</p>
 <figure style="margin:1.5rem auto;max-width:180px;text-align:center;">
-  <a href="https://amzn.to/3DVYHzh" target="_blank" rel="noopener"
-     style="display:block;width:100%;height:80px;background:linear-gradient(135deg,#ede7f6,#d1c4e9);border-radius:6px;box-shadow:2px 4px 12px rgba(0,0,0,0.10);display:flex;align-items:center;justify-content:center;font-size:2rem;">&#128218;</a>
+  <img src="../libri/rise-of-superman.jpg" alt="Copertina: The Rise of Superman"
+       style="width:100%;box-shadow:2px 4px 12px rgba(0,0,0,0.15);"/>
   <figcaption style="margin-top:0.5rem;font-size:0.8rem;">
     <a href="https://amzn.to/3DVYHzh" target="_blank" rel="noopener"
        style="color:var(--accent);text-decoration:none;font-weight:600;">The Rise of Superman &mdash; Steven Kotler</a>
@@ -514,8 +514,8 @@
     (<span class="fc">&#128142; ff.62.4
     Maslow nel 2024</span>).</p>
 <figure style="margin:1.5rem auto;max-width:180px;text-align:center;">
-  <a href="https://amzn.to/40LSU4A" target="_blank" rel="noopener"
-     style="display:block;width:100%;height:80px;background:linear-gradient(135deg,#e8f5e9,#c8e6c9);border-radius:6px;box-shadow:2px 4px 12px rgba(0,0,0,0.10);display:flex;align-items:center;justify-content:center;font-size:2rem;">&#128218;</a>
+  <img src="../libri/pathless-path.jpg" alt="Copertina: The Pathless Path"
+       style="width:100%;box-shadow:2px 4px 12px rgba(0,0,0,0.15);"/>
   <figcaption style="margin-top:0.5rem;font-size:0.8rem;">
     <a href="https://amzn.to/40LSU4A" target="_blank" rel="noopener"
        style="color:var(--accent);text-decoration:none;font-weight:600;">The Pathless Path &mdash; Paul Millerd</a>
@@ -622,7 +622,7 @@
 
     <figure class="my-4 text-center">
       <a href="https://amzn.to/3YjL7Mh" target="_blank" rel="noopener">
-        <img src="https://m.media-amazon.com/images/I/71bWN-TQKML._SL300_.jpg" alt="Nexus — Yuval Noah Harari" loading="lazy" width="200" style="border-radius:8px;box-shadow:0 2px 8px rgba(0,0,0,0.1);display:inline-block" />
+        <img src="../libri/nexus-harari.jpg" alt="Copertina: Nexus" loading="lazy" width="200" style="border-radius:8px;box-shadow:0 2px 8px rgba(0,0,0,0.1);display:inline-block" />
       </a>
       <figcaption class="text-xs text-zinc-500 mt-2">
         <a href="https://amzn.to/3YjL7Mh" target="_blank" rel="noopener" style="color:var(--accent);text-decoration:none;">


### PR DESCRIPTION
## Summary
- Downloaded 15 real book cover images from Google Books API to `libri/`
- Replaced all gradient placeholder `<div>` blocks with actual `<img>` tags using local paths
- Replaced external image URLs (Substack, Amazon media) with local copies
- Covers ch01 (6 books), ch02 (1 book), ch03 (8 books)

## Books covered
Good Nature, Le otto montagne, La saggezza del Tao, Good Energy, We Are Electric, How Bad Are Bananas, Chip War, L'era della dopamina, Four Thousand Weeks, Die with Zero, Out of Touch, Peak Performance, Rise of Superman, The Pathless Path, Nexus

## Note
The libri/ images and ch01/ch02 HTML updates were included in the prior backup commit on main. This PR adds the remaining ch03 HTML updates (8 gradient placeholders + 1 external URL replaced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)