### PR TITLE
fix: highlight colors + toggle cleanup + review

### DIFF
--- a/book/chapter-02-metaverso.html
+++ b/book/chapter-02-metaverso.html
@@ -38,7 +38,7 @@
         .toc-link{border-left:3px solid transparent;transition:all 0.2s;min-height:44px;display:flex;align-items:center}.toc-link:hover,.toc-link:focus{border-left-color:var(--accent);padding-left:12px}
         blockquote{border-left:4px solid var(--accent);padding:12px 20px;margin:1.5em 0;background:#f0fdf4;font-style:italic}
         .sep{height:2px;background:linear-gradient(90deg,var(--accent),transparent);margin:3em 0}
-        .note-highlight{background:linear-gradient(180deg,transparent 60%,rgba(46,204,113,0.22) 60%);padding:0 2px;font-style:normal;color:inherit}
+        .note-highlight{background:linear-gradient(180deg,transparent 60%,rgba(74,144,226,0.22) 60%);padding:0 2px;font-style:normal;color:inherit}
         .prose{overflow-wrap:break-word;word-wrap:break-word;-webkit-hyphens:auto;hyphens:auto}
         h2[id],h3[id]{scroll-margin-top:2rem}
         figure{margin:2em 0}figure img{width:100%;height:auto;border:3px solid var(--ff-black)}figcaption{font-family:'IBM Plex Mono',monospace;font-size:0.75rem;color:#666;margin-top:8px;letter-spacing:0.04em}

--- a/book/chapter-02-prodotti.html
+++ b/book/chapter-02-prodotti.html
@@ -38,7 +38,7 @@
         .toc-link{border-left:3px solid transparent;transition:all 0.2s;min-height:44px;display:flex;align-items:center}.toc-link:hover,.toc-link:focus{border-left-color:var(--accent);padding-left:12px}
         blockquote{border-left:4px solid var(--accent);padding:12px 20px;margin:1.5em 0;background:#f0fdf4;font-style:italic}
         .sep{height:2px;background:linear-gradient(90deg,var(--accent),transparent);margin:3em 0}
-        .note-highlight{background:linear-gradient(180deg,transparent 60%,rgba(46,204,113,0.22) 60%);padding:0 2px;font-style:normal;color:inherit}
+        .note-highlight{background:linear-gradient(180deg,transparent 60%,rgba(74,144,226,0.22) 60%);padding:0 2px;font-style:normal;color:inherit}
         .prose{overflow-wrap:break-word;word-wrap:break-word;-webkit-hyphens:auto;hyphens:auto}
         h2[id],h3[id]{scroll-margin-top:2rem}
         figure{margin:2em 0}figure img{width:100%;height:auto;border:3px solid var(--ff-black)}figcaption{font-family:'IBM Plex Mono',monospace;font-size:0.75rem;color:#666;margin-top:8px;letter-spacing:0.04em}

--- a/book/chapter-02-robotica.html
+++ b/book/chapter-02-robotica.html
@@ -38,7 +38,7 @@
         .toc-link{border-left:3px solid transparent;transition:all 0.2s;min-height:44px;display:flex;align-items:center}.toc-link:hover,.toc-link:focus{border-left-color:var(--accent);padding-left:12px}
         blockquote{border-left:4px solid var(--accent);padding:12px 20px;margin:1.5em 0;background:#f0fdf4;font-style:italic}
         .sep{height:2px;background:linear-gradient(90deg,var(--accent),transparent);margin:3em 0}
-        .note-highlight{background:linear-gradient(180deg,transparent 60%,rgba(46,204,113,0.22) 60%);padding:0 2px;font-style:normal;color:inherit}
+        .note-highlight{background:linear-gradient(180deg,transparent 60%,rgba(74,144,226,0.22) 60%);padding:0 2px;font-style:normal;color:inherit}
         .prose{overflow-wrap:break-word;word-wrap:break-word;-webkit-hyphens:auto;hyphens:auto}
         h2[id],h3[id]{scroll-margin-top:2rem}
         figure{margin:2em 0}figure img{width:100%;height:auto;border:3px solid var(--ff-black)}figcaption{font-family:'IBM Plex Mono',monospace;font-size:0.75rem;color:#666;margin-top:8px;letter-spacing:0.04em}

--- a/book/chapter-03-alimentazione.html
+++ b/book/chapter-03-alimentazione.html
@@ -38,7 +38,7 @@
         .toc-link{border-left:3px solid transparent;transition:all 0.2s;min-height:44px;display:flex;align-items:center}.toc-link:hover,.toc-link:focus{border-left-color:var(--accent);padding-left:12px}
         blockquote{border-left:4px solid var(--accent);padding:12px 20px;margin:1.5em 0;background:#f0fdf4;font-style:italic}
         .sep{height:2px;background:linear-gradient(90deg,var(--accent),transparent);margin:3em 0}
-        .note-highlight{background:linear-gradient(180deg,transparent 60%,rgba(46,204,113,0.22) 60%);padding:0 2px;font-style:normal;color:inherit}
+        .note-highlight{background:linear-gradient(180deg,transparent 60%,rgba(208,2,27,0.22) 60%);padding:0 2px;font-style:normal;color:inherit}
         .prose{overflow-wrap:break-word;word-wrap:break-word;-webkit-hyphens:auto;hyphens:auto}
         h2[id],h3[id]{scroll-margin-top:2rem}
         figure{margin:2em 0}figure img{width:100%;height:auto;border:3px solid var(--ff-black)}figcaption{font-family:'IBM Plex Mono',monospace;font-size:0.75rem;color:#666;margin-top:8px;letter-spacing:0.04em}

--- a/book/chapter-03-cultura.html
+++ b/book/chapter-03-cultura.html
@@ -38,7 +38,7 @@
         .toc-link{border-left:3px solid transparent;transition:all 0.2s;min-height:44px;display:flex;align-items:center}.toc-link:hover,.toc-link:focus{border-left-color:var(--accent);padding-left:12px}
         blockquote{border-left:4px solid var(--accent);padding:12px 20px;margin:1.5em 0;background:#f0fdf4;font-style:italic}
         .sep{height:2px;background:linear-gradient(90deg,var(--accent),transparent);margin:3em 0}
-        .note-highlight{background:linear-gradient(180deg,transparent 60%,rgba(46,204,113,0.22) 60%);padding:0 2px;font-style:normal;color:inherit}
+        .note-highlight{background:linear-gradient(180deg,transparent 60%,rgba(208,2,27,0.22) 60%);padding:0 2px;font-style:normal;color:inherit}
         .prose{overflow-wrap:break-word;word-wrap:break-word;-webkit-hyphens:auto;hyphens:auto}
         h2[id],h3[id]{scroll-margin-top:2rem}
         figure{margin:2em 0}figure img{width:100%;height:auto;border:3px solid var(--ff-black)}figcaption{font-family:'IBM Plex Mono',monospace;font-size:0.75rem;color:#666;margin-top:8px;letter-spacing:0.04em}

--- a/book/chapter-03-psicologia.html
+++ b/book/chapter-03-psicologia.html
@@ -38,7 +38,7 @@
         .toc-link{border-left:3px solid transparent;transition:all 0.2s;min-height:44px;display:flex;align-items:center}.toc-link:hover,.toc-link:focus{border-left-color:var(--accent);padding-left:12px}
         blockquote{border-left:4px solid var(--accent);padding:12px 20px;margin:1.5em 0;background:#f0fdf4;font-style:italic}
         .sep{height:2px;background:linear-gradient(90deg,var(--accent),transparent);margin:3em 0}
-        .note-highlight{background:linear-gradient(180deg,transparent 60%,rgba(46,204,113,0.22) 60%);padding:0 2px;font-style:normal;color:inherit}
+        .note-highlight{background:linear-gradient(180deg,transparent 60%,rgba(208,2,27,0.22) 60%);padding:0 2px;font-style:normal;color:inherit}
         .prose{overflow-wrap:break-word;word-wrap:break-word;-webkit-hyphens:auto;hyphens:auto}
         h2[id],h3[id]{scroll-margin-top:2rem}
         figure{margin:2em 0}figure img{width:100%;height:auto;border:3px solid var(--ff-black)}figcaption{font-family:'IBM Plex Mono',monospace;font-size:0.75rem;color:#666;margin-top:8px;letter-spacing:0.04em}

--- a/book/index.html
+++ b/book/index.html
@@ -499,7 +499,7 @@
           details summary::-webkit-details-marker { display: none; }
         </style>
 
-        <p class="ff-body-sm mt-3" style="color:#555;">35+ iniezioni da notes.json (30 marzo &ndash; 4 aprile 2026). 462 link ff.x.y cliccabili verso Substack. Navigazione hamburger con ricerca. EPUB aggiornato.</p>
+        <p class="ff-body-sm mt-3" style="color:#555;">10 iniezioni ff.x.y (30 marzo &ndash; 4 aprile 2026). 462 link ff.x.y cliccabili verso Substack. Navigazione hamburger con ricerca. EPUB aggiornato.</p>
 
         <div style="display:flex;flex-direction:column;gap:1.2rem;margin-top:1rem;">
 
@@ -545,67 +545,18 @@
             <a class="ff-button underline text-xs" href="/book/chapter-03-psicologia.html#s1-3">Leggi in Cap. 3 &sect;1.3 &rarr;</a>
           </div>
 
-          <!-- note 1380 — Arbor Energy -->
-          <div style="border-left:4px solid var(--ff-green);padding-left:12px;">
-            <div style="font-weight:700;color:var(--ff-green);font-size:0.95rem;">&#9889; Turbine CO&#8322; supercritico stampate 3D</div>
-            <p class="ff-body-sm mt-1" style="color:#444;">Arbor Energy ottiene un ordine da $1 miliardo per turbine fuel-agnostic: zero emissioni su gas naturale, carbon-negative su biomassa.</p>
-            <a class="ff-button underline text-xs" href="/book/chapter-01-ambiente.html#s2-2">Leggi in Cap. 1 &sect;2.2 &rarr;</a>
-          </div>
-
-          <!-- note 1351 — Rinnovabili superano carbone -->
-          <div style="border-left:4px solid var(--ff-green);padding-left:12px;">
-            <div style="font-weight:700;color:var(--ff-green);font-size:0.95rem;">&#127811; Le rinnovabili superano il carbone</div>
-            <p class="ff-body-sm mt-1" style="color:#444;">Le fonti rinnovabili hanno superato il carbone nella generazione elettrica mondiale &mdash; prima di quanto le previsioni pi&ugrave; ottimistiche osassero sperare.</p>
-            <a class="ff-button underline text-xs" href="/book/chapter-01-ambiente.html#s2-2">Leggi in Cap. 1 &sect;2.2 &rarr;</a>
-          </div>
-
-          <!-- note 1327 — 0% superficie, 10% elettricit&agrave; -->
-          <div style="border-left:4px solid var(--ff-green);padding-left:12px;">
-            <div style="font-weight:700;color:var(--ff-green);font-size:0.95rem;">&#9728;&#65039; 0% di suolo, 10% di elettricit&agrave;</div>
-            <p class="ff-body-sm mt-1" style="color:#444;">I pannelli fotovoltaici occupano lo 0% della superficie terrestre (arrotondato), eppure producono gi&agrave; il 10% dell&rsquo;elettricit&agrave; globale.</p>
-            <a class="ff-button underline text-xs" href="/book/chapter-01-ambiente.html#s2-2">Leggi in Cap. 1 &sect;2.2 &rarr;</a>
-          </div>
-
-          <!-- note 1363 — AMI / LeCun JEPA -->
-          <div style="border-left:4px solid var(--ff-blue);padding-left:12px;">
-            <div style="font-weight:700;color:var(--ff-blue);font-size:0.95rem;">&#129504; AMI di LeCun: $1.03B per JEPA</div>
-            <p class="ff-body-sm mt-1" style="color:#444;">La startup di Yann LeCun raccoglie $1.03 miliardi per un&rsquo;architettura con memoria persistente, ragionamento causale e world models per robotica e healthcare.</p>
-            <a class="ff-button underline text-xs" href="/book/chapter-02-robotica.html#s1-3">Leggi in Cap. 2 &sect;1.3 &rarr;</a>
-          </div>
-
-          <!-- note 1354 — Dragon Hatchling -->
-          <div style="border-left:4px solid var(--ff-blue);padding-left:12px;">
-            <div style="font-weight:700;color:var(--ff-blue);font-size:0.95rem;">&#129430; Dragon Hatchling imita il cervello</div>
-            <p class="ff-body-sm mt-1" style="color:#444;">Architettura AI con neuroni semplificati e relazioni causa-effetto dirette, a met&agrave; tra transformer e corteccia biologica.</p>
-            <a class="ff-button underline text-xs" href="/book/chapter-02-robotica.html#s1-3">Leggi in Cap. 2 &sect;1.3 &rarr;</a>
-          </div>
-
-          <!-- note 1344 — Waymo 85% meno lesioni -->
-          <div style="border-left:4px solid var(--ff-blue);padding-left:12px;">
-            <div style="font-weight:700;color:var(--ff-blue);font-size:0.95rem;">&#128663; Waymo: 85% in meno di lesioni gravi</div>
-            <p class="ff-body-sm mt-1" style="color:#444;">Con 57 milioni di miglia di dati, Waymo registra l&rsquo;85% in meno di lesioni gravi e il 79% in meno di incidenti con lesioni.</p>
-            <a class="ff-button underline text-xs" href="/book/chapter-02-prodotti.html#s3-4">Leggi in Cap. 2 &sect;3.4 &rarr;</a>
-          </div>
-
-          <!-- note 1375 — Polpaccio e mortalit&agrave; -->
+          <!-- ff.29.1 — Non figliamo più -->
           <div style="border-left:4px solid var(--ff-red);padding-left:12px;">
-            <div style="font-weight:700;color:var(--ff-red);font-size:0.95rem;">&#129470; Il polpaccio come oracolo di longevit&agrave;</div>
-            <p class="ff-body-sm mt-1" style="color:#444;">Circonferenza del polpaccio sotto 35 cm predice mortalit&agrave; pi&ugrave; alta negli anziani; sopra 38,5 cm associata a mortalit&agrave; ridotta.</p>
-            <a class="ff-button underline text-xs" href="/book/chapter-03-alimentazione.html#s2-1">Leggi in Cap. 3 &sect;2.1 &rarr;</a>
-          </div>
-
-          <!-- note 1339 — Bilanciere di Taleb -->
-          <div style="border-left:4px solid var(--ff-red);padding-left:12px;">
-            <div style="font-weight:700;color:var(--ff-red);font-size:0.95rem;">&#9878;&#65039; La strategia del bilanciere</div>
-            <p class="ff-body-sm mt-1" style="color:#444;">Taleb applicato ai giovani: o rinunciare a tutto per un&rsquo;impresa rischiosa, o scegliere il percorso pi&ugrave; sicuro. La zona intermedia &egrave; la pi&ugrave; pericolosa.</p>
-            <a class="ff-button underline text-xs" href="/book/chapter-03-cultura.html#s3-1">Leggi in Cap. 3 &sect;3.1 &rarr;</a>
-          </div>
-
-          <!-- note 1349 — India supera Cina -->
-          <div style="border-left:4px solid var(--ff-red);padding-left:12px;">
-            <div style="font-weight:700;color:var(--ff-red);font-size:0.95rem;">&#127470;&#127475; L&rsquo;India supera la Cina nelle universit&agrave; USA</div>
-            <p class="ff-body-sm mt-1" style="color:#444;">L&rsquo;India ha superato la Cina come primo paese di provenienza degli studenti internazionali nelle universit&agrave; americane.</p>
+            <div style="font-weight:700;color:var(--ff-red);font-size:0.95rem;">&#128118; Non figliamo pi&ugrave;</div>
+            <p class="ff-body-sm mt-1" style="color:#444;">La fertilit&agrave; globale &egrave; scesa da 4,5 a 2,4 figli per donna in 60 anni. Musk, Grimes e il Washington Post convergono: il costo percepito di un figlio ha superato il beneficio per met&agrave; del pianeta.</p>
             <a class="ff-button underline text-xs" href="/book/chapter-03-cultura.html#s3-2">Leggi in Cap. 3 &sect;3.2 &rarr;</a>
+          </div>
+
+          <!-- ff.89.3 — L'essenziale è invisibile agli occhi -->
+          <div style="border-left:4px solid var(--ff-red);padding-left:12px;">
+            <div style="font-weight:700;color:var(--ff-red);font-size:0.95rem;">&#129332; L&rsquo;essenziale &egrave; invisibile agli occhi</div>
+            <p class="ff-body-sm mt-1" style="color:#444;">Saint-Exup&eacute;ry nel 1943: &ldquo;I grandi amano le cifre.&rdquo; Ottant&rsquo;anni dopo, LinkedIn funziona cos&igrave;: metriche come surrogato della relazione. Naval e Stutz confermano: meno ego, parla con la tua ombra.</p>
+            <a class="ff-button underline text-xs" href="/book/chapter-03-psicologia.html#s3-3">Leggi in Cap. 3 &sect;3.3 &rarr;</a>
           </div>
 
           <!-- ff.83.3 — Linguaggio e pensiero -->
@@ -620,20 +571,6 @@
             <div style="font-weight:700;color:var(--ff-blue);font-size:0.95rem;">&#9208;&#65039; L&rsquo;importanza di scrivere e pensare</div>
             <p class="ff-body-sm mt-1" style="color:#444;">Tim Ferriss: ha ancora senso scrivere? S&igrave; &mdash; perch&eacute; senza dare voce ai pensieri viviamo nell&rsquo;allucinazione del capire. Delegare la scrittura a un LLM equivale a restringere i propri confini.</p>
             <a class="ff-button underline text-xs" href="/book/chapter-02-prodotti.html#s3-2">Leggi in Cap. 2 &sect;3.2 &rarr;</a>
-          </div>
-
-          <!-- ff.29.1 — Non figliamo più -->
-          <div style="border-left:4px solid var(--ff-red);padding-left:12px;">
-            <div style="font-weight:700;color:var(--ff-red);font-size:0.95rem;">&#128118; Non figliamo pi&ugrave;</div>
-            <p class="ff-body-sm mt-1" style="color:#444;">La fertilit&agrave; globale &egrave; scesa da 4,5 a 2,4 figli per donna in 60 anni. Musk: senza figli, non c&rsquo;&egrave; futuro (su Marte). Le proiezioni per il 2100: Cina e India sotto il miliardo.</p>
-            <a class="ff-button underline text-xs" href="/book/chapter-03-cultura.html#s3-2">Leggi in Cap. 3 &sect;3.2 &rarr;</a>
-          </div>
-
-          <!-- ff.89.3 — L'essenziale è invisibile agli occhi -->
-          <div style="border-left:4px solid var(--ff-red);padding-left:12px;">
-            <div style="font-weight:700;color:var(--ff-red);font-size:0.95rem;">&#129332; L&rsquo;essenziale &egrave; invisibile agli occhi</div>
-            <p class="ff-body-sm mt-1" style="color:#444;">Saint-Exup&eacute;ry nel 1943: i grandi amano le cifre, non chiedono mai &ldquo;fa collezione di farfalle?&rdquo;. LinkedIn funziona cos&igrave;: metriche come surrogato della relazione.</p>
-            <a class="ff-button underline text-xs" href="/book/chapter-03-psicologia.html#s1-4">Leggi in Cap. 3 &sect;1.4 &rarr;</a>
           </div>
 
         </div>


### PR DESCRIPTION
## Summary
- **Highlight colors fixed**: Tecnologia chapters (02-*) now use blue `rgba(74,144,226,0.22)` and Societa chapters (03-*) use red `rgba(208,2,27,0.22)` instead of the incorrect green that was copy-pasted from Natura
- **Toggle entries cleaned**: Removed all 9 raw "note XXXX" entries, replaced with ff.29.1 (Non figliamo piu) and ff.89.3 (L'essenziale e invisibile agli occhi). Toggle now has exactly 10 ff.x.y entries
- **Spot-check review** findings below (no fixes in this PR, scope control)

## Files changed
- `book/chapter-02-robotica.html` — highlight green→blue
- `book/chapter-02-prodotti.html` — highlight green→blue
- `book/chapter-02-metaverso.html` — highlight green→blue
- `book/chapter-03-psicologia.html` — highlight green→red
- `book/chapter-03-cultura.html` — highlight green→red
- `book/chapter-03-alimentazione.html` — highlight green→red
- `book/index.html` — toggle entries cleanup

## Spot-check review findings

### GOOD (gold-standard compliance)
- **chapter-01-ambiente.html** (lines 123-148): Excellent. Data claims as clickable links, mark highlights on key numbers, fc citations with emoji, bidirectional bibliography refs (fonte-18, fonte-19, fonte-20 in metaverso). Multiple source paragraphs with cross-chapter references.
- **chapter-01-cibo.html** (lines 110-139): Strong. Dense data with highlights, multiple external links (NCBi, PubMed, Examine, Dynomight), fc citations. The ff.94.2 grassi paragraph is exemplary with 5+ external links.
- **chapter-02-robotica.html** (lines 150-178): Good. GPT-5 data with link, Polymarket stats highlighted, fc citations present. Dragon Hatchling injection (line 178) is plain text without external links — acceptable since the note itself had none.
- **chapter-02-prodotti.html** (lines 140-164): Excellent. ff.83.4 has bibliography ref (fonte-28), bidirectional anchor, mark highlights. Google/Andy Grove paragraph rich with data and fc citations.
- **chapter-02-metaverso.html** (lines 130-158): Strong. NFT/blockchain section has 4+ external links, mark highlights on key stats (727M, 90B, 15T), fc citations with cross-refs. Balaji paragraph has 2 external links.
- **chapter-03-psicologia.html** (lines 131-148): Excellent. Dense paragraph with 6+ external links (Amazon, Nature/Twitter, Sahil Bloom, Tim Ferriss, James Clear), multiple mark highlights, fc citations. One of the best paragraphs in the book.
- **chapter-03-cultura.html** (lines 121-134): Good. Maslow 2.0 paragraph has external link (agile-od.com), mark highlights, fc citations. Die with Zero paragraph has data claims highlighted.
- **chapter-03-alimentazione.html** (lines 120-148): Strong. Dense data paragraphs with external links (ScienceDirect, Instagram), mark highlights on key measurements (35cm, 38.5cm), fc citations.

### NEEDS ATTENTION (future PRs)
1. **chapter-01-cibo.html line 126**: "note_id:1342 — Tacoma" injection has NO external link and NO mark highlight — plain narrative without data anchoring
2. **chapter-01-ambiente.html line 145**: "note_id:1351" injection is plain text, no external link, no highlight
3. **chapter-01-ambiente.html line 148**: "note_id:1380 — Arbor Energy" has a link but uses non-standard link styling (IBM Plex Mono inline) instead of the standard note-highlight + bibliography pattern
4. **chapter-02-robotica.html line 178**: "note_id:1354 — Dragon Hatchling" injection is plain text, no links, no highlights
5. **chapter-01-mobilita.html**: Generally solid but some older paragraphs (line 100-103) lack external links on data claims (fractal dimension, PNAS study is linked but could use more anchoring)
6. **chapter-03-cultura.html line 136**: Paragraph has highlights but no external links on the AI/measurement claims

### Pattern observed
Raw note injections (note_id:XXXX format) consistently lack the gold-standard formatting (external links, mark highlights, bibliography). The ff.x.y injections are much better formatted. This suggests the injection pipeline treats raw notes differently from ff.x.y corpus entries.

## Test plan
- [ ] Visual check: open each chapter in browser, verify highlight colors match chapter identity
- [ ] Toggle: verify all 10 entries link to correct chapter sections
- [ ] No regression: spot-check that no content was lost in the toggle replacement

🤖 Generated with [Claude Code](https://claude.com/claude-code)