### PR TITLE
fix: internal bibliography + style review + stats update

### DIFF
--- a/book/build-bibliography.cjs
+++ b/book/build-bibliography.cjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * build-bibliography.cjs — Builds internal bibliography sections for each subchapter page.
+ * Each entry links to the section anchor where the ff.X.Y reference appears.
+ */
+const fs = require('fs');
+
+const files = fs.readdirSync('.').filter(f => /^chapter-0[123]-[a-z]+\.html$/.test(f)).sort();
+
+for (const file of files) {
+  let html = fs.readFileSync(file, 'utf-8');
+
+  // 1. Extract all h2/h3 section anchors with their line positions
+  const sections = [];
+  const lines = html.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/<h[23] id="(s[\d-]+)"[^>]*>([\s\S]*?)<\/h[23]>/);
+    if (m) {
+      sections.push({ id: m[1], title: m[2].replace(/<[^>]*>/g, '').replace(/&[a-z]+;/g, c => {
+        const map = {'&mdash;':'—','&agrave;':'à','&egrave;':'è','&igrave;':'ì','&ograve;':'ò','&ugrave;':'ù','&rsquo;':"'",'&lsquo;':"'",'&nbsp;':' '};
+        return map[c] || c;
+      }).trim(), line: i });
+    }
+  }
+
+  // 2. Extract all fc spans with their line positions
+  const refs = [];
+  for (let i = 0; i < lines.length; i++) {
+    // Match <span class="fc">CONTENT</span> — may span multiple lines
+    const lineBlock = lines.slice(i, Math.min(i + 3, lines.length)).join('\n');
+    const fcMatches = [...lineBlock.matchAll(/<span class="fc">([\s\S]*?)<\/span>/g)];
+    for (const fm of fcMatches) {
+      const raw = fm[1].replace(/<[^>]*>/g, '').trim();
+      // Extract emoji, ff code, and title
+      // Pattern: EMOJI ff.X.Y\nTitle or EMOJI ff.X.Y Title
+      const codeMatch = raw.match(/([\s\S]*?)(ff\.\d+(?:\.\d+)?)\s*([\s\S]*)/);
+      if (codeMatch) {
+        let emoji = codeMatch[1].trim();
+        const code = codeMatch[2];
+        let title = codeMatch[3].replace(/^\n/, '').trim();
+
+        // Decode HTML entities in emoji
+        emoji = emoji.replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(parseInt(n)))
+                     .replace(/&#x([0-9a-f]+);/gi, (_, h) => String.fromCodePoint(parseInt(h, 16)));
+
+        // Decode entities in title
+        title = title.replace(/&[a-z]+;/g, c => {
+          const map = {'&mdash;':'—','&agrave;':'à','&egrave;':'è','&igrave;':'ì','&ograve;':'ò','&ugrave;':'ù','&rsquo;':"'",'&lsquo;':"'",'&eacute;':'é','&nbsp;':' '};
+          return map[c] || c;
+        });
+
+        // Find which section this ref belongs to
+        let sectionId = sections.length > 0 ? sections[0].id : 's1';
+        for (const sec of sections) {
+          if (sec.line <= i) sectionId = sec.id;
+        }
+
+        // Avoid duplicates
+        if (!refs.find(r => r.code === code)) {
+          refs.push({ emoji, code, title, sectionId, line: i });
+        }
+      }
+    }
+  }
+
+  // Also extract note refs: note XXXX
+  for (let i = 0; i < lines.length; i++) {
+    const lineBlock = lines.slice(i, Math.min(i + 3, lines.length)).join('\n');
+    const noteMatches = [...lineBlock.matchAll(/<span class="fc">([\s\S]*?)<\/span>/g)];
+    for (const nm of noteMatches) {
+      const raw = nm[1].replace(/<[^>]*>/g, '').trim();
+      const noteMatch = raw.match(/([\s\S]*?)(note \d+)\s*([\s\S]*)/i);
+      if (noteMatch && !refs.find(r => r.code === noteMatch[2])) {
+        let emoji = noteMatch[1].trim()
+          .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(parseInt(n)));
+        const code = noteMatch[2];
+        let title = noteMatch[3].replace(/^\n/, '').trim()
+          .replace(/&[a-z]+;/g, c => ({'&mdash;':'—','&agrave;':'à','&egrave;':'è','&rsquo;':"'"}[c] || c));
+        let sectionId = sections.length > 0 ? sections[0].id : 's1';
+        for (const sec of sections) {
+          if (sec.line <= i) sectionId = sec.id;
+        }
+        refs.push({ emoji, code, title, sectionId, line: i });
+      }
+    }
+  }
+
+  // Sort refs by line number
+  refs.sort((a, b) => a.line - b.line);
+
+  console.log(`\n${file}: ${refs.length} unique refs, ${sections.length} sections`);
+  for (const r of refs.slice(0, 5)) {
+    console.log(`  ${r.emoji} ${r.code} — ${r.title} → #${r.sectionId}`);
+  }
+  if (refs.length > 5) console.log(`  ... and ${refs.length - 5} more`);
+
+  // 3. Build bibliography HTML
+  let bibHtml = `\n    <!-- ===== Note del capitolo ===== -->
+    <section id="note-capitolo" class="mt-12 brutal-card accent-bar">
+      <h2 class="text-lg font-bold uppercase mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.12em;">Note del capitolo</h2>
+      <p class="text-sm text-zinc-500 mb-4">${refs.length} riferimenti in questa sezione. Clicca per navigare al paragrafo.</p>
+      <ol style="list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:0.5rem;">\n`;
+
+  for (let ri = 0; ri < refs.length; ri++) {
+    const r = refs[ri];
+    const displayEmoji = r.emoji || '🎼';
+    // HTML-encode the emoji for safety
+    bibHtml += `        <li id="nota-${ri + 1}" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#${r.sectionId}" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">${displayEmoji}</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">${r.code}</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">${r.title}</span>
+          </a>
+        </li>\n`;
+  }
+
+  bibHtml += `      </ol>
+    </section>\n`;
+
+  // 4. Remove old bibliography if exists
+  html = html.replace(/\n\s*<!-- ===== Note del capitolo ===== -->[\s\S]*?<\/section>\s*\n/g, '\n');
+  // Also remove old Fonti esterne bibliography
+  html = html.replace(/\n\s*<section id="bibliografia"[\s\S]*?<\/section>\s*\n/g, '\n');
+
+  // 5. Insert new bibliography before the navigation section
+  const navInsertPoint = html.indexOf('<!-- Navigation -->');
+  if (navInsertPoint > 0) {
+    html = html.slice(0, navInsertPoint) + bibHtml + '\n    ' + html.slice(navInsertPoint);
+  } else {
+    // Fallback: insert before </article>
+    const articleEnd = html.lastIndexOf('</article>');
+    if (articleEnd > 0) {
+      html = html.slice(0, articleEnd) + bibHtml + '\n    ' + html.slice(articleEnd);
+    }
+  }
+
+  fs.writeFileSync(file, html, 'utf-8');
+}
+
+console.log('\nDone — all bibliographies rebuilt as internal navigation.');

--- a/book/chapter-01-ambiente.html
+++ b/book/chapter-01-ambiente.html
@@ -228,7 +228,7 @@
     <p>Per capire quanto sia precario l&rsquo;equilibrio, basta guardare i numeri della radiazione. L&rsquo;energia solare che raggiunge la Terra equivale a <mark class="note-highlight">170.000 TW</mark> &mdash; una cascata alta un chilometro che percorre l&rsquo;intero equatore. Di questi, circa <mark class="note-highlight">50.000 TW (il 30%) vengono riflessi</mark> dalle nubi e dalle superfici. La produzione energetica mondiale? Appena 15 TW, un diecimillesimo della radiazione solare incidente. Piccolissime variazioni nella quantit&agrave; di luce riflessa &mdash; una nuvola in pi&ugrave;, un ghiacciaio in meno &mdash; spostano flussi energetici enormi rispetto a tutto ci&ograve; che l&rsquo;umanit&agrave; produce. Questo rende la geoingegneria tecnicamente implementabile con sforzi modesti, ma rende anche l&rsquo;equilibrio climatico cos&igrave; fragile che qualsiasi intervento pu&ograve; innescare conseguenze sproporzionate. La sproporzione tra scala naturale e scala umana &egrave; il dato pi&ugrave; importante di tutto il dibattito climatico: non siamo piccoli rispetto al pianeta, siamo infinitesimali rispetto al suo bilancio energetico
     (<span class="fc">&#127754; ff.56.3
     Una cascata alta un chilometro</span>).
-    Ma quanto conviene investire sul clima rispetto ad altri problemi globali? Lex Fridman ha discusso il tema con Bjorn Lomborg (<a href="https://amzn.to/3Ib7rQ8" target="_blank" rel="noopener" style="font-size:0.92rem;font-weight:600;color:var(--accent);text-decoration:none;"><em>False Alarm</em></a>) e Andrew Revkin (21 anni al New York Times). Il calcolo &egrave; spietato: ogni dollaro investito in educazione porta <mark class="note-highlight">45 volte il ritorno</mark>; in malaria e tubercolosi (1,5 milioni di morti l&rsquo;anno) <mark class="note-highlight">42 volte</mark>; per il cambiamento climatico, <mark class="note-highlight">10 volte</mark>. Il clima conta, ma non &egrave; dove il dollaro marginale salva pi&ugrave; vite. Lomborg aggiunge un dato che nessuno ripete volentieri: <a href="https://epic.uchicago.edu/area-of-focus/climate-change-and-the-us-economic-future/" target="_blank" rel="noopener" style="font-size:0.92rem;font-weight:600;color:var(--accent);text-decoration:none;">il cambiamento climatico produrr&agrave; una riduzione dello <mark class="note-highlight">0,7-2,4% annuo</mark> da qui al 2100 per gli USA</a> &mdash; lo stesso costo dei contenziosi legali (2,4% del PIL nel 2016). Dobbiamo passare da un &ldquo;monoteismo naturale&rdquo; a un &ldquo;politeismo sociale&rdquo;
+    Ma quanto conviene investire sul clima rispetto ad altri problemi globali? Lex Fridman ha discusso il tema con Bjorn Lomborg, autore di <a href="https://amzn.to/3Ib7rQ8" target="_blank" rel="noopener" style="font-size:0.92rem;font-weight:600;color:var(--accent);text-decoration:none;"><em>False Alarm</em></a>, e Andrew Revkin (21 anni al New York Times). Il calcolo &egrave; spietato: ogni dollaro investito in educazione porta <mark class="note-highlight">45 volte il ritorno</mark>; in malaria e tubercolosi (1,5 milioni di morti l&rsquo;anno) <mark class="note-highlight">42 volte</mark>; per il cambiamento climatico, <mark class="note-highlight">10 volte</mark>. Il clima conta, ma non &egrave; dove il dollaro marginale salva pi&ugrave; vite. Lomborg aggiunge un dato che nessuno ripete volentieri: <a href="https://epic.uchicago.edu/area-of-focus/climate-change-and-the-us-economic-future/" target="_blank" rel="noopener" style="font-size:0.92rem;font-weight:600;color:var(--accent);text-decoration:none;">il cambiamento climatico produrr&agrave; una riduzione dello <mark class="note-highlight">0,7-2,4% annuo</mark> da qui al 2100 per gli USA</a> &mdash; lo stesso costo dei contenziosi legali (2,4% del PIL nel 2016). Dobbiamo passare da un &ldquo;monoteismo naturale&rdquo; a un &ldquo;politeismo sociale&rdquo;
     (<span class="fc">&#128293; ff.51.3
     Sono il tuo sogno eretico</span>).</p>
 
@@ -503,6 +503,539 @@
 
     <!-- ===== 1.3 ===== -->
     </article>
+    
+    <!-- ===== Note del capitolo ===== -->
+    <section id="note-capitolo" class="mt-12 brutal-card accent-bar">
+      <h2 class="text-lg font-bold uppercase mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.12em;">Note del capitolo</h2>
+      <p class="text-sm text-zinc-500 mb-4">75 riferimenti in questa sezione. Clicca per navigare al paragrafo.</p>
+      <ol style="list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:0.5rem;">
+        <li id="nota-1" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🥤</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.130.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Plastic is fantastic</span>
+          </a>
+        </li>
+        <li id="nota-2" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🗑</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.130.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Microplastiche: da dove provengono?</span>
+          </a>
+        </li>
+        <li id="nota-3" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🩸</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.130.5</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Microplastiche induriscono arterie</span>
+          </a>
+        </li>
+        <li id="nota-4" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🎨</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.130.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Arte riciclabile?</span>
+          </a>
+        </li>
+        <li id="nota-5" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💀</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.130.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La danza macabra</span>
+          </a>
+        </li>
+        <li id="nota-6" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🐧</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.47.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Lavatrici contro le microplastiche</span>
+          </a>
+        </li>
+        <li id="nota-7" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">☀️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.12</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Sole, cuore e amore</span>
+          </a>
+        </li>
+        <li id="nota-8" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌤️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.70</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Il sole: soluzione o morte?</span>
+          </a>
+        </li>
+        <li id="nota-9" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🇨🇳</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.42.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Inquinano o spingono la transizione?</span>
+          </a>
+        </li>
+        <li id="nota-10" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌬</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.11.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La rivincita delle rinnovabili?</span>
+          </a>
+        </li>
+        <li id="nota-11" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🇨🇳</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.11.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La Cina fa storia a sé?</span>
+          </a>
+        </li>
+        <li id="nota-12" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🚀</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.46.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Costi astronomici</span>
+          </a>
+        </li>
+        <li id="nota-13" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">😭</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.46.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Anni buttati</span>
+          </a>
+        </li>
+        <li id="nota-14" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">👨‍🏫</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.115.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">A lezione con un miliardario</span>
+          </a>
+        </li>
+        <li id="nota-15" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🔚</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.11.5</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Finire le risorse</span>
+          </a>
+        </li>
+        <li id="nota-16" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">☢️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.28.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Intelligenza artificiale per la fusione nucleare</span>
+          </a>
+        </li>
+        <li id="nota-17" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💚</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.51.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">L'affabulazione per il verde</span>
+          </a>
+        </li>
+        <li id="nota-18" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🛶</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.132.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Tutto scorre anche Skyrim</span>
+          </a>
+        </li>
+        <li id="nota-19" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🐒</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.143.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Darwinismo urbano</span>
+          </a>
+        </li>
+        <li id="nota-20" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">❄️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.56</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Il condizionatore terrestre</span>
+          </a>
+        </li>
+        <li id="nota-21" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🕳️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.56.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Siamo già geo-ingegneri</span>
+          </a>
+        </li>
+        <li id="nota-22" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌱</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.33</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Le piante ci salveranno?</span>
+          </a>
+        </li>
+        <li id="nota-23" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🏭</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.33.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Piante modificate per catturare CO2</span>
+          </a>
+        </li>
+        <li id="nota-24" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌡️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.56.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Gli ultimi 22k anni di termometro terrestre</span>
+          </a>
+        </li>
+        <li id="nota-25" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌊</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.56.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Una cascata alta un chilometro</span>
+          </a>
+        </li>
+        <li id="nota-26" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🔥</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.51.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Sono il tuo sogno eretico</span>
+          </a>
+        </li>
+        <li id="nota-27" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌧️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.56.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Controllare la pioggia</span>
+          </a>
+        </li>
+        <li id="nota-28" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💸</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.56.5</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Altro che il MOSE a Venezia</span>
+          </a>
+        </li>
+        <li id="nota-29" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🔄</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.87.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Un purificatore d'aria per tutti</span>
+          </a>
+        </li>
+        <li id="nota-30" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">☯️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.108.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Essere acqua</span>
+          </a>
+        </li>
+        <li id="nota-31" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">❄️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.134.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Le 72 stagioni giapponesi</span>
+          </a>
+        </li>
+        <li id="nota-32" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💧</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.112.5</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Acqua da tutte le parti</span>
+          </a>
+        </li>
+        <li id="nota-33" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🏞️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.112.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Fiumi inattesi</span>
+          </a>
+        </li>
+        <li id="nota-34" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">⛷️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.43</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Lo sci sta sparendo con la neve?</span>
+          </a>
+        </li>
+        <li id="nota-35" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">⚡</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.105</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Elettricità e vita</span>
+          </a>
+        </li>
+        <li id="nota-36" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌊</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.136</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">On-da e-ner-ge-ti-caaa!</span>
+          </a>
+        </li>
+        <li id="nota-37" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🔢</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.32</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">I numeri non mentono</span>
+          </a>
+        </li>
+        <li id="nota-38" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌱</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.16.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Quali startup monitorare?</span>
+          </a>
+        </li>
+        <li id="nota-39" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🧪</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.46</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Elementale, Watson?</span>
+          </a>
+        </li>
+        <li id="nota-40" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💊</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.4.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">E quella del prossimo farmaco innovativo</span>
+          </a>
+        </li>
+        <li id="nota-41" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💨</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.87</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Siamo quello che respiriamo</span>
+          </a>
+        </li>
+        <li id="nota-42" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">☀️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.143.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Sole e Asian Brown Cloud</span>
+          </a>
+        </li>
+        <li id="nota-43" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🎓</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.103.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">NASA, MENSA e QI</span>
+          </a>
+        </li>
+        <li id="nota-44" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">😱</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.30.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Qualche esempio meno divertente</span>
+          </a>
+        </li>
+        <li id="nota-45" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">⚖️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.61</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La decrescita felice è impossibile?</span>
+          </a>
+        </li>
+        <li id="nota-46" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💡</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.50.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Consumisti ma non di energia</span>
+          </a>
+        </li>
+        <li id="nota-47" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌎</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Clima</span>
+          </a>
+        </li>
+        <li id="nota-48" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">📈</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.14.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Foto (reali) che fanno male</span>
+          </a>
+        </li>
+        <li id="nota-49" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🗺</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.14.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Un piccolo approfondimento sull'Ucraina</span>
+          </a>
+        </li>
+        <li id="nota-50" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌮</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.55.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Campi da arare e dati da reclamare</span>
+          </a>
+        </li>
+        <li id="nota-51" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🔺</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.122.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Nike fatte da vermi</span>
+          </a>
+        </li>
+        <li id="nota-52" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🦪</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.84.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Molluschi e altri sensori</span>
+          </a>
+        </li>
+        <li id="nota-53" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💣</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.70.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Che bomba i pannelli solari!</span>
+          </a>
+        </li>
+        <li id="nota-54" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">⚡</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.105.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Elettroma</span>
+          </a>
+        </li>
+        <li id="nota-55" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🦁</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.141.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Rallentare se inseguiti da leoni</span>
+          </a>
+        </li>
+        <li id="nota-56" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🐷</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.25.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Trapianti di cuore di maiale</span>
+          </a>
+        </li>
+        <li id="nota-57" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🫀</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.25.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La dimensione del problema dei trapianti</span>
+          </a>
+        </li>
+        <li id="nota-58" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🙊</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.25.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Tradurre il linguaggio suino</span>
+          </a>
+        </li>
+        <li id="nota-59" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌲</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.33.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La valenza filosofica e conoscitiva degli alberi</span>
+          </a>
+        </li>
+        <li id="nota-60" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌐</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.81.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Buoni propositi di COP28</span>
+          </a>
+        </li>
+        <li id="nota-61" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🔥</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.143.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Fuoco (3 facce)</span>
+          </a>
+        </li>
+        <li id="nota-62" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">☢</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.46.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Nucleare: un rebrand necessario</span>
+          </a>
+        </li>
+        <li id="nota-63" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌬</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.87.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Quanto è inquinata l&#39;aria in Italia?</span>
+          </a>
+        </li>
+        <li id="nota-64" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌿</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.143.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Lusso naturale</span>
+          </a>
+        </li>
+        <li id="nota-65" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🫁</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.76.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Cento milioni di respiri</span>
+          </a>
+        </li>
+        <li id="nota-66" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">⛷</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.43.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Lo sci sta sparendo con la neve?</span>
+          </a>
+        </li>
+        <li id="nota-67" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🥣</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.92.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Fagioli di bazar</span>
+          </a>
+        </li>
+        <li id="nota-68" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🏃</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.120.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Quanto correre per scappare alla morte?</span>
+          </a>
+        </li>
+        <li id="nota-69" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🍁</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.33.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Raccoglitori di CO2</span>
+          </a>
+        </li>
+        <li id="nota-70" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌿</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.79.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Ecologia e economia degli alberi di Natale</span>
+          </a>
+        </li>
+        <li id="nota-71" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">⚒</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.113.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Una dieta mineraria?</span>
+          </a>
+        </li>
+        <li id="nota-72" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">📉</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.1.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Da 51 miliardi a 0</span>
+          </a>
+        </li>
+        <li id="nota-73" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">⛏</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.42.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Minerali preziosi?</span>
+          </a>
+        </li>
+        <li id="nota-74" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">⛲</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.58.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Andare alle Cascate del Niagara</span>
+          </a>
+        </li>
+        <li id="nota-75" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌴</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.70.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La fine dell'estate</span>
+          </a>
+        </li>
+      </ol>
+    </section>
 
     <!-- Navigation -->
     <nav class="mt-10 mb-8" aria-label="Navigazione sezioni">

--- a/book/chapter-01-cibo.html
+++ b/book/chapter-01-cibo.html
@@ -307,7 +307,7 @@
 
     <blockquote class="pull-quote">In Sardegna, la famiglia Melis &egrave; entrata nel Guinness con una media di 93 anni tra 9 fratelli. In America, il 60% delle calorie proviene da alimenti ultra-processati e l'obesit&agrave; &egrave; passata dal 5,3% al 8,5% dei decessi. La diversit&agrave; &egrave; resilienza, la monocultura &egrave; fragilit&agrave;.</blockquote>
 
-    <p>Nel corpus, la sostenibilit&agrave; migliora quando togliamo attriti, non quando aggiungiamo slogan. Il cittadino medio non ha bisogno di un manifesto in pi&ugrave;: ha bisogno di <mark class="note-highlight">tre scorciatoie praticabili</mark> &mdash; un pasto che riduca infiammazione, un gesto di mobilit&agrave; che abbassi emissioni e sedentariet&agrave;, una regola d&apos;acquisto che premi durata invece di impulso. Questa grammatica minima trasforma la natura da scenario romantico a infrastruttura di salute pubblica.</p>
+    <p>La sostenibilit&agrave; migliora quando togliamo attriti, non quando aggiungiamo slogan. Il cittadino medio non ha bisogno di un manifesto in pi&ugrave;: ha bisogno di <mark class="note-highlight">tre scorciatoie praticabili</mark> &mdash; un pasto che riduca infiammazione, un gesto di mobilit&agrave; che abbassi emissioni e sedentariet&agrave;, una regola d&apos;acquisto che premi durata invece di impulso. Questa grammatica minima trasforma la natura da scenario romantico a infrastruttura di salute pubblica.</p>
 
     <p>Le note su microbioma, obesit&agrave; e contatto con materiali naturali raccontano la stessa geometria: <mark class="note-highlight">quando migliori le condizioni di base, il comportamento cambia senza coercizione</mark>. La dieta dei centenari funziona perch&eacute; &egrave; cultura quotidiana prima che protocollo nutrizionale
     (<span class="fc">&#129491; ff.92.2
@@ -387,6 +387,357 @@
         <a href="https://fortissimo.substack.com/subscribe" target="_blank" rel="noopener" class="cta-btn">Iscriviti gratis &rarr;</a>
     </section>
     </article>
+    
+    <!-- ===== Note del capitolo ===== -->
+    <section id="note-capitolo" class="mt-12 brutal-card accent-bar">
+      <h2 class="text-lg font-bold uppercase mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.12em;">Note del capitolo</h2>
+      <p class="text-sm text-zinc-500 mb-4">49 riferimenti in questa sezione. Clicca per navigare al paragrafo.</p>
+      <ol style="list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:0.5rem;">
+        <li id="nota-1" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🧠</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.92.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Un organo in più: il microbioma</span>
+          </a>
+        </li>
+        <li id="nota-2" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">👌</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.92.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La dieta perfetta (secondo GPT)</span>
+          </a>
+        </li>
+        <li id="nota-3" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💊</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.104.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">L'hacker del corpo</span>
+          </a>
+        </li>
+        <li id="nota-4" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🕛</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.35.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Smartwatch e non solo</span>
+          </a>
+        </li>
+        <li id="nota-5" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🥛</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.113.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">L'inganno del latte proteico</span>
+          </a>
+        </li>
+        <li id="nota-6" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🍜</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.104.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Noodles stampati in 3D</span>
+          </a>
+        </li>
+        <li id="nota-7" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">☕</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.92.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Tè o caffè? Benzina del microbioma</span>
+          </a>
+        </li>
+        <li id="nota-8" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🍔</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.94.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Grassi buoni e cattivi</span>
+          </a>
+        </li>
+        <li id="nota-9" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💊</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.49.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Il superuomo che prende 100 pillole al giorno</span>
+          </a>
+        </li>
+        <li id="nota-10" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🚬</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.94.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Omega-3 come sigarette?</span>
+          </a>
+        </li>
+        <li id="nota-11" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🍷</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.32.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Beviamoci su (o forse no)</span>
+          </a>
+        </li>
+        <li id="nota-12" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🍔</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.49.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Diete e inquinanti</span>
+          </a>
+        </li>
+        <li id="nota-13" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🚫</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.104.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Gli abominevoli 5</span>
+          </a>
+        </li>
+        <li id="nota-14" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">⚽</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.49</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La pandemia del 21esimo secolo</span>
+          </a>
+        </li>
+        <li id="nota-15" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">❓</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.66.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Siamo sempre più malati?</span>
+          </a>
+        </li>
+        <li id="nota-16" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">⚖️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.113.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Buttiamo la bilancia?</span>
+          </a>
+        </li>
+        <li id="nota-17" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🕐</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.22.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Dieta circadiana?</span>
+          </a>
+        </li>
+        <li id="nota-18" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🥔</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.22.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Perché mangiare cibo non processato (e ricco di fibre)</span>
+          </a>
+        </li>
+        <li id="nota-19" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">➗</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.113.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">L'importanza dei rapporti</span>
+          </a>
+        </li>
+        <li id="nota-20" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🍔</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.19.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">L'hamburger preferito di Hemingway</span>
+          </a>
+        </li>
+        <li id="nota-21" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💦</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.19.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Flatulenze inquinanti</span>
+          </a>
+        </li>
+        <li id="nota-22" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🐷</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.19.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Scelte sostenibili cool</span>
+          </a>
+        </li>
+        <li id="nota-23" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💉</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.19.5</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Carne stampata 3D</span>
+          </a>
+        </li>
+        <li id="nota-24" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">♨️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.19.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Fornelli assassini</span>
+          </a>
+        </li>
+        <li id="nota-25" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🦑</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.8.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Squid Game in real life?</span>
+          </a>
+        </li>
+        <li id="nota-26" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💦</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.13.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">O di amore con se stessi</span>
+          </a>
+        </li>
+        <li id="nota-27" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💉</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.107</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">GLP-1 la cura all'obesità</span>
+          </a>
+        </li>
+        <li id="nota-28" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">👴</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.99.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Cosa mangiare per non invecchiare?</span>
+          </a>
+        </li>
+        <li id="nota-29" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🎢</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.145.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Picchi glicemici (e come evitarli)</span>
+          </a>
+        </li>
+        <li id="nota-30" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🚬</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.145.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Il cibo nuoce gravemente alla salute</span>
+          </a>
+        </li>
+        <li id="nota-31" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">👚</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.39</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Come ti vesti?</span>
+          </a>
+        </li>
+        <li id="nota-32" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🪴</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.138.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Toccare legno o ferro?</span>
+          </a>
+        </li>
+        <li id="nota-33" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🚬</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.138.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Roomba o piante ornamentali?</span>
+          </a>
+        </li>
+        <li id="nota-34" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">😬</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.138.5</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Sto lontano dallo stress</span>
+          </a>
+        </li>
+        <li id="nota-35" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💚</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.51.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">L'affabulazione per il verde</span>
+          </a>
+        </li>
+        <li id="nota-36" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">☯</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.108.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Essere acqua</span>
+          </a>
+        </li>
+        <li id="nota-37" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🪑</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.22.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Aggiungi un posto a tavola</span>
+          </a>
+        </li>
+        <li id="nota-38" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💜</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.61.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La dualità dell'anima</span>
+          </a>
+        </li>
+        <li id="nota-39" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">📝</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.65.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Il compito a casa per la vita</span>
+          </a>
+        </li>
+        <li id="nota-40" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💰</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.16.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Tanti trillioni di dollari</span>
+          </a>
+        </li>
+        <li id="nota-41" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🏋</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.53.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Sportivi professionisti in nostro aiuto</span>
+          </a>
+        </li>
+        <li id="nota-42" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🧵</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.97.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Caressa e carezze contro lo stress</span>
+          </a>
+        </li>
+        <li id="nota-43" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🤴</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.105.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Trasformare una rana in principe azzurro?</span>
+          </a>
+        </li>
+        <li id="nota-44" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🧠</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.105.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Rane, cervelli e c-anali ionici</span>
+          </a>
+        </li>
+        <li id="nota-45" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">😴</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.75.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Ninna nanna neurale</span>
+          </a>
+        </li>
+        <li id="nota-46" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">⚔️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.120.5</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Tumore vs battiti cardiaci?</span>
+          </a>
+        </li>
+        <li id="nota-47" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🚲</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.5.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Pedalata assistita</span>
+          </a>
+        </li>
+        <li id="nota-48" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">⚡</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.1.6</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Fusione Nucleare</span>
+          </a>
+        </li>
+        <li id="nota-49" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🤯</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.2.7</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Dormiteci sopra!</span>
+          </a>
+        </li>
+      </ol>
+    </section>
 
     <!-- Navigation -->
     <nav class="mt-10 mb-8" aria-label="Navigazione sezioni">

--- a/book/chapter-01-mobilita.html
+++ b/book/chapter-01-mobilita.html
@@ -117,7 +117,7 @@
       </figcaption>
     </figure>
 
-    <p>Questo sposta il tema dalla mobilit&agrave; alla progettazione quotidiana: non solo dove andiamo, ma <em>come</em> ci arriviamo. Nel corpus emerge una traiettoria coerente: prima ridurre l'attrito per chi cammina e pedala (<span class="fc">&#127961; ff.34
+    <p>Questo sposta il tema dalla mobilit&agrave; alla progettazione quotidiana: non solo dove andiamo, ma <em>come</em> ci arriviamo. La traiettoria &egrave; coerente: prima ridurre l&rsquo;attrito per chi cammina e pedala (<span class="fc">&#127961; ff.34
     Ripensare le citt&agrave;</span>), poi rendere visibile il costo reale degli spostamenti (<span class="fc">&#127820; ff.58
     How bad are bananas?</span>). La citt&agrave; non &egrave; sfondo: &egrave; una tecnologia comportamentale.</p>
 
@@ -214,6 +214,119 @@
 
     <!-- ===== 1.2 ===== -->
     </article>
+    
+    <!-- ===== Note del capitolo ===== -->
+    <section id="note-capitolo" class="mt-12 brutal-card accent-bar">
+      <h2 class="text-lg font-bold uppercase mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.12em;">Note del capitolo</h2>
+      <p class="text-sm text-zinc-500 mb-4">15 riferimenti in questa sezione. Clicca per navigare al paragrafo.</p>
+      <ol style="list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:0.5rem;">
+        <li id="nota-1" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🏎</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.138.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La strada più veloce</span>
+          </a>
+        </li>
+        <li id="nota-2" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">😊</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.138.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La strada più felice</span>
+          </a>
+        </li>
+        <li id="nota-3" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🏙</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.34</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Ripensare le città</span>
+          </a>
+        </li>
+        <li id="nota-4" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🍌</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.58</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">How bad are bananas?</span>
+          </a>
+        </li>
+        <li id="nota-5" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🚦</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.34.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Mobilità e traffico</span>
+          </a>
+        </li>
+        <li id="nota-6" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🚦</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.34.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Spazi vivibili</span>
+          </a>
+        </li>
+        <li id="nota-7" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🚲</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.20.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La rivincita delle biciclette</span>
+          </a>
+        </li>
+        <li id="nota-8" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🚕</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.60</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La guida autonoma è qui!</span>
+          </a>
+        </li>
+        <li id="nota-9" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">⚡</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.5</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Elettrizzante!</span>
+          </a>
+        </li>
+        <li id="nota-10" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🚗</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.32.5</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Le auto elettriche: ecologiche o no?</span>
+          </a>
+        </li>
+        <li id="nota-11" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">❓</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.5.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Non è tutto verde quello che luccica</span>
+          </a>
+        </li>
+        <li id="nota-12" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">⚰</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.5.6</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La pericolosità del traffico, nel mondo</span>
+          </a>
+        </li>
+        <li id="nota-13" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌎</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Clima</span>
+          </a>
+        </li>
+        <li id="nota-14" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">✈️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.59</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">L'ottimismo vola!</span>
+          </a>
+        </li>
+        <li id="nota-15" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">👘</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.12.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Fra l'altro, siamo davvero così intelligenti?</span>
+          </a>
+        </li>
+      </ol>
+    </section>
 
     <!-- Navigation -->
     <nav class="mt-10 mb-8" aria-label="Navigazione sezioni">

--- a/book/chapter-02-metaverso.html
+++ b/book/chapter-02-metaverso.html
@@ -213,7 +213,7 @@ Fondare la propria nazione</span>).</p>
 
     <blockquote class="pull-quote">Nel 2011, Cina e Giappone detenevano il 23% del debito americano; oggi il 6%. Il 70% delle transazioni crypto in Nigeria avviene in stablecoin. Le stablecoin nel 2024 hanno movimentato 15 trilioni di dollari, superando Visa e Mastercard messe insieme. Le reti sono pi&ugrave; resilienti degli imperi: un protocollo blockchain sopravvive alla caduta di un governo; un trattato internazionale non sopravvive a un tweet.</blockquote>
 
-    <p>Un passaggio ricorrente nel corpus &egrave; che la partita non &egrave; solo tecnologica ma istituzionale: quando un network ridefinisce propriet&agrave;, pagamenti e identit&agrave;, cambia anche il perimetro dello Stato e delle piattaforme private. &Egrave; per questo che il tema crypto compare accanto a sovranit&agrave;, governance e lavoro: non come nicchia finanziaria, ma come <mark class="note-highlight">stress test del patto sociale digitale</mark>. Lo spostamento demografico che nel capitolo Societ&agrave; viene analizzato come <a href="https://www.wealest.com/articles/barbell-strategy" target="_blank" rel="noopener" style="font-size:0.92rem;font-weight:600;color:var(--accent);text-decoration:none;">&ldquo;barbell strategy&rdquo;</a> trova nella decentralizzazione una grammatica economica coerente
+    <p>La partita, per&ograve;, non &egrave; solo tecnologica: &egrave; istituzionale. quando un network ridefinisce propriet&agrave;, pagamenti e identit&agrave;, cambia anche il perimetro dello Stato e delle piattaforme private. &Egrave; per questo che il tema crypto compare accanto a sovranit&agrave;, governance e lavoro: non come nicchia finanziaria, ma come <mark class="note-highlight">stress test del patto sociale digitale</mark>. Lo spostamento demografico che nel capitolo Societ&agrave; viene analizzato come <a href="https://www.wealest.com/articles/barbell-strategy" target="_blank" rel="noopener" style="font-size:0.92rem;font-weight:600;color:var(--accent);text-decoration:none;">&ldquo;barbell strategy&rdquo;</a> trova nella decentralizzazione una grammatica economica coerente
     (<span class="fc">&#127760; ff.95.1 La sovranit&agrave; dei network</span>; <span class="fc">&#128176; ff.50 Cosa &egrave; successo nel 1971?</span>).</p>
 
     <h3 id="s2-4" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">2.2.4 &mdash; Cripto in guerra e simulazioni</h3>
@@ -237,6 +237,217 @@ Fondare la propria nazione</span>).</p>
 
     <!-- ===== 2.3 ===== -->
     </article>
+    
+    <!-- ===== Note del capitolo ===== -->
+    <section id="note-capitolo" class="mt-12 brutal-card accent-bar">
+      <h2 class="text-lg font-bold uppercase mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.12em;">Note del capitolo</h2>
+      <p class="text-sm text-zinc-500 mb-4">29 riferimenti in questa sezione. Clicca per navigare al paragrafo.</p>
+      <ol style="list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:0.5rem;">
+        <li id="nota-1" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌐</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Metaverso</span>
+          </a>
+        </li>
+        <li id="nota-2" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🔫</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.11</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Sparare nel metaverso</span>
+          </a>
+        </li>
+        <li id="nota-3" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">👽</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.3.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Cosa sei realmente, Meta? (parte 2)</span>
+          </a>
+        </li>
+        <li id="nota-4" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">👾</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.3.5</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Discord</span>
+          </a>
+        </li>
+        <li id="nota-5" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">2️⃣</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.10.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Siamo già nel metaverso?</span>
+          </a>
+        </li>
+        <li id="nota-6" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">1️⃣</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.10.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Vivremo in un&#39;altra realtà?</span>
+          </a>
+        </li>
+        <li id="nota-7" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🏙️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.52.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Centralizzare conviene</span>
+          </a>
+        </li>
+        <li id="nota-8" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">3️⃣</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.10.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Compreremo solo case digitali?</span>
+          </a>
+        </li>
+        <li id="nota-9" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🎨</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.45.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Arte e grafici dal 2022</span>
+          </a>
+        </li>
+        <li id="nota-10" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🦆</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.95.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">FarmVille e feudalesimo</span>
+          </a>
+        </li>
+        <li id="nota-11" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌐</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.95.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La sovranità dei network</span>
+          </a>
+        </li>
+        <li id="nota-12" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🔑</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.95.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La proprietà privata digitale</span>
+          </a>
+        </li>
+        <li id="nota-13" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">⛓️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.95.5</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Cosa risolve la blockchain?</span>
+          </a>
+        </li>
+        <li id="nota-14" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💵</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.125.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Stabilizzare il dollaro</span>
+          </a>
+        </li>
+        <li id="nota-15" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌐</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.52.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Fondare la propria nazione</span>
+          </a>
+        </li>
+        <li id="nota-16" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💰</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.50</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Cosa è successo nel 1971?</span>
+          </a>
+        </li>
+        <li id="nota-17" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💎</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.110.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Le criptovalute contro obsolescenza statale</span>
+          </a>
+        </li>
+        <li id="nota-18" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💳</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.135.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">America, Nigeria e criptovalute</span>
+          </a>
+        </li>
+        <li id="nota-19" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">⚔️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.24</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Guerra criptica</span>
+          </a>
+        </li>
+        <li id="nota-20" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🏛️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.135.5</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Politica tecnologica</span>
+          </a>
+        </li>
+        <li id="nota-21" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🥶</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.82.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Guerra fredda</span>
+          </a>
+        </li>
+        <li id="nota-22" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🏯</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.125.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Cicli imperiali</span>
+          </a>
+        </li>
+        <li id="nota-23" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌐</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.125.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">L'alternativa alla Cina: Internet</span>
+          </a>
+        </li>
+        <li id="nota-24" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🍩</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.117</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Viviamo in una simulazione</span>
+          </a>
+        </li>
+        <li id="nota-25" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🃏</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.72</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Giochiamo a UNO?</span>
+          </a>
+        </li>
+        <li id="nota-26" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🤖</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.73.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La convergenza AI-Bitcoin</span>
+          </a>
+        </li>
+        <li id="nota-27" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🪙</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.24.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">L'accelerazione della guerra sulle cripto</span>
+          </a>
+        </li>
+        <li id="nota-28" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🧮</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.84.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Vecchi schermi?</span>
+          </a>
+        </li>
+        <li id="nota-29" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🧮</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.117.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Simulazioni e algoritmi</span>
+          </a>
+        </li>
+      </ol>
+    </section>
 
     <!-- Navigation -->
     <nav class="mt-10 mb-8" aria-label="Navigazione sezioni">

--- a/book/chapter-02-prodotti.html
+++ b/book/chapter-02-prodotti.html
@@ -199,7 +199,7 @@
 
     <h3 id="s3-4" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">2.3.4 &mdash; Il collo di bottiglia fisico</h3>
 
-    <p>Nel corpus emerge un punto ricorrente: il prossimo salto non &egrave; nel modello, ma nella <em>fisica</em> che lo sostiene. L'embargo sulle GPU avanzate ha costretto la Cina a spremere efficienza da hardware meno performante, trasformando il <mark class="note-highlight">watt in metrica competitiva</mark> (<span class="fc">🌊 ff.135.2 Onda anomala energetica</span>). <a href="https://techcrunch.com/2025/07/14/mark-zuckerberg-says-meta-is-building-a-5gw-ai-data-center/" target="_blank" rel="noopener" style="font-size:0.92rem;font-weight:600;color:var(--accent);text-decoration:none;">Mark Zuckerberg annuncia la costruzione di Hyperion, un data center AI da <mark class="note-highlight">5 GW</mark></a> &mdash; cinque volte pi&ugrave; grande degli attuali. Nuovi display per realt&agrave; mista avvicinano il metaverso all'uso quotidiano: non mondi virtuali separati, ma livelli informativi sovrapposti al mondo reale, sempre attivi e contestuali.</p>
+    <p>Il prossimo salto non &egrave; nel modello, ma nella <em>fisica</em> che lo sostiene. L'embargo sulle GPU avanzate ha costretto la Cina a spremere efficienza da hardware meno performante, trasformando il <mark class="note-highlight">watt in metrica competitiva</mark> (<span class="fc">🌊 ff.135.2 Onda anomala energetica</span>). <a href="https://techcrunch.com/2025/07/14/mark-zuckerberg-says-meta-is-building-a-5gw-ai-data-center/" target="_blank" rel="noopener" style="font-size:0.92rem;font-weight:600;color:var(--accent);text-decoration:none;">Mark Zuckerberg annuncia la costruzione di Hyperion, un data center AI da <mark class="note-highlight">5 GW</mark></a> &mdash; cinque volte pi&ugrave; grande degli attuali. Nuovi display per realt&agrave; mista avvicinano il metaverso all'uso quotidiano: non mondi virtuali separati, ma livelli informativi sovrapposti al mondo reale, sempre attivi e contestuali.</p>
 
     <p>Lo stesso vale per l'energia di accumulo: senza batterie pi&ugrave; economiche e dense, l'AI resta una promessa costosa. La traiettoria &egrave; chiara: catene industriali orientate a chimiche pi&ugrave; abbondanti e meno dipendenti da materiali critici, con il baricentro produttivo che si sposta verso soluzioni scalabili per rete elettrica, mobilit&agrave; e datacenter (<span class="fc">&#128267; ff.42 Made in China</span>). Per contestualizzare il consumo: <a href="https://x.com/DrewPavlou/status/1941651240636866780" target="_blank" rel="noopener" style="font-size:0.92rem;font-weight:600;color:var(--accent);text-decoration:none;">un cheeseburger McDonald's equivale all'energia di <mark class="note-highlight">80.000 richieste ChatGPT</mark></a>. La vera corsa, quindi, non &egrave; solo al modello migliore: &egrave; al <mark class="note-highlight">sistema integrato <em>chip + elettricit&agrave; + storage + interfaccia</em></mark>.</p>
 
@@ -270,6 +270,329 @@ Un cantiere infinito</span>).</p>
         <a href="https://fortissimo.substack.com/subscribe" target="_blank" rel="noopener" class="cta-btn">Iscriviti gratis &rarr;</a>
     </section>
     </article>
+    
+    <!-- ===== Note del capitolo ===== -->
+    <section id="note-capitolo" class="mt-12 brutal-card accent-bar">
+      <h2 class="text-lg font-bold uppercase mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.12em;">Note del capitolo</h2>
+      <p class="text-sm text-zinc-500 mb-4">45 riferimenti in questa sezione. Clicca per navigare al paragrafo.</p>
+      <ol style="list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:0.5rem;">
+        <li id="nota-1" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🩺</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.124.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Medico in famiglia (e in tasca)</span>
+          </a>
+        </li>
+        <li id="nota-2" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🤹</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.124.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">ChatGPT tuttofare</span>
+          </a>
+        </li>
+        <li id="nota-3" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🚶</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.87</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Il respiro</span>
+          </a>
+        </li>
+        <li id="nota-4" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">👽</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.119.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Intelligenze aliene</span>
+          </a>
+        </li>
+        <li id="nota-5" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">👩</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.103.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Turing e Her</span>
+          </a>
+        </li>
+        <li id="nota-6" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">✍️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.119.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Longa 'Manus' con gli agenti AI?</span>
+          </a>
+        </li>
+        <li id="nota-7" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🍦</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.119.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Meglio di DALL-E: arte e gelati</span>
+          </a>
+        </li>
+        <li id="nota-8" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌊</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.123.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Non solo Studio Ghibli</span>
+          </a>
+        </li>
+        <li id="nota-9" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🙏</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.119.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Se il prete è un'AI</span>
+          </a>
+        </li>
+        <li id="nota-10" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🖦️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.106.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">AI col mouse</span>
+          </a>
+        </li>
+        <li id="nota-11" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🚀</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.45.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Quali trend decolleranno?</span>
+          </a>
+        </li>
+        <li id="nota-12" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">📈</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.88.5</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Un paio di esempi di accelerazione</span>
+          </a>
+        </li>
+        <li id="nota-13" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">📜</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.54.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Un sonetto di Petrarca</span>
+          </a>
+        </li>
+        <li id="nota-14" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">✍️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.95.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Reinventare scrittura e stampa</span>
+          </a>
+        </li>
+        <li id="nota-15" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">📱</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.140.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">L'era degli App-fluencers</span>
+          </a>
+        </li>
+        <li id="nota-16" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🕹️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.132.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">I benefici dei videogiochi</span>
+          </a>
+        </li>
+        <li id="nota-17" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">📐</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.132.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Misurare e modellare il mondo</span>
+          </a>
+        </li>
+        <li id="nota-18" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🔎</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.28</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Google ricerca il futuro</span>
+          </a>
+        </li>
+        <li id="nota-19" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🔯</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.126.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Da campi di sterminio a Intel</span>
+          </a>
+        </li>
+        <li id="nota-20" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💥</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.82</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Guerra a colpi di chip</span>
+          </a>
+        </li>
+        <li id="nota-21" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🇨🇳</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.42</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Made in China</span>
+          </a>
+        </li>
+        <li id="nota-22" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">⚛️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.69</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Quantico?</span>
+          </a>
+        </li>
+        <li id="nota-23" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🏮</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.125.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Cina: il prossimo impero mondiale?</span>
+          </a>
+        </li>
+        <li id="nota-24" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🔋</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.5.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Duracell? No, Tesla</span>
+          </a>
+        </li>
+        <li id="nota-25" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">😎</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.5.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La Tesla delle biciclette</span>
+          </a>
+        </li>
+        <li id="nota-26" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🚗</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.93</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Tesla: la fine di un'era?</span>
+          </a>
+        </li>
+        <li id="nota-27" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🎨</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.30</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">DALL-E genera arte</span>
+          </a>
+        </li>
+        <li id="nota-28" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🤖</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.83</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Imparare da ChatGPT</span>
+          </a>
+        </li>
+        <li id="nota-29" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🦴</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.124.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Dalì sciogli clavicole</span>
+          </a>
+        </li>
+        <li id="nota-30" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">✍️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.124.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Longa manus</span>
+          </a>
+        </li>
+        <li id="nota-31" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🐦</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.126.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Non è la fine di Google</span>
+          </a>
+        </li>
+        <li id="nota-32" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌊</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.135.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Onda anomala energetica</span>
+          </a>
+        </li>
+        <li id="nota-33" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🤤</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.110.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Robot e AI: opportunità</span>
+          </a>
+        </li>
+        <li id="nota-34" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🚧</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.110.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Un cantiere infinito</span>
+          </a>
+        </li>
+        <li id="nota-35" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🧰</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.123</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">L'AI con il coltellino svizzero</span>
+          </a>
+        </li>
+        <li id="nota-36" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🎼</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.129</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Il valzer di Tesla</span>
+          </a>
+        </li>
+        <li id="nota-37" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🗃️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.59.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Pressioni sociali e burocrazia</span>
+          </a>
+        </li>
+        <li id="nota-38" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🧮</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.140.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Deflazione mentale e crisi accademica</span>
+          </a>
+        </li>
+        <li id="nota-39" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🧬</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.4.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La struttura delle proteine</span>
+          </a>
+        </li>
+        <li id="nota-40" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">📉</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.4.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">DNA meglio dei microchip!</span>
+          </a>
+        </li>
+        <li id="nota-41" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🤖</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.71.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">ChatGPT (ti) vede</span>
+          </a>
+        </li>
+        <li id="nota-42" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🇫🇮</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.1.5</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Il consumo energetico di Bitcoin</span>
+          </a>
+        </li>
+        <li id="nota-43" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">📱</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.8.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Schermi piccoli</span>
+          </a>
+        </li>
+        <li id="nota-44" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🥃</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.54.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Il contesto: l'amaro dell'impotenza</span>
+          </a>
+        </li>
+        <li id="nota-45" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🚕</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.102.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Wuhan: dal Covid a Baidu</span>
+          </a>
+        </li>
+      </ol>
+    </section>
 
     <!-- Navigation -->
     <nav class="mt-10 mb-8" aria-label="Navigazione sezioni">

--- a/book/chapter-02-robotica.html
+++ b/book/chapter-02-robotica.html
@@ -118,7 +118,7 @@
     (<span class="fc">&#127464;&#127475; ff.2.2 Alibaba e l'alternativa efficiente</span>).
     Nel frattempo il professore Wang Yu, alla AI Conference di Shanghai, ha coniato il <mark class="note-highlight">&ldquo;watt-to-bit&rdquo;</mark> &mdash; parametro per classificare l'efficienza dei modelli. La Cina, costretta dall'embargo sulle GPU a spremere ogni granello di caffè dalle macchine meno performanti, ne ha fatto una necessit&agrave; strategica: l'ARC Prize include gi&agrave; il costo per task nella sua leaderboard
     (<span class="fc">&#9749; ff.135.4 L'AGI avanza: il &ldquo;caff&egrave;&rdquo; cinese</span>).
-    Nel filo editoriale di Futuro Fortissimo c'&egrave; un punto fermo: l'AI non &egrave; solo una corsa a benchmark, &egrave; una riorganizzazione di lavoro e decisioni. Il punto non &egrave; prevedere tutto: &egrave; mantenere governabile l'accelerazione
+    L&rsquo;AI non &egrave; solo una corsa a benchmark: &egrave; una riorganizzazione di lavoro e decisioni. Il punto non &egrave; prevedere tutto, ma mantenere governabile l&rsquo;accelerazione
     (<span class="fc">🕳️ ff.129.1 La singolarit&agrave; gentile di Altman</span>).</p>
 
     <!-- ===== NEW 2026-03-24 — Esplosione cambriana e AI (ff.82.1) ===== -->
@@ -380,6 +380,511 @@ La terza vIA?</span>).</p>
 
     <!-- ===== 2.2 ===== -->
     </article>
+    
+    <!-- ===== Note del capitolo ===== -->
+    <section id="note-capitolo" class="mt-12 brutal-card accent-bar">
+      <h2 class="text-lg font-bold uppercase mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.12em;">Note del capitolo</h2>
+      <p class="text-sm text-zinc-500 mb-4">71 riferimenti in questa sezione. Clicca per navigare al paragrafo.</p>
+      <ol style="list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:0.5rem;">
+        <li id="nota-1" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🍫</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.139.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Svizzero? No, NVIDIA</span>
+          </a>
+        </li>
+        <li id="nota-2" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🧃</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.139.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Combini e paperclips</span>
+          </a>
+        </li>
+        <li id="nota-3" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🦉</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.36.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Il super-librozzo sulla singolarità</span>
+          </a>
+        </li>
+        <li id="nota-4" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💲</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.135.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">I costi dell'Intelligenza Artificiale</span>
+          </a>
+        </li>
+        <li id="nota-5" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌊</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.135.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Onda anomala energetica</span>
+          </a>
+        </li>
+        <li id="nota-6" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">☀️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.70</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Il sole: soluzione o morte?</span>
+          </a>
+        </li>
+        <li id="nota-7" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">♾️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.135.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Siamo nella singolarità?</span>
+          </a>
+        </li>
+        <li id="nota-8" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💡</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Mente artificiale e psichedelia</span>
+          </a>
+        </li>
+        <li id="nota-9" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🇨🇳</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.2.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Alibaba e l'alternativa efficiente</span>
+          </a>
+        </li>
+        <li id="nota-10" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">☕</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.135.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">L'AGI avanza: il &ldquo;caffè&rdquo; cinese</span>
+          </a>
+        </li>
+        <li id="nota-11" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🕳️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.129.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La singolarità gentile di Altman</span>
+          </a>
+        </li>
+        <li id="nota-12" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🦖</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.82.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Estinzione di massa?</span>
+          </a>
+        </li>
+        <li id="nota-13" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🗣️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.48.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Tutti parlano di ChatGPT</span>
+          </a>
+        </li>
+        <li id="nota-14" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">📈</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.88.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Una bolla finanziaria?</span>
+          </a>
+        </li>
+        <li id="nota-15" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🐔</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.82.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Polli computazionali</span>
+          </a>
+        </li>
+        <li id="nota-16" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🛠️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.123.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">L'AI con il coltellino svizzero</span>
+          </a>
+        </li>
+        <li id="nota-17" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🗣️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.134.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Parole, parole, parole&hellip;</span>
+          </a>
+        </li>
+        <li id="nota-18" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🤖</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.144.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Agenti autonomi e Moltbook</span>
+          </a>
+        </li>
+        <li id="nota-19" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🦾</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.3.6</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">L'integrazione corpo-computer</span>
+          </a>
+        </li>
+        <li id="nota-20" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🔎</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.83.5</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Capire il cervello con l'AI</span>
+          </a>
+        </li>
+        <li id="nota-21" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💎</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.123.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Minecraft oltre l'uomo</span>
+          </a>
+        </li>
+        <li id="nota-22" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🍓</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.103.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Prima di parlare, pensa</span>
+          </a>
+        </li>
+        <li id="nota-23" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🗺️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.123.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Il nuovo campione di GeoGuessr: o3</span>
+          </a>
+        </li>
+        <li id="nota-24" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">📜</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.67.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Due articoli</span>
+          </a>
+        </li>
+        <li id="nota-25" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🤖</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.88.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">ChatGPT controlla un robot</span>
+          </a>
+        </li>
+        <li id="nota-26" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">👀</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.88.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Dalle parole ai fatti</span>
+          </a>
+        </li>
+        <li id="nota-27" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🤖</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.37.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Tesla AI Day</span>
+          </a>
+        </li>
+        <li id="nota-28" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🤝</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.89</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Relazioni</span>
+          </a>
+        </li>
+        <li id="nota-29" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌵</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.37.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Finirà come Westworld?</span>
+          </a>
+        </li>
+        <li id="nota-30" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🧹</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.9.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Un WALL-E in real life</span>
+          </a>
+        </li>
+        <li id="nota-31" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💱</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.9.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">I robot ci ruberanno il lavoro?</span>
+          </a>
+        </li>
+        <li id="nota-32" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🦼</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.9.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Robot oltre la disabilità</span>
+          </a>
+        </li>
+        <li id="nota-33" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🔭</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.102.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Automatizzare la ricerca scientifica</span>
+          </a>
+        </li>
+        <li id="nota-34" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💊</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.53</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La cura ai tumori?</span>
+          </a>
+        </li>
+        <li id="nota-35" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🔬</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.46</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Elementale, Watson?</span>
+          </a>
+        </li>
+        <li id="nota-36" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🐍</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.115</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">L'anno del serpente</span>
+          </a>
+        </li>
+        <li id="nota-37" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🔎</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.114</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">MinIAture</span>
+          </a>
+        </li>
+        <li id="nota-38" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🤖</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.36.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Siamo già mischiati con l'AI?</span>
+          </a>
+        </li>
+        <li id="nota-39" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🤖</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.36.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Una bella chiaccherata</span>
+          </a>
+        </li>
+        <li id="nota-40" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🇨🇳</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.60.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">DriveGPT</span>
+          </a>
+        </li>
+        <li id="nota-41" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🐍</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.115.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Veleni esponenziali</span>
+          </a>
+        </li>
+        <li id="nota-42" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">☢️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.28.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Intelligenza artificiale per la fusione nucleare</span>
+          </a>
+        </li>
+        <li id="nota-43" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🐱</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.69.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Dal gatto di Schr&ouml;dinger ai qu-bit</span>
+          </a>
+        </li>
+        <li id="nota-44" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🍏</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.69.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La Apple quantistica?</span>
+          </a>
+        </li>
+        <li id="nota-45" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🍎</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.64.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Da Newton a Einstein</span>
+          </a>
+        </li>
+        <li id="nota-46" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🦊</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.98.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Sora luna, e il cantico delle creature a nove code</span>
+          </a>
+        </li>
+        <li id="nota-47" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🍫</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.139.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Dov&#39;è la mia macchina volante (in GTA 6)?</span>
+          </a>
+        </li>
+        <li id="nota-48" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🐰</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.48.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Steve Jobs e l'intervista a Playboy</span>
+          </a>
+        </li>
+        <li id="nota-49" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🛣️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.127.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La terza vIA?</span>
+          </a>
+        </li>
+        <li id="nota-50" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🥽</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.85.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Un nuovo &ldquo;iPhone moment&rdquo;?</span>
+          </a>
+        </li>
+        <li id="nota-51" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🅰️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.126.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">AlphaEvolve</span>
+          </a>
+        </li>
+        <li id="nota-52" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">📚</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.144.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Aragoste in letteratura e AI</span>
+          </a>
+        </li>
+        <li id="nota-53" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🐒</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.36.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Esempi di superintelligenza?</span>
+          </a>
+        </li>
+        <li id="nota-54" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🥧</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.129.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Pi-greco, FigureAI e 1 ora logistica</span>
+          </a>
+        </li>
+        <li id="nota-55" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🦞</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.144.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">OpenClaw e il pensionato dei PDF</span>
+          </a>
+        </li>
+        <li id="nota-56" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🖱</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.106.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">AI col mouse</span>
+          </a>
+        </li>
+        <li id="nota-57" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🎮</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.37.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Non provi NVIDIA?</span>
+          </a>
+        </li>
+        <li id="nota-58" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🏓</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.105.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Neuroni che giocano a Pong</span>
+          </a>
+        </li>
+        <li id="nota-59" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🛠️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.140.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Vibe coding in un weekend</span>
+          </a>
+        </li>
+        <li id="nota-60" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🦖</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.4.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Mammut resuscitati dall'estinzione</span>
+          </a>
+        </li>
+        <li id="nota-61" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🏙️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.2.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Un modello &ldquo;grande&rdquo; come New York</span>
+          </a>
+        </li>
+        <li id="nota-62" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🧙</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.63.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Harry Potter tra Pixar, steroidi e rave estivi</span>
+          </a>
+        </li>
+        <li id="nota-63" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💸</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.112.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">5 anni per fare soldi</span>
+          </a>
+        </li>
+        <li id="nota-64" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💃</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.129.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Il valzer di Tesla</span>
+          </a>
+        </li>
+        <li id="nota-65" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🆕</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.60.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">I taxi di Tesla</span>
+          </a>
+        </li>
+        <li id="nota-66" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">👁️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.12.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Coscienza e intelligenza</span>
+          </a>
+        </li>
+        <li id="nota-67" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">⚡</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.75.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Tesmed alla testa</span>
+          </a>
+        </li>
+        <li id="nota-68" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🐕</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.106.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Vita da cani</span>
+          </a>
+        </li>
+        <li id="nota-69" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🏆</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.47.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Serpenti marini digitali</span>
+          </a>
+        </li>
+        <li id="nota-70" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🩸</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.102.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Dal sangue ad Amazon</span>
+          </a>
+        </li>
+        <li id="nota-71" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌱</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.109.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Dai media al digital wellbeing</span>
+          </a>
+        </li>
+      </ol>
+    </section>
 
     <!-- Navigation -->
     <nav class="mt-10 mb-8" aria-label="Navigazione sezioni">

--- a/book/chapter-03-alimentazione.html
+++ b/book/chapter-03-alimentazione.html
@@ -137,7 +137,7 @@
 
     <h3 id="s2-2" class="text-lg sm:text-xl font-bold mt-10 mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.02em;text-transform:uppercase;">3.2.2 &mdash; Flow e limiti estremi</h3>
 
-    <p>Nel corpus sportivo emerge anche un principio di progettazione personale: <mark class="note-highlight">la continuit&agrave; batte l'eroismo</mark>. Sessioni brevi ma frequenti, routine condivise e feedback semplici (passi, respiro, recupero) creano aderenza nel lungo periodo molto pi&ugrave; dei picchi motivazionali. &Egrave; la stessa logica del training: piccoli carichi sostenibili, ripetuti, che nel tempo diventano trasformazione (<span class="fc">&#127939; ff.86.1
+    <p>C&rsquo;&egrave; un principio di progettazione personale che attraversa tutti questi dati: <mark class="note-highlight">la continuit&agrave; batte l'eroismo</mark>. Sessioni brevi ma frequenti, routine condivise e feedback semplici (passi, respiro, recupero) creano aderenza nel lungo periodo molto pi&ugrave; dei picchi motivazionali. &Egrave; la stessa logica del training: piccoli carichi sostenibili, ripetuti, che nel tempo diventano trasformazione (<span class="fc">&#127939; ff.86.1
     Se non ti muovi, muori</span>; <span class="fc">&#127942; ff.133
     Sono un Ironman?</span>).
     Ma c'&egrave; un livello successivo, dove il carico smette di essere sostenibile e diventa estremo &mdash; e proprio l&igrave; il flow raggiunge la sua forma pi&ugrave; pura. Steven Kotler, in <em>The Rise of Superman</em>, documenta come negli sport estremi la possibilit&agrave; concreta di morire renda il flow non un optional ma una condizione di sopravvivenza: dagli scacchi alle pareti della Patagonia, la posta in gioco calibra la concentrazione
@@ -232,6 +232,168 @@
     <div class="sep"></div>
 
     </article>
+    
+    <!-- ===== Note del capitolo ===== -->
+    <section id="note-capitolo" class="mt-12 brutal-card accent-bar">
+      <h2 class="text-lg font-bold uppercase mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.12em;">Note del capitolo</h2>
+      <p class="text-sm text-zinc-500 mb-4">22 riferimenti in questa sezione. Clicca per navigare al paragrafo.</p>
+      <ol style="list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:0.5rem;">
+        <li id="nota-1" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🏃</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.86.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Se non ti muovi, muori</span>
+          </a>
+        </li>
+        <li id="nota-2" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💨</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.86.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Misurare l'ossigeno bruciato</span>
+          </a>
+        </li>
+        <li id="nota-3" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">⏱</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.35</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Sto bene, sono Super Sapiens</span>
+          </a>
+        </li>
+        <li id="nota-4" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">📈</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.86.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Report Strava 2023</span>
+          </a>
+        </li>
+        <li id="nota-5" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🏋</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.17</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Sport e chi ne fa le feci</span>
+          </a>
+        </li>
+        <li id="nota-6" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🏃</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.17.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Il report del 2021 di Strava</span>
+          </a>
+        </li>
+        <li id="nota-7" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🤞</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.53.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Meno morti per il cancro</span>
+          </a>
+        </li>
+        <li id="nota-8" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🥗</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.120.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Dieta o esercizio?</span>
+          </a>
+        </li>
+        <li id="nota-9" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🏆</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.133</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Sono un Ironman?</span>
+          </a>
+        </li>
+        <li id="nota-10" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">♟️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.122.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Dagli scacchi alla Patagonia</span>
+          </a>
+        </li>
+        <li id="nota-11" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🔺</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.122.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Piramidi in 4 minuti?</span>
+          </a>
+        </li>
+        <li id="nota-12" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🕸️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.17.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Social network positivi?</span>
+          </a>
+        </li>
+        <li id="nota-13" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🔱</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.57.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Tra miti greci, filosofia e nuove religioni</span>
+          </a>
+        </li>
+        <li id="nota-14" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🧠</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.120.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Lattato al cervello?</span>
+          </a>
+        </li>
+        <li id="nota-15" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">❤️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.120.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Questioni di cuore</span>
+          </a>
+        </li>
+        <li id="nota-16" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🍬</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.145.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Caramelle e sconosciuti</span>
+          </a>
+        </li>
+        <li id="nota-17" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🧠</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.128</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La mente ci limita?</span>
+          </a>
+        </li>
+        <li id="nota-18" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🩺</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.57</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Il medico mi ha prescritto una maratona</span>
+          </a>
+        </li>
+        <li id="nota-19" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🤰</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.94.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Come rimanere incinta?</span>
+          </a>
+        </li>
+        <li id="nota-20" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌀</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.87.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Breve storia del respiro</span>
+          </a>
+        </li>
+        <li id="nota-21" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💤</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.47</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Russa? No problem!</span>
+          </a>
+        </li>
+        <li id="nota-22" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s2-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌄</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.22</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Dieta circadiana?</span>
+          </a>
+        </li>
+      </ol>
+    </section>
 
     <!-- Navigation -->
     <nav class="mt-10 mb-8" aria-label="Navigazione sezioni">

--- a/book/chapter-03-cultura.html
+++ b/book/chapter-03-cultura.html
@@ -400,7 +400,7 @@
     (<span class="fc">&#128084; ff.9.3
     L&apos;ottimismo vola (con il reddito di cittadinanza)</span>).</p>
 
-    <p>Se c&apos;&egrave; una sintesi utile del capitolo Societ&agrave;, &egrave; questa: <mark class="note-highlight">la qualit&agrave; della vita collettiva dipende da come gestiamo l&apos;attenzione prima ancora che dall&apos;opinione che esprimiamo</mark>. L&apos;economia digitale premia reazioni rapide, ma le comunit&agrave; reggono su processi lenti: ascolto, fiducia, continuit&agrave;. Nel corpus torna spesso questa frizione tra velocit&agrave; e significato: quando trasformiamo ogni giornata in una gara di notifiche, aumentiamo produttivit&agrave; apparente e riduciamo utilit&agrave; percepita; quando invece costruiamo routine minime, relazioni affidabili e spazi di recupero mentale, la stessa quantit&agrave; di lavoro produce meno ansia e pi&ugrave; impatto. Non &egrave; una nostalgia anti-tech, &egrave; una questione di architettura sociale. <mark class="note-highlight">Una societ&agrave; non si misura dal numero di strumenti intelligenti che possiede, ma da quanta dignit&agrave; riesce a mantenere nelle sue interazioni quotidiane</mark>: cura, reciprocit&agrave;, responsabilit&agrave; condivisa. Anche la cosiddetta moral ambition diventa concreta solo qui: nel passaggio dal commento all&apos;azione, dal branding personale al contributo reale per qualcun altro. In pratica, il futuro sociale non si gioca nell&apos;ultimo trend, ma nella capacit&agrave; di progettare ambienti in cui attenzione, salute mentale e legami umani non siano costi collaterali del progresso, bens&igrave; il suo criterio di qualit&agrave;.</p>
+    <p><mark class="note-highlight">La qualit&agrave; della vita collettiva dipende da come gestiamo l&rsquo;attenzione prima ancora che dall&rsquo;opinione che esprimiamo</mark>. L&rsquo;economia digitale premia reazioni rapide, ma le comunit&agrave; reggono su processi lenti: ascolto, fiducia, continuit&agrave;. La frizione tra velocit&agrave; e significato &egrave; ovunque: quando trasformiamo ogni giornata in una gara di notifiche, aumentiamo produttivit&agrave; apparente e riduciamo utilit&agrave; percepita; quando invece costruiamo routine minime, relazioni affidabili e spazi di recupero mentale, la stessa quantit&agrave; di lavoro produce meno ansia e pi&ugrave; impatto. Non &egrave; una nostalgia anti-tech, &egrave; una questione di architettura sociale. <mark class="note-highlight">Una societ&agrave; non si misura dal numero di strumenti intelligenti che possiede, ma da quanta dignit&agrave; riesce a mantenere nelle sue interazioni quotidiane</mark>: cura, reciprocit&agrave;, responsabilit&agrave; condivisa. Anche la cosiddetta moral ambition diventa concreta solo qui: nel passaggio dal commento all&apos;azione, dal branding personale al contributo reale per qualcun altro. In pratica, il futuro sociale non si gioca nell&apos;ultimo trend, ma nella capacit&agrave; di progettare ambienti in cui attenzione, salute mentale e legami umani non siano costi collaterali del progresso, bens&igrave; il suo criterio di qualit&agrave;.</p>
 
     <!-- ===== NEW — metaverso numeri, Giappone kawaii/otaku, uteri in vetro ===== -->
     <p>La trasformazione culturale pi&ugrave; profonda non riguarda cosa facciamo, ma dove esistiamo. <mark class="note-highlight">ARK Invest stima che nel 2010 il novanta per cento del nostro tempo fosse ancorato alla vita fisica</mark>; entro il 2030 la bilancia si capovolger&agrave;, con le ore digitali che supereranno quelle analogiche. Il metaverso &mdash; parola ormai logora ma economia reale &mdash; &egrave; passato da 500 milioni di dollari di ricavi nel 2020 a <mark class="note-highlight">800 milioni nel 2024, con una crescita annua del 13,1%</mark>; se l&rsquo;infrastruttura completa si materializzasse, potrebbe valere 2,5 trilioni di dollari su un PIL globale di 150 trilioni. Numeri che suonano astratti finch&eacute; non li si confronta con il PIL dell&rsquo;Italia intera
@@ -428,6 +428,455 @@
         <a href="https://fortissimo.substack.com/subscribe" target="_blank" rel="noopener" class="cta-btn">Iscriviti gratis &rarr;</a>
     </section>
     </article>
+    
+    <!-- ===== Note del capitolo ===== -->
+    <section id="note-capitolo" class="mt-12 brutal-card accent-bar">
+      <h2 class="text-lg font-bold uppercase mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.12em;">Note del capitolo</h2>
+      <p class="text-sm text-zinc-500 mb-4">63 riferimenti in questa sezione. Clicca per navigare al paragrafo.</p>
+      <ol style="list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:0.5rem;">
+        <li id="nota-1" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💥</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.62.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Il cambio di paradigma</span>
+          </a>
+        </li>
+        <li id="nota-2" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💰</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.62.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La tassa sulla miseria</span>
+          </a>
+        </li>
+        <li id="nota-3" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🔧</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.21.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La magia dell'insalata a domicilio e della Bic</span>
+          </a>
+        </li>
+        <li id="nota-4" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💎</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.62.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Maslow nel 2024</span>
+          </a>
+        </li>
+        <li id="nota-5" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🔮</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.89.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Piramide di Maslow 2.0</span>
+          </a>
+        </li>
+        <li id="nota-6" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌱</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.55</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Sopravvivere alla rivoluzione</span>
+          </a>
+        </li>
+        <li id="nota-7" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">📉</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.111.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Una vita spericolata</span>
+          </a>
+        </li>
+        <li id="nota-8" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">📈</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.111.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Esperienze = investimenti</span>
+          </a>
+        </li>
+        <li id="nota-9" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">⏳</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.44.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">L'infinitudine là fuori</span>
+          </a>
+        </li>
+        <li id="nota-10" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">✅</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.44.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La fallacia del tempo a contenitori</span>
+          </a>
+        </li>
+        <li id="nota-11" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🥋</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.62.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Uscire dalla via maestra</span>
+          </a>
+        </li>
+        <li id="nota-12" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🪣</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.108.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Quale è il vostro Perfect Day?</span>
+          </a>
+        </li>
+        <li id="nota-13" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🧱</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.5.5</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Il muro di Marchetti</span>
+          </a>
+        </li>
+        <li id="nota-14" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🏠</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.44.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Stabilirsi stabilizza</span>
+          </a>
+        </li>
+        <li id="nota-15" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">📈</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.13.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Una crescita infinita?</span>
+          </a>
+        </li>
+        <li id="nota-16" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🇳🇬</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.13.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La Nigeria esploderà?</span>
+          </a>
+        </li>
+        <li id="nota-17" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🤝</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.97.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">L'epidemia silenziosa</span>
+          </a>
+        </li>
+        <li id="nota-18" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">👫</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.29</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Viva la mamma!</span>
+          </a>
+        </li>
+        <li id="nota-19" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💍</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.23</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Matrimoni privatizzati</span>
+          </a>
+        </li>
+        <li id="nota-20" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">👰</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.23.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Matrimonio privatizzato?</span>
+          </a>
+        </li>
+        <li id="nota-21" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🔮</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.74.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Il nostro futuro?</span>
+          </a>
+        </li>
+        <li id="nota-22" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">👵🏻</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.77.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La famiglia tradizionale è passato?</span>
+          </a>
+        </li>
+        <li id="nota-23" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌬️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.23.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Le relazioni negli ultimi 100 anni</span>
+          </a>
+        </li>
+        <li id="nota-24" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">⛪</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.77.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Una questione di valori?</span>
+          </a>
+        </li>
+        <li id="nota-25" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🤔</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.50.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La stranezza degli ultimi 50 anni</span>
+          </a>
+        </li>
+        <li id="nota-26" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🇺🇸</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.125.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Cicli imperiali</span>
+          </a>
+        </li>
+        <li id="nota-27" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💵</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.125.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Stabilizzare il dollaro</span>
+          </a>
+        </li>
+        <li id="nota-28" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🏮</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.125.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Cina: il prossimo impero mondiale?</span>
+          </a>
+        </li>
+        <li id="nota-29" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">⚔️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.14</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La guerra non è futuro</span>
+          </a>
+        </li>
+        <li id="nota-30" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💰</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.38</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Soldi spartiti male</span>
+          </a>
+        </li>
+        <li id="nota-31" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">📈</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.14.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Nostradamus: Ray Dalio e l'ordine mondiale</span>
+          </a>
+        </li>
+        <li id="nota-32" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌐</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.42.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Un nuovo ordine globale?</span>
+          </a>
+        </li>
+        <li id="nota-33" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🧠</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.103.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La nuova Era dell'Intelligenza</span>
+          </a>
+        </li>
+        <li id="nota-34" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🎧</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.131.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Tre ascolti</span>
+          </a>
+        </li>
+        <li id="nota-35" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">📖</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.131.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Quattro riflessioni</span>
+          </a>
+        </li>
+        <li id="nota-36" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">☀</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.10.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Soldi fusi</span>
+          </a>
+        </li>
+        <li id="nota-37" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🧠</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.12.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Cervelli in fuga</span>
+          </a>
+        </li>
+        <li id="nota-38" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🕊️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.106.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Nexus e Harari</span>
+          </a>
+        </li>
+        <li id="nota-39" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🎨</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.18.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">L'arte tra intelligenza artificiale e l'uomo</span>
+          </a>
+        </li>
+        <li id="nota-40" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🖼️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.18.5</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Dipinti ricreati dall'AI</span>
+          </a>
+        </li>
+        <li id="nota-41" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🎸</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.127.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Rock 'n' roll e vibe coding</span>
+          </a>
+        </li>
+        <li id="nota-42" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🎨</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.2.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Avete trovato l'opera d'arte col vostro cane/gatto?</span>
+          </a>
+        </li>
+        <li id="nota-43" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🎨</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.108.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">L'arte nei cessi</span>
+          </a>
+        </li>
+        <li id="nota-44" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🚁</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.127.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">E Palantir che c'entra?</span>
+          </a>
+        </li>
+        <li id="nota-45" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">⛱</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.102.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Il futuro non va in vacanza</span>
+          </a>
+        </li>
+        <li id="nota-46" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💌</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.89</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Meno Tinder, più relazioni</span>
+          </a>
+        </li>
+        <li id="nota-47" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🐶</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.12.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Homo Sapiens vs Neanderthal</span>
+          </a>
+        </li>
+        <li id="nota-48" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">📺</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.8.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Cosa ci guardiamo stasera?</span>
+          </a>
+        </li>
+        <li id="nota-49" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🔒</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.52.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Un mondo criptico</span>
+          </a>
+        </li>
+        <li id="nota-50" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🐦</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.14.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Uccellini del ben augurio?</span>
+          </a>
+        </li>
+        <li id="nota-51" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">📚</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.127.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Leopardi e l'equazione di Schr&ouml;dinger</span>
+          </a>
+        </li>
+        <li id="nota-52" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🧭</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.108</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Inno alla routine</span>
+          </a>
+        </li>
+        <li id="nota-53" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🏄</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.121</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Il flow ti mette le ali</span>
+          </a>
+        </li>
+        <li id="nota-54" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🍷</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.8.6</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Bere e dimenticare</span>
+          </a>
+        </li>
+        <li id="nota-55" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">👁️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.38.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La cripto valuta per ridurre le disuguaglianze</span>
+          </a>
+        </li>
+        <li id="nota-56" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🤑</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.77.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">O di soldi?</span>
+          </a>
+        </li>
+        <li id="nota-57" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌐</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.1.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Sensibilizzazione e arte</span>
+          </a>
+        </li>
+        <li id="nota-58" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🙅</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.112.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Non possiamo prevedere nulla</span>
+          </a>
+        </li>
+        <li id="nota-59" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">👔</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.9.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">L&apos;ottimismo vola (con il reddito di cittadinanza)</span>
+          </a>
+        </li>
+        <li id="nota-60" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🔢</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.15.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Diamo i numeri!</span>
+          </a>
+        </li>
+        <li id="nota-61" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">📙</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.74.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Breve dizionario culturale</span>
+          </a>
+        </li>
+        <li id="nota-62" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🧫</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.29.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Maternità non convenzionali: uteri in vetro</span>
+          </a>
+        </li>
+        <li id="nota-63" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s3-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🏃🏻</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.68.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Sempre più veloci</span>
+          </a>
+        </li>
+      </ol>
+    </section>
 
     <!-- Navigation -->
     <nav class="mt-10 mb-8" aria-label="Navigazione sezioni">

--- a/book/chapter-03-psicologia.html
+++ b/book/chapter-03-psicologia.html
@@ -149,7 +149,9 @@
     Ammazzare il tempo</span>).</p>
 
     <!-- ===== inject 2026-03-30 — note_id:1279 — YouGov: anni migliori ===== -->
-    <p>C&rsquo;&egrave; per&ograve; un dato che ribalta la malinconia del tempo perduto. Un sondaggio YouGov rivela che ogni fascia d&rsquo;et&agrave; considera i propri anni attuali come i migliori. Il 52% delle donne e il 39% degli uomini colloca il meglio dopo i trenta. Non si tratta forse di ottimismo ingenuo, ma di un meccanismo pi&ugrave; profondo: chi sopravvive a un decennio tende a rivalutarlo, e chi lo sta vivendo non ha ancora accumulato abbastanza rimpianti per sminuirlo.</p>
+    <p>C&rsquo;&egrave; per&ograve; un dato che ribalta la malinconia del tempo perduto. Un sondaggio YouGov rivela che ogni fascia d&rsquo;et&agrave; considera i propri anni attuali come i migliori. <mark class="note-highlight">Il 52% delle donne e il 39% degli uomini colloca il meglio dopo i trenta</mark>. Non si tratta di ottimismo ingenuo, ma di un meccanismo pi&ugrave; profondo: chi sopravvive a un decennio tende a rivalutarlo, e chi lo sta vivendo non ha ancora accumulato abbastanza rimpianti per sminuirlo
+    (<span class="fc">&#128202; note 1279
+    YouGov: gli anni migliori</span>).</p>
 
     <!-- ===== NEW 2026-03-26 — Sprecare 3 ore davanti a un quadro (ff.44.4) ===== -->
     <p>Burkeman non si limita alla teoria: porta un esempio che &egrave; anche un esercizio. <a href="https://projects.iq.harvard.edu/files/whenartmakesmusic/files/2_roberts_harvard_art_historian_jennifer_roberts_teaches_the_value_of_immersive_attention_harvard_magazine.pdf" target="_blank" rel="noopener" style="font-size:0.92rem;font-weight:600;color:var(--accent);text-decoration:none;"><em class="note-highlight">Jennifer Roberts, insegnante di storia dell'arte ad Harvard, assegna ogni anno ai suoi studenti un compito radicale: fissare un quadro per tre ore</em></a>. Non analizzarlo, non descriverlo: guardarlo. Il messaggio &egrave; che la continua ricerca di nuovi stimoli e l'ottimizzazione compulsiva del tempo sono modi per sottrarci all'ansia dello stare fermi &mdash; per non pensare alla nostra essenza, alla nostra finitudine, alla nostra mortalit&agrave;. Certe forme d'arte impongono vincoli temporali al pubblico in modo piuttosto ovvio: un'esibizione dal vivo de <em>Le nozze di Figaro</em> o una proiezione di <em>Lawrence d'Arabia</em> non lasciano altra scelta che dedicare all'opera il proprio tempo. Eppure sempre pi&ugrave; spesso capita il contrario: lasciare un film a met&agrave;, catturati dall'ansia di fare altro, promettendosi &ldquo;lo finir&ograve; dopo&rdquo; &mdash; un &ldquo;dopo&rdquo; che non arriva mai
@@ -388,6 +390,392 @@
     <div class="sep"></div>
 
     </article>
+    
+    <!-- ===== Note del capitolo ===== -->
+    <section id="note-capitolo" class="mt-12 brutal-card accent-bar">
+      <h2 class="text-lg font-bold uppercase mb-4" style="font-family:'IBM Plex Mono',monospace;letter-spacing:0.12em;">Note del capitolo</h2>
+      <p class="text-sm text-zinc-500 mb-4">54 riferimenti in questa sezione. Clicca per navigare al paragrafo.</p>
+      <ol style="list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:0.5rem;">
+        <li id="nota-1" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💬</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.134.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Parole, parole, parole</span>
+          </a>
+        </li>
+        <li id="nota-2" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💬</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.134.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Dare un nome alle emozioni</span>
+          </a>
+        </li>
+        <li id="nota-3" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🦴</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.134.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Umanità all'osso</span>
+          </a>
+        </li>
+        <li id="nota-4" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💫</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.121.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Le basi del flow</span>
+          </a>
+        </li>
+        <li id="nota-5" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💫</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.121.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Il flow ti mette le ali</span>
+          </a>
+        </li>
+        <li id="nota-6" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-1" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🔺</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.122.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Piramidi in 4 minuti?</span>
+          </a>
+        </li>
+        <li id="nota-7" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">😱</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.44</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Che ansia!</span>
+          </a>
+        </li>
+        <li id="nota-8" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🏔</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.137.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Orografia di una discesa</span>
+          </a>
+        </li>
+        <li id="nota-9" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💎</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.137.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Cristalli e Bach</span>
+          </a>
+        </li>
+        <li id="nota-10" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">✏️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.67.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Quattro riflessioni</span>
+          </a>
+        </li>
+        <li id="nota-11" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">⌛</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.8.7</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Ammazzare il tempo</span>
+          </a>
+        </li>
+        <li id="nota-12" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">📊</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">note 1279</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">YouGov: gli anni migliori</span>
+          </a>
+        </li>
+        <li id="nota-13" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🖼</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.44.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Sprecare 3 ore davanti a un quadro</span>
+          </a>
+        </li>
+        <li id="nota-14" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🛡</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.111.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Figli, salute e anni sprecati</span>
+          </a>
+        </li>
+        <li id="nota-15" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🏆</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.137.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Picchi entropici</span>
+          </a>
+        </li>
+        <li id="nota-16" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-2" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">⏱</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.65.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Una vita in vacanza</span>
+          </a>
+        </li>
+        <li id="nota-17" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌎</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.118.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Il Mondo Nuovo</span>
+          </a>
+        </li>
+        <li id="nota-18" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌶️</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.118.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Paprika - Sognando un sogno &#12497;&#12503;&#12522;&#12459; (2006)</span>
+          </a>
+        </li>
+        <li id="nota-19" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌳</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.118.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La cura: albero e silenzi?</span>
+          </a>
+        </li>
+        <li id="nota-20" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🏆</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.117.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Giornate da Oscar</span>
+          </a>
+        </li>
+        <li id="nota-21" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🍩</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.117.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Ciambelle atomiche</span>
+          </a>
+        </li>
+        <li id="nota-22" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">📚</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.72.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Se la biblioteca di Alessandria avesse 100 libri</span>
+          </a>
+        </li>
+        <li id="nota-23" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🔗</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.64.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Solo link che connettono informazioni?</span>
+          </a>
+        </li>
+        <li id="nota-24" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🎯</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.132.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Crisi dell'attenzione?</span>
+          </a>
+        </li>
+        <li id="nota-25" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">😰</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.141.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Sentirsi inutili nell'era AI</span>
+          </a>
+        </li>
+        <li id="nota-26" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🤑</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.73.6</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Una nuova fase per il capitalismo</span>
+          </a>
+        </li>
+        <li id="nota-27" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🍄</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.2.5</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Psichedelia portami via</span>
+          </a>
+        </li>
+        <li id="nota-28" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🍄</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.2.6</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Psichedelia portami via (parte 2)</span>
+          </a>
+        </li>
+        <li id="nota-29" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-3" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🎵</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.7.5</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Spotify Wrapped</span>
+          </a>
+        </li>
+        <li id="nota-30" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">😤</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.90</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">L'epidemia di stress</span>
+          </a>
+        </li>
+        <li id="nota-31" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">😶</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.41</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Non ho parole</span>
+          </a>
+        </li>
+        <li id="nota-32" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💊</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.49.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Il superuomo che prende 100 pillole al giorno</span>
+          </a>
+        </li>
+        <li id="nota-33" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">⚡</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.75</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Massaggi al cervello</span>
+          </a>
+        </li>
+        <li id="nota-34" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🕒</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.108.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Quale è il vostro Perfect Day?</span>
+          </a>
+        </li>
+        <li id="nota-35" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌎</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.142.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Il viaggio come ricalibrazione</span>
+          </a>
+        </li>
+        <li id="nota-36" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">👶</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.108.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Con gli occhi del fanciullino</span>
+          </a>
+        </li>
+        <li id="nota-37" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">😲</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.18.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">L'importanza di staccare il cervello</span>
+          </a>
+        </li>
+        <li id="nota-38" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">👨‍🏫</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.78.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Scuola di vita?</span>
+          </a>
+        </li>
+        <li id="nota-39" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">👩</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.109.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La donna più influente di LinkedIn</span>
+          </a>
+        </li>
+        <li id="nota-40" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">💲</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.109.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Elemosina dall'AI</span>
+          </a>
+        </li>
+        <li id="nota-41" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🧶</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.109.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Sbrigliare un gomitolo in un minuto</span>
+          </a>
+        </li>
+        <li id="nota-42" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">👥</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.78.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">L'ombra di Stutz</span>
+          </a>
+        </li>
+        <li id="nota-43" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌿</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.68.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Meno ego e controllo, più flow e presente: la cura di Naval</span>
+          </a>
+        </li>
+        <li id="nota-44" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🤝</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.97.2</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">La carestia del contatto</span>
+          </a>
+        </li>
+        <li id="nota-45" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">✏</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.141.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Done-List e compiti per le vacanze</span>
+          </a>
+        </li>
+        <li id="nota-46" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🐆</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.7.7</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Bisognano, signore?</span>
+          </a>
+        </li>
+        <li id="nota-47" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">1️⃣</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.77.5</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">O una scelta individualistica?</span>
+          </a>
+        </li>
+        <li id="nota-48" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">👰</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.13.3</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Trend relazionali</span>
+          </a>
+        </li>
+        <li id="nota-49" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🏙</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.34.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Sempre più cittadini</span>
+          </a>
+        </li>
+        <li id="nota-50" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🚧</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.110.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Tutte le strade portano alle buche di Roma</span>
+          </a>
+        </li>
+        <li id="nota-51" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🌎</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.142.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Siamo noi gli alieni</span>
+          </a>
+        </li>
+        <li id="nota-52" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">👨&zwj;💻</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.117.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Liberarci dalla simulazione degli algoritmi?</span>
+          </a>
+        </li>
+        <li id="nota-53" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">📺</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.8.1</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">Il tramonto della TV notturna</span>
+          </a>
+        </li>
+        <li id="nota-54" style="border-left:3px solid var(--accent);padding:6px 12px;transition:background 0.2s;">
+          <a href="#s1-4" style="text-decoration:none;color:inherit;display:block;">
+            <span style="font-size:1.1em;">🤖</span>
+            <strong style="font-family:'IBM Plex Mono',monospace;font-size:0.82rem;color:var(--accent);">ff.127.4</strong>
+            <span style="font-size:0.88rem;color:#444;margin-left:4px;">L'aristocrazia delle macchine</span>
+          </a>
+        </li>
+      </ol>
+    </section>
 
     <!-- Navigation -->
     <nav class="mt-10 mb-8" aria-label="Navigazione sezioni">

--- a/book/index.html
+++ b/book/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Libro — Tre Macro Temi | Futuro Fortissimo</title>
-  <meta name="description" content="Tre saggi su Natura, Tecnologia e Societ&agrave; con 421 fonti dal corpus di Futuro Fortissimo." />
+  <meta name="description" content="Tre saggi su Natura, Tecnologia e Societ&agrave; con 451 fonti dal corpus di Futuro Fortissimo." />
 
   <link rel="canonical" href="https://futurofortissimo.github.io/book/" />
 
@@ -465,7 +465,7 @@
     <!-- Download CTA -->
     <div class="book-cta" id="bookCta">
       <div class="book-cta__headline">Scarica il libro gratuitamente</div>
-      <p class="book-cta__sub">Inserisci la tua email per ricevere il link di download. Tre saggi, 421 fonti, 50k parole.</p>
+      <p class="book-cta__sub">Inserisci la tua email per ricevere il link di download. Tre saggi, 451 fonti, 50k parole.</p>
       <form class="book-cta__form" id="bookDownloadForm" action="https://formsubmit.co/ajax/michelemerelli.8@gmail.com" method="POST">
         <input type="hidden" name="_subject" value="FF Libro — Nuovo download richiesto">
         <input type="hidden" name="_template" value="table">
@@ -630,7 +630,7 @@
         </ul>
         <div class="mt-4 flex items-center justify-between gap-3">
           <a class="ff-button underline" data-track="chapter_open" href="/book/chapter-01.html">Leggi capitolo &rarr;</a>
-          <div class="ff-caption" style="color: #888;">140 refs · ~77 min · 19.4k parole</div>
+          <div class="ff-caption" style="color: #888;">149 refs · ~86 min · 21k parole</div>
         </div>
       </article>
 
@@ -672,7 +672,7 @@
         </ul>
         <div class="mt-4 flex items-center justify-between gap-3">
           <a class="ff-button underline" data-track="chapter_open" href="/book/chapter-02.html">Leggi capitolo &rarr;</a>
-          <div class="ff-caption" style="color: #888;">141 refs · ~63 min · 15.9k parole</div>
+          <div class="ff-caption" style="color: #888;">151 refs · ~72 min · 17.6k parole</div>
         </div>
       </article>
 
@@ -714,7 +714,7 @@
         </ul>
         <div class="mt-4 flex items-center justify-between gap-3">
           <a class="ff-button underline" data-track="chapter_open" href="/book/chapter-03.html">Leggi capitolo &rarr;</a>
-          <div class="ff-caption" style="color: #888;">140 refs · ~60 min · 15.2k parole</div>
+          <div class="ff-caption" style="color: #888;">151 refs · ~70 min · 17.3k parole</div>
         </div>
       </article>
 
@@ -732,7 +732,7 @@
     <!-- Footer note -->
     <section class="mt-6 brutal-card" style="border-color:#ddd;box-shadow:none;">
       <h2 class="text-base font-bold uppercase">Come leggere</h2>
-      <p class="ff-body-sm mt-3" style="color: #333;">Ogni capitolo intreccia le note del corpus di Futuro Fortissimo (421 riferimenti in totale), trovando connessioni nascoste tra i temi. Le citazioni inline (<strong>ff.x.y</strong>) rimandano direttamente alle fonti originali nell'archivio. I capitoli includono immagini dal corpus e citazioni dirette collegate alle note originali.</p>
+      <p class="ff-body-sm mt-3" style="color: #333;">Ogni capitolo intreccia le note del corpus di Futuro Fortissimo (451 riferimenti in totale), trovando connessioni nascoste tra i temi. Le citazioni inline (<strong>ff.x.y</strong>) rimandano direttamente alle fonti originali nell'archivio. I capitoli includono immagini dal corpus e citazioni dirette collegate alle note originali.</p>
     </section>
 
   </main>


### PR DESCRIPTION
## Summary

- **Bibliography rebuilt as INTERNAL navigation** — all 9 subchapter pages now have "Note del capitolo" sections where each entry links to the `#section` anchor (NOT external URLs). Click = navigate to the paragraph.
- **7 meta-commentary instances removed** — "nel corpus emerge", "nel filo editoriale di Futuro Fortissimo", etc. across 6 files
- **YouGov paragraph fixed** — added missing `<mark>` highlights + fc citation
- **False Alarm link** — converted from old-style parenthetical to inline
- **Stats refreshed** — 451 total refs, all overview pages + index updated
- **build-bibliography.cjs** — reusable script to rebuild internal bibliographies

## What the bibliography looks like now

Each subchapter page has:
```
Note del capitolo
15 riferimenti in questa sezione. Clicca per navigare al paragrafo.
🏎 ff.138.1 — La strada più veloce        → #s1-1
😊 ff.138.2 — La strada più felice        → #s1-1
🏙 ff.34 — Ripensare le città             → #s1-1
...
```

Clicking navigates to the section anchor. External links are ONLY in the main prose.

## Test plan
- [ ] Click any bibliography entry → scrolls to correct section
- [ ] No "nel corpus" text remains in any file
- [ ] Stats match in index.html and overview pages
- [ ] YouGov paragraph has highlight marks + fc citation

🤖 Generated with [Claude Code](https://claude.com/claude-code)