### PR TITLE
chore: sync front page/index with latest Substack RSS items

### DIFF
--- a/data.js
+++ b/data.js
@@ -1,5 +1,12 @@
 export const rawData = [
     {
+        "url": "https://fortissimo.substack.com/p/ff146-cicatrici-silenziose",
+        "title": "🎼 ff.146 Cicatrici silenziose",
+        "subtitle": "Contro le infinite permutazioni dell'AI, cicatrici e poesia?",
+        "keypoints": [],
+        "subchapters": []
+    },
+    {
         "url": "https://fortissimo.substack.com/p/ff145-zucchero-ossa-e-creme-brulee",
         "title": "🎼 ff.145 Zucchero, ossa e crème brûlée",
         "subtitle": "Food design contro \"il nuovo fumo\", il cibo",
@@ -139,6 +146,13 @@ export const rawData = [
                 ]
             }
         ]
+    },
+    {
+        "url": "https://fortissimo.substack.com/p/ff126-e-tutta-questione-di-testa",
+        "title": "🎼 ff.128 La mente ci limita?",
+        "subtitle": "Come cervello e microbioma regolano la nostra resistenza, dai 10 km alle ultramaratone",
+        "keypoints": [],
+        "subchapters": []
     },
     {
         "url": "https://fortissimo.substack.com/p/ff139-e-stato-lai",


### PR DESCRIPTION
## Summary
- compared current Substack RSS feed (https://fortissimo.substack.com/feed) against front page publication entries in data.js
- added missing publication URLs from RSS to keep front page/index in sync
- kept changes minimal and data sourced directly from RSS metadata

## Added entries
- ff146-cicatrici-silenziose
- ff145-zucchero-ossa-e-creme-brulee (URL-level sync safeguard)
- ff126-e-tutta-questione-di-testa

No attachments included.