### PR TITLE
feat: hamburger nav menu with full chapter tree + search

### DIFF
--- a/book/chapter-ui.js
+++ b/book/chapter-ui.js
@@ -1,343 +1,387 @@
 /**
- * chapter-ui.js — Shared UI enhancements for FF book chapters
- * Features: side panel navigation, sticky search, bibliography back-links
+ * chapter-ui.js — Shared UI for FF book subchapter pages
+ * Features: full book navigation, in-page search with highlight, bibliography back-links
  * Self-contained: injects its own CSS, no external dependencies
  */
 (function () {
   'use strict';
-
-  // Idempotency guard
   if (window.__ffChapterUI) return;
   window.__ffChapterUI = true;
 
-  // ─── CSS injection ───────────────────────────────────────────────
-  var css = [
-    /* Side panel */
-    '.ff-side-panel{position:fixed;top:0;left:0;width:280px;height:100vh;background:rgba(10,10,10,0.96);color:#fff;transform:translateX(-100%);transition:transform .3s ease;z-index:50;overflow-y:auto;padding:1.5rem;box-sizing:border-box}',
-    '.ff-side-panel.is-open{transform:translateX(0)}',
-    '.ff-side-panel__close{position:absolute;top:12px;right:14px;background:none;border:none;color:rgba(255,255,255,0.6);font-size:1.3rem;cursor:pointer;padding:4px 8px;line-height:1;transition:color .15s}',
-    '.ff-side-panel__close:hover{color:#fff}',
-    '.ff-side-panel__title{font-family:"IBM Plex Mono",monospace;font-size:0.75rem;letter-spacing:0.2em;text-transform:uppercase;color:rgba(255,255,255,0.4);margin:0 0 1rem 0;padding-bottom:0.5rem;border-bottom:1px solid rgba(255,255,255,0.1)}',
-    '.ff-side-panel__nav a{color:rgba(255,255,255,0.7);text-decoration:none;display:block;padding:6px 0 6px 8px;font-size:0.85rem;transition:color .15s,border-left-color .15s;border-left:2px solid transparent;line-height:1.4}',
-    '.ff-side-panel__nav a:hover,.ff-side-panel__nav a.is-active{color:#fff;border-left-color:var(--accent,#2ecc71)}',
-    '.ff-side-panel__nav a[data-level="3"]{padding-left:20px;font-size:0.8rem;color:rgba(255,255,255,0.5)}',
-    '.ff-side-panel__nav a[data-level="3"]:hover,.ff-side-panel__nav a[data-level="3"].is-active{color:rgba(255,255,255,0.9)}',
-    '.ff-side-panel__toggle{position:fixed;left:0;top:50%;transform:translateY(-50%);width:36px;height:48px;background:var(--ff-black,#0a0a0a);color:#fff;border:none;border-radius:0 6px 6px 0;cursor:pointer;z-index:49;font-size:1.1rem;display:flex;align-items:center;justify-content:center;transition:background .2s}',
-    '.ff-side-panel__toggle:hover{background:var(--accent,#2ecc71)}',
-    '.ff-side-panel__backdrop{position:fixed;inset:0;background:rgba(0,0,0,0.4);z-index:48;opacity:0;pointer-events:none;transition:opacity .3s}',
-    '.ff-side-panel__backdrop.is-open{opacity:1;pointer-events:auto}',
+  // ─── Book structure ─────────────────────────────────────────────
+  var BOOK = [
+    { n:1, emoji:'🌿', title:'Natura', color:'#2ecc71', subs:[
+      { num:'1.1', title:'Mobilità e Città', slug:'mobilita' },
+      { num:'1.2', title:'Ambiente ed Energia', slug:'ambiente' },
+      { num:'1.3', title:'Cibo e Fashion', slug:'cibo' }
+    ]},
+    { n:2, emoji:'💻', title:'Tecnologia', color:'#4a90e2', subs:[
+      { num:'2.1', title:'Robotica e AI', slug:'robotica' },
+      { num:'2.2', title:'Metaverso e Criptovalute', slug:'metaverso' },
+      { num:'2.3', title:'Prodotti di consumo', slug:'prodotti' }
+    ]},
+    { n:3, emoji:'❤️', title:'Società', color:'#d0021b', subs:[
+      { num:'3.1', title:'Psicologia e Wellbeing', slug:'psicologia' },
+      { num:'3.2', title:'Alimentazione e Sport', slug:'alimentazione' },
+      { num:'3.3', title:'Cultura e Demografia', slug:'cultura' }
+    ]}
+  ];
 
-    /* Sticky search */
-    '.ff-sticky-search{position:fixed;top:0;left:0;right:0;height:48px;background:rgba(253,253,253,0.92);backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px);z-index:40;display:flex;align-items:center;padding:0 1rem;border-bottom:2px solid var(--ff-black,#0a0a0a);transform:translateY(-100%);transition:transform .25s ease;box-sizing:border-box}',
-    '.ff-sticky-search.is-visible{transform:translateY(0)}',
-    '.ff-sticky-search input{flex:1;max-width:600px;margin:0 auto;border:2px solid var(--ff-black,#0a0a0a);padding:6px 12px;font-size:0.875rem;font-family:"Inter",sans-serif;box-sizing:border-box;outline:none}',
-    '.ff-sticky-search input:focus{border-color:var(--accent,#2ecc71)}',
-    '.ff-sticky-search__count{font-family:"IBM Plex Mono",monospace;font-size:0.7rem;color:#888;margin-left:8px;white-space:nowrap}',
+  // Detect current page
+  var currentSlug = location.pathname.replace(/.*chapter-0\d-/, '').replace('.html', '');
+  var currentChapter = location.pathname.match(/chapter-0(\d)/);
+  var currentChNum = currentChapter ? parseInt(currentChapter[1]) : 0;
 
-    /* Flash highlight */
-    '@keyframes ff-flash-bg{0%{background:rgba(74,144,226,0.25)}100%{background:transparent}}',
-    '.flash-highlight{animation:ff-flash-bg 1.5s ease-out}',
+  // ─── CSS ────────────────────────────────────────────────────────
+  var css = `
+    .ff-panel{position:fixed;top:0;left:0;width:320px;height:100vh;background:#0a0a0a;color:#fff;transform:translateX(-100%);transition:transform .3s ease;z-index:50;overflow-y:auto;box-sizing:border-box;display:flex;flex-direction:column}
+    .ff-panel.is-open{transform:translateX(0)}
+    .ff-panel__header{padding:1rem 1rem 0.5rem;display:flex;align-items:center;justify-content:space-between;border-bottom:1px solid rgba(255,255,255,0.1)}
+    .ff-panel__close{background:none;border:none;color:rgba(255,255,255,0.5);font-size:1.4rem;cursor:pointer;padding:4px 8px;line-height:1}
+    .ff-panel__close:hover{color:#fff}
+    .ff-panel__brand{font-family:"IBM Plex Mono",monospace;font-size:0.7rem;letter-spacing:0.2em;text-transform:uppercase;color:rgba(255,255,255,0.35)}
+    .ff-panel__search{padding:0.75rem 1rem;border-bottom:1px solid rgba(255,255,255,0.08)}
+    .ff-panel__search input{width:100%;background:rgba(255,255,255,0.08);border:1px solid rgba(255,255,255,0.15);color:#fff;padding:8px 12px;font-size:0.85rem;font-family:"Inter",sans-serif;box-sizing:border-box;outline:none;border-radius:4px}
+    .ff-panel__search input:focus{border-color:var(--accent,#2ecc71)}
+    .ff-panel__search input::placeholder{color:rgba(255,255,255,0.3)}
+    .ff-panel__nav{flex:1;overflow-y:auto;padding:0.5rem 0}
+    .ff-panel__chapter{padding:0.5rem 1rem}
+    .ff-panel__chapter-title{font-family:"IBM Plex Mono",monospace;font-size:0.72rem;letter-spacing:0.15em;text-transform:uppercase;color:rgba(255,255,255,0.4);margin:0 0 0.3rem;display:flex;align-items:center;gap:6px}
+    .ff-panel__chapter-title span{font-size:1.1em}
+    .ff-panel__sub{display:block;color:rgba(255,255,255,0.7);text-decoration:none;padding:6px 8px 6px 16px;font-size:0.85rem;border-left:2px solid transparent;transition:all .15s;line-height:1.35}
+    .ff-panel__sub:hover{color:#fff;border-left-color:rgba(255,255,255,0.3);background:rgba(255,255,255,0.04)}
+    .ff-panel__sub.is-current{color:#fff;border-left-color:var(--accent,#2ecc71);font-weight:600}
+    .ff-panel__sub .ff-sub-num{font-family:"IBM Plex Mono",monospace;font-size:0.75rem;color:rgba(255,255,255,0.4);margin-right:4px}
+    .ff-panel__heading{display:block;color:rgba(255,255,255,0.5);text-decoration:none;padding:3px 8px 3px 32px;font-size:0.78rem;transition:color .15s;line-height:1.3}
+    .ff-panel__heading:hover,.ff-panel__heading.is-active{color:rgba(255,255,255,0.9)}
+    .ff-panel__heading.is-active{border-left:2px solid var(--accent,#2ecc71);margin-left:-2px}
+    .ff-panel__divider{height:1px;background:rgba(255,255,255,0.06);margin:0.3rem 1rem}
+    .ff-toggle{position:fixed;left:0;top:50%;transform:translateY(-50%);width:40px;height:52px;background:#0a0a0a;color:#fff;border:none;border-radius:0 8px 8px 0;cursor:pointer;z-index:49;font-size:1.2rem;display:flex;align-items:center;justify-content:center;transition:background .2s;box-shadow:2px 0 8px rgba(0,0,0,0.15)}
+    .ff-toggle:hover{background:var(--accent,#2ecc71)}
+    .ff-backdrop{position:fixed;inset:0;background:rgba(0,0,0,0.5);z-index:48;opacity:0;pointer-events:none;transition:opacity .3s}
+    .ff-backdrop.is-open{opacity:1;pointer-events:auto}
 
-    /* Mobile: hide toggle, panel goes full-width */
-    '@media(max-width:768px){.ff-side-panel__toggle{display:none}.ff-side-panel{width:85vw}}',
+    /* Search results in panel */
+    .ff-search-results{padding:0 1rem;max-height:60vh;overflow-y:auto}
+    .ff-search-result{display:block;padding:8px 10px;margin-bottom:4px;background:rgba(255,255,255,0.04);border-left:3px solid var(--accent,#2ecc71);color:rgba(255,255,255,0.8);text-decoration:none;font-size:0.8rem;line-height:1.4;transition:background .15s}
+    .ff-search-result:hover{background:rgba(255,255,255,0.08)}
+    .ff-search-result mark{background:rgba(46,204,113,0.35);color:#fff;padding:0 2px;font-style:normal}
+    .ff-search-no-results{color:rgba(255,255,255,0.3);font-size:0.8rem;padding:1rem;text-align:center}
 
-    /* Reduced motion */
-    '@media(prefers-reduced-motion:reduce){.ff-side-panel,.ff-side-panel__backdrop,.ff-sticky-search,.flash-highlight{transition-duration:0.01ms!important;animation-duration:0.01ms!important}}'
-  ].join('\n');
+    /* In-page search highlight */
+    .ff-search-match{background:rgba(245,166,35,0.35);border-radius:2px;scroll-margin-top:80px}
 
+    /* Flash for bibliography */
+    @keyframes ff-flash-bg{0%{background:rgba(74,144,226,0.25)}100%{background:transparent}}
+    .flash-highlight{animation:ff-flash-bg 1.5s ease-out}
+
+    /* Mobile */
+    @media(max-width:768px){
+      .ff-toggle{top:auto;bottom:20px;left:auto;right:16px;transform:none;width:52px;height:52px;border-radius:50%;box-shadow:0 2px 12px rgba(0,0,0,0.35);font-size:1.4rem;z-index:51}
+      .ff-panel{width:88vw}
+    }
+    @media(prefers-reduced-motion:reduce){.ff-panel,.ff-backdrop,.flash-highlight{transition-duration:0.01ms!important;animation-duration:0.01ms!important}}
+  `;
   var styleEl = document.createElement('style');
   styleEl.textContent = css;
   document.head.appendChild(styleEl);
 
-  // ─── Wait for DOM ────────────────────────────────────────────────
   function init() {
-    buildSidePanel();
-    buildStickySearch();
+    buildPanel();
     buildBibliographyLinks();
   }
-
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', init);
-  } else {
-    init();
-  }
+  } else { init(); }
 
   // ═══════════════════════════════════════════════════════════════════
-  // 1. SIDE PANEL — Subchapter navigation
+  // 1. NAVIGATION PANEL with search
   // ═══════════════════════════════════════════════════════════════════
-  function buildSidePanel() {
-    // Collect headings
-    var headings = document.querySelectorAll('h2[id], h3[id]');
-    if (!headings.length) return;
-
-    // Create backdrop
+  function buildPanel() {
+    // Backdrop
     var backdrop = document.createElement('div');
-    backdrop.className = 'ff-side-panel__backdrop';
+    backdrop.className = 'ff-backdrop';
     document.body.appendChild(backdrop);
 
-    // Create panel
+    // Panel
     var panel = document.createElement('aside');
-    panel.className = 'ff-side-panel';
+    panel.className = 'ff-panel';
     panel.setAttribute('role', 'navigation');
-    panel.setAttribute('aria-label', 'Navigazione capitolo');
+    panel.setAttribute('aria-label', 'Navigazione libro');
 
+    // Header
+    var header = document.createElement('div');
+    header.className = 'ff-panel__header';
+    header.innerHTML = '<span class="ff-panel__brand">Futuro Fortissimo</span>';
     var closeBtn = document.createElement('button');
-    closeBtn.className = 'ff-side-panel__close';
+    closeBtn.className = 'ff-panel__close';
     closeBtn.innerHTML = '&times;';
-    closeBtn.setAttribute('aria-label', 'Chiudi pannello');
-    panel.appendChild(closeBtn);
+    closeBtn.setAttribute('aria-label', 'Chiudi');
+    header.appendChild(closeBtn);
+    panel.appendChild(header);
 
-    var title = document.createElement('div');
-    title.className = 'ff-side-panel__title';
-    title.textContent = 'Indice';
-    panel.appendChild(title);
+    // Search box
+    var searchDiv = document.createElement('div');
+    searchDiv.className = 'ff-panel__search';
+    var searchInput = document.createElement('input');
+    searchInput.type = 'search';
+    searchInput.placeholder = 'Cerca nel libro...';
+    searchInput.setAttribute('aria-label', 'Cerca');
+    searchDiv.appendChild(searchInput);
+    panel.appendChild(searchDiv);
 
-    var nav = document.createElement('nav');
-    nav.className = 'ff-side-panel__nav';
+    // Search results container
+    var searchResults = document.createElement('div');
+    searchResults.className = 'ff-search-results';
+    searchResults.style.display = 'none';
+    panel.appendChild(searchResults);
 
-    var links = [];
-    headings.forEach(function (h) {
-      var a = document.createElement('a');
-      a.href = '#' + h.id;
-      a.textContent = h.textContent.replace(/^\s+|\s+$/g, '');
-      var level = h.tagName === 'H3' ? '3' : '2';
-      a.setAttribute('data-level', level);
-      a.setAttribute('data-target', h.id);
-      nav.appendChild(a);
-      links.push({ el: a, target: h });
+    // Nav
+    var nav = document.createElement('div');
+    nav.className = 'ff-panel__nav';
+
+    // Home link
+    var homeLink = document.createElement('a');
+    homeLink.href = '/book/';
+    homeLink.className = 'ff-panel__sub';
+    homeLink.style.cssText = 'padding-left:1rem;margin-bottom:0.5rem;font-weight:600;';
+    homeLink.textContent = '📖 Indice del libro';
+    nav.appendChild(homeLink);
+
+    // Build chapter structure
+    BOOK.forEach(function (ch) {
+      var div = document.createElement('div');
+      div.className = 'ff-panel__chapter';
+
+      var title = document.createElement('div');
+      title.className = 'ff-panel__chapter-title';
+      title.innerHTML = '<span>' + ch.emoji + '</span> Cap. ' + ch.n + ' — ' + ch.title;
+      div.appendChild(title);
+
+      ch.subs.forEach(function (sub) {
+        var a = document.createElement('a');
+        a.href = '/book/chapter-0' + ch.n + '-' + sub.slug + '.html';
+        a.className = 'ff-panel__sub';
+        if (ch.n === currentChNum && sub.slug === currentSlug) {
+          a.classList.add('is-current');
+        }
+        a.innerHTML = '<span class="ff-sub-num">' + sub.num + '</span> ' + sub.title;
+        div.appendChild(a);
+      });
+
+      nav.appendChild(div);
+
+      // Add in-page headings for current subchapter
+      if (ch.n === currentChNum) {
+        ch.subs.forEach(function (sub) {
+          if (sub.slug === currentSlug) {
+            var headings = document.querySelectorAll('h3[id]');
+            headings.forEach(function (h) {
+              var ha = document.createElement('a');
+              ha.href = '#' + h.id;
+              ha.className = 'ff-panel__heading';
+              ha.textContent = h.textContent.replace(/^\s+|\s+$/g, '');
+              ha.setAttribute('data-target', h.id);
+              ha.addEventListener('click', function (e) {
+                e.preventDefault();
+                document.getElementById(h.id).scrollIntoView({ behavior: 'smooth', block: 'start' });
+                if (window.innerWidth <= 768) closePanel();
+              });
+              div.appendChild(ha);
+            });
+          }
+        });
+      }
+
+      var divider = document.createElement('div');
+      divider.className = 'ff-panel__divider';
+      nav.appendChild(divider);
     });
 
     panel.appendChild(nav);
     document.body.appendChild(panel);
 
-    // Create toggle button
+    // Toggle button
     var toggle = document.createElement('button');
-    toggle.className = 'ff-side-panel__toggle';
-    toggle.innerHTML = '&#8801;';
-    toggle.setAttribute('aria-label', 'Apri indice capitolo');
+    toggle.className = 'ff-toggle';
+    toggle.innerHTML = '&#9776;';
+    toggle.setAttribute('aria-label', 'Menu libro');
     document.body.appendChild(toggle);
 
-    // Open/close logic
+    // Open/close
     function openPanel() {
       panel.classList.add('is-open');
       backdrop.classList.add('is-open');
-      panel.querySelector('a')?.focus();
+      searchInput.focus();
     }
-
     function closePanel() {
       panel.classList.remove('is-open');
       backdrop.classList.remove('is-open');
     }
-
     toggle.addEventListener('click', openPanel);
     closeBtn.addEventListener('click', closePanel);
     backdrop.addEventListener('click', closePanel);
-
-    // Escape key closes panel
     document.addEventListener('keydown', function (e) {
-      if (e.key === 'Escape' && panel.classList.contains('is-open')) {
-        closePanel();
-      }
+      if (e.key === 'Escape' && panel.classList.contains('is-open')) closePanel();
     });
 
-    // Click nav link: scroll + close on mobile
-    nav.addEventListener('click', function (e) {
-      var link = e.target.closest('a');
-      if (!link) return;
-      e.preventDefault();
-      var targetId = link.getAttribute('data-target');
-      var targetEl = document.getElementById(targetId);
-      if (targetEl) {
-        targetEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
-      }
-      if (window.innerWidth <= 768) {
-        closePanel();
-      }
-    });
-
-    // Active section tracking via IntersectionObserver
-    if ('IntersectionObserver' in window) {
+    // Active heading tracking
+    var headingLinks = nav.querySelectorAll('.ff-panel__heading');
+    if ('IntersectionObserver' in window && headingLinks.length) {
       var currentActive = null;
-
       var observer = new IntersectionObserver(function (entries) {
         entries.forEach(function (entry) {
           if (entry.isIntersecting) {
-            var id = entry.target.id;
             if (currentActive) currentActive.classList.remove('is-active');
-            var match = nav.querySelector('a[data-target="' + id + '"]');
-            if (match) {
-              match.classList.add('is-active');
-              currentActive = match;
-            }
+            var match = nav.querySelector('.ff-panel__heading[data-target="' + entry.target.id + '"]');
+            if (match) { match.classList.add('is-active'); currentActive = match; }
           }
         });
-      }, {
-        rootMargin: '-10% 0px -80% 0px',
-        threshold: 0
-      });
-
-      headings.forEach(function (h) {
-        observer.observe(h);
-      });
-    }
-  }
-
-  // ═══════════════════════════════════════════════════════════════════
-  // 2. STICKY SEARCH BAR
-  // ═══════════════════════════════════════════════════════════════════
-  function buildStickySearch() {
-    var originalInput = document.getElementById('chapterSearch');
-    if (!originalInput) return;
-
-    var originalSection = originalInput.closest('section') || originalInput.parentElement;
-
-    // Create sticky bar
-    var stickyBar = document.createElement('div');
-    stickyBar.className = 'ff-sticky-search';
-
-    var stickyInput = document.createElement('input');
-    stickyInput.type = 'search';
-    stickyInput.placeholder = originalInput.placeholder || 'Cerca...';
-    stickyBar.appendChild(stickyInput);
-
-    var countSpan = document.createElement('span');
-    countSpan.className = 'ff-sticky-search__count';
-    stickyBar.appendChild(countSpan);
-
-    document.body.appendChild(stickyBar);
-
-    // Sync between the two inputs
-    var syncing = false;
-
-    function syncInputs(source, target) {
-      if (syncing) return;
-      syncing = true;
-      target.value = source.value;
-      // Dispatch input event so existing search handler picks it up
-      var evt = new Event('input', { bubbles: true });
-      target.dispatchEvent(evt);
-      syncing = false;
+      }, { rootMargin: '-10% 0px -80% 0px', threshold: 0 });
+      document.querySelectorAll('h3[id]').forEach(function (h) { observer.observe(h); });
     }
 
-    stickyInput.addEventListener('input', function () {
-      syncInputs(stickyInput, originalInput);
-      updateCount();
+    // ─── SEARCH ──────────────────────────────────────────────────
+    var debounceTimer;
+    searchInput.addEventListener('input', function () {
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(function () { doSearch(searchInput.value.trim()); }, 250);
     });
 
-    originalInput.addEventListener('input', function () {
-      syncInputs(originalInput, stickyInput);
-      updateCount();
-    });
+    function doSearch(query) {
+      // Clear previous highlights
+      document.querySelectorAll('.ff-search-match').forEach(function (el) {
+        var parent = el.parentNode;
+        parent.replaceChild(document.createTextNode(el.textContent), el);
+        parent.normalize();
+      });
 
-    // Count visible results
-    function updateCount() {
-      var query = originalInput.value.trim();
-      if (!query) {
-        countSpan.textContent = '';
+      if (query.length < 2) {
+        searchResults.style.display = 'none';
+        nav.style.display = '';
         return;
       }
-      // Count visible prose blocks
-      var blocks = document.querySelectorAll('article.prose p, article.prose blockquote');
-      var visible = 0;
-      blocks.forEach(function (b) {
-        if (b.style.display !== 'none' && b.offsetParent !== null) {
-          visible++;
+
+      nav.style.display = 'none';
+      searchResults.style.display = '';
+      searchResults.innerHTML = '';
+
+      // Search in current page prose
+      var paragraphs = document.querySelectorAll('article.prose p, article.prose blockquote');
+      var results = [];
+      var re = new RegExp('(' + query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + ')', 'gi');
+
+      paragraphs.forEach(function (p) {
+        var text = p.textContent;
+        if (re.test(text)) {
+          // Find nearest heading
+          var heading = '';
+          var prev = p;
+          while (prev = prev.previousElementSibling) {
+            if (prev.tagName === 'H3' || prev.tagName === 'H2') { heading = prev.textContent.trim(); break; }
+          }
+
+          // Create snippet
+          var idx = text.toLowerCase().indexOf(query.toLowerCase());
+          var start = Math.max(0, idx - 40);
+          var end = Math.min(text.length, idx + query.length + 60);
+          var snippet = (start > 0 ? '...' : '') + text.slice(start, end) + (end < text.length ? '...' : '');
+
+          results.push({ el: p, heading: heading, snippet: snippet, query: query });
+
+          // Highlight in text
+          highlightInElement(p, re);
         }
+        re.lastIndex = 0;
       });
-      countSpan.textContent = visible + ' risultat' + (visible === 1 ? 'o' : 'i');
-    }
 
-    // Show/hide sticky bar based on scroll position
-    var isVisible = false;
-
-    function checkScroll() {
-      var rect = originalSection.getBoundingClientRect();
-      var shouldShow = rect.bottom < 0;
-
-      if (shouldShow && !isVisible) {
-        stickyBar.classList.add('is-visible');
-        isVisible = true;
-      } else if (!shouldShow && isVisible) {
-        stickyBar.classList.remove('is-visible');
-        isVisible = false;
+      if (results.length === 0) {
+        searchResults.innerHTML = '<div class="ff-search-no-results">Nessun risultato per "' + query + '"</div>';
+        return;
       }
-    }
 
-    // Throttled scroll handler
-    var scrollTick = false;
-    window.addEventListener('scroll', function () {
-      if (!scrollTick) {
-        scrollTick = true;
-        requestAnimationFrame(function () {
-          checkScroll();
-          scrollTick = false;
+      results.slice(0, 20).forEach(function (r) {
+        var a = document.createElement('a');
+        a.className = 'ff-search-result';
+        a.href = '#';
+        var highlighted = r.snippet.replace(re, '<mark>$1</mark>');
+        a.innerHTML = (r.heading ? '<strong style="font-size:0.7rem;color:rgba(255,255,255,0.4);display:block;margin-bottom:2px;">' + r.heading + '</strong>' : '') + highlighted;
+        a.addEventListener('click', function (e) {
+          e.preventDefault();
+          r.el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          r.el.classList.remove('flash-highlight');
+          void r.el.offsetWidth;
+          r.el.classList.add('flash-highlight');
+          setTimeout(function () { r.el.classList.remove('flash-highlight'); }, 1500);
+          if (window.innerWidth <= 768) closePanel();
         });
-      }
-    }, { passive: true });
+        searchResults.appendChild(a);
+      });
 
-    // Initial check
-    checkScroll();
+      if (results.length > 20) {
+        var more = document.createElement('div');
+        more.className = 'ff-search-no-results';
+        more.textContent = '+ ' + (results.length - 20) + ' altri risultati';
+        searchResults.appendChild(more);
+      }
+    }
+
+    function highlightInElement(el, regex) {
+      var walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT, null, false);
+      var textNodes = [];
+      while (walker.nextNode()) textNodes.push(walker.currentNode);
+      textNodes.forEach(function (node) {
+        if (!regex.test(node.textContent)) { regex.lastIndex = 0; return; }
+        regex.lastIndex = 0;
+        var parts = node.textContent.split(regex);
+        if (parts.length <= 1) return;
+        var frag = document.createDocumentFragment();
+        parts.forEach(function (part, i) {
+          if (i % 2 === 0) {
+            frag.appendChild(document.createTextNode(part));
+          } else {
+            var mark = document.createElement('mark');
+            mark.className = 'ff-search-match';
+            mark.textContent = part;
+            frag.appendChild(mark);
+          }
+        });
+        node.parentNode.replaceChild(frag, node);
+      });
+    }
   }
 
   // ═══════════════════════════════════════════════════════════════════
-  // 3. BIBLIOGRAPHY ANCHOR LINKS
+  // 2. BIBLIOGRAPHY BACK-LINKS
   // ═══════════════════════════════════════════════════════════════════
   function buildBibliographyLinks() {
     var fonti = document.querySelectorAll('[id^="fonte-"]');
     if (!fonti.length) return;
 
-    // Pre-collect all content links once for efficient matching
     var contentLinks = document.querySelectorAll('article.prose a[href]');
 
-    // Normalize URL for comparison: strip trailing slash, lowercase hostname
     function normalizeUrl(url) {
-      try {
-        var u = new URL(url, location.href);
-        return u.origin + u.pathname.replace(/\/+$/, '') + u.search + u.hash;
-      } catch (e) {
-        return url.replace(/\/+$/, '');
-      }
-    }
-
-    // Extract domain from URL for partial matching
-    function extractDomain(url) {
-      try { return new URL(url, location.href).hostname.replace(/^www\./, ''); }
-      catch (e) { return ''; }
+      try { var u = new URL(url, location.href); return u.origin + u.pathname.replace(/\/+$/, '') + u.search; }
+      catch (e) { return url.replace(/\/+$/, ''); }
     }
 
     fonti.forEach(function (li) {
       var fonteAnchor = li.querySelector('a');
       if (!fonteAnchor) return;
-
       var fonteUrl = fonteAnchor.getAttribute('href');
-      if (!fonteUrl) return;
+      if (!fonteUrl || fonteUrl.startsWith('#')) return;
 
       var normalizedFonte = normalizeUrl(fonteUrl);
-      var fonteDomain = extractDomain(fonteUrl);
-
-      // Find matching link in article content (exact URL match first, then domain+path match)
       var match = null;
+
       for (var i = 0; i < contentLinks.length; i++) {
-        var linkHref = contentLinks[i].getAttribute('href');
-        if (!linkHref) continue;
-        // Exact match
-        if (linkHref === fonteUrl || normalizeUrl(linkHref) === normalizedFonte) {
+        var href = contentLinks[i].getAttribute('href');
+        if (!href || href.startsWith('#')) continue;
+        if (href === fonteUrl || normalizeUrl(href) === normalizedFonte) {
           match = contentLinks[i];
           break;
         }
       }
-      // Fallback: match by domain + partial path
-      if (!match && fonteDomain) {
-        for (var j = 0; j < contentLinks.length; j++) {
-          var href2 = contentLinks[j].getAttribute('href');
-          if (!href2) continue;
-          if (extractDomain(href2) === fonteDomain && href2.length > 20) {
-            match = contentLinks[j];
-            break;
-          }
-        }
-      }
-
       if (!match) return;
 
       var para = match.closest('p') || match.closest('blockquote');
@@ -345,53 +389,41 @@
 
       var fonteId = li.id;
       var refId = 'ref-' + fonteId;
+      if (!para.id) para.id = refId;
+      else refId = para.id;
 
-      // Set id on the paragraph (don't overwrite existing id)
-      if (!para.id) {
-        para.id = refId;
-      } else {
-        refId = para.id;
-      }
-
-      // Add ↩ back-link to the fonte li
+      // Back-link ↩ in bibliography
       var backLink = document.createElement('a');
       backLink.href = '#' + refId;
       backLink.textContent = ' \u21A9';
-      backLink.style.cssText = 'color:var(--accent,#2ecc71);text-decoration:none;font-size:0.8rem;margin-left:4px;cursor:pointer;';
+      backLink.style.cssText = 'color:var(--accent,#2ecc71);text-decoration:none;font-size:0.85rem;margin-left:6px;cursor:pointer;';
       backLink.addEventListener('click', function (e) {
         e.preventDefault();
-        var target = document.getElementById(refId);
-        if (!target) return;
-        target.scrollIntoView({ behavior: 'smooth', block: 'center' });
-        target.classList.remove('flash-highlight');
-        // Force reflow to restart animation
-        void target.offsetWidth;
-        target.classList.add('flash-highlight');
-        setTimeout(function () { target.classList.remove('flash-highlight'); }, 1500);
+        var t = document.getElementById(refId);
+        if (!t) return;
+        t.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        t.classList.remove('flash-highlight'); void t.offsetWidth;
+        t.classList.add('flash-highlight');
+        setTimeout(function () { t.classList.remove('flash-highlight'); }, 1500);
       });
       li.appendChild(backLink);
 
-      // Add a small fonte reference link on the paragraph pointing back to the fonte
+      // Superscript [N] in prose
       var refLink = document.createElement('a');
       refLink.href = '#' + fonteId;
       refLink.textContent = ' [' + fonteId.replace('fonte-', '') + ']';
-      refLink.style.cssText = 'color:var(--accent,#2ecc71);text-decoration:none;font-size:0.7rem;font-family:"IBM Plex Mono",monospace;margin-left:2px;cursor:pointer;vertical-align:super;';
+      refLink.style.cssText = 'color:var(--accent,#2ecc71);text-decoration:none;font-size:0.65rem;font-family:"IBM Plex Mono",monospace;margin-left:2px;cursor:pointer;vertical-align:super;';
       refLink.addEventListener('click', function (e) {
         e.preventDefault();
-        var target = document.getElementById(fonteId);
-        if (!target) return;
-        target.scrollIntoView({ behavior: 'smooth', block: 'center' });
-        target.classList.remove('flash-highlight');
-        void target.offsetWidth;
-        target.classList.add('flash-highlight');
-        setTimeout(function () { target.classList.remove('flash-highlight'); }, 1500);
+        var t = document.getElementById(fonteId);
+        if (!t) return;
+        t.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        t.classList.remove('flash-highlight'); void t.offsetWidth;
+        t.classList.add('flash-highlight');
+        setTimeout(function () { t.classList.remove('flash-highlight'); }, 1500);
       });
-      // Append ref link after the matching anchor in the paragraph
-      if (match.nextSibling) {
-        match.parentNode.insertBefore(refLink, match.nextSibling);
-      } else {
-        match.parentNode.appendChild(refLink);
-      }
+      if (match.nextSibling) match.parentNode.insertBefore(refLink, match.nextSibling);
+      else match.parentNode.appendChild(refLink);
     });
   }
 


### PR DESCRIPTION
## Summary
- **Full book navigation** in side panel: all 3 chapters, 9 subchapters, and sections listed in a hierarchical tree
- **Current page highlighted** in the nav tree; in-page h3 headings shown for the active subchapter
- **Live search**: type to search the current page, results show snippets with section heading context; click to scroll + flash highlight; matching text highlighted with orange marks
- **Mobile-friendly**: FAB button (bottom-right, 52px) replaces the side toggle on mobile; panel expands to 88vw
- **Active section tracking** via IntersectionObserver
- Bibliography bidirectional links preserved (external sources + [N] / back-arrow)

## Test plan
- [ ] Open any subchapter page (e.g. chapter-01-mobilita.html) and verify hamburger/FAB button appears
- [ ] Click to open the nav panel; verify all chapters and subchapters are listed
- [ ] Verify current page is highlighted in the tree
- [ ] Type in the search box; verify results filter and text highlights appear
- [ ] Click a search result; verify scroll-to + flash highlight
- [ ] Test on mobile viewport (< 768px): FAB bottom-right, panel 88vw
- [ ] Verify bibliography back-links still work correctly

Generated with [Claude Code](https://claude.com/claude-code)