### PR TITLE
inject(natura): Cina rinnovabili erodono quota fossile

### DIFF
--- a/book/chapter-01-ambiente.html
+++ b/book/chapter-01-ambiente.html
@@ -80,7 +80,7 @@
         </ol>
       </nav>
       <h1 class="text-2xl sm:text-3xl font-bold">🌿 1.2 &mdash; Ambiente ed Energia</h1>
-      <div class="reading-time mt-2">74 refs &middot; ~40 min &middot; 9.8k parole</div>
+      <div class="reading-time mt-2">75 refs &middot; ~41 min &middot; 10.0k parole</div>
     </div>
   </header>
 
@@ -431,6 +431,11 @@
     E c'&egrave; un'altra conversione che nessuno vuole fare: <a href="https://ourworldindata.org/what-are-the-trade-offs-between-animal-welfare-and-the-environmental-impact-of-meat" target="_blank" rel="noopener" style="font-size:0.92rem;font-weight:600;color:var(--accent);text-decoration:none;">sostituire il manzo con il pollo riduce l'impronta carbonica dell'<mark class="note-highlight">80%</mark>, ma richiede duecento volte pi&ugrave; animali</a>.
     Il dilemma &egrave; matematicamente perfetto e moralmente irrisolvibile &mdash; esattamente il tipo di trade-off che la transizione energetica impone a ogni livello, dal piatto alla centrale elettrica.</p>
 
+    <!-- ===== inject 2026-04-14 — note_id:1402 — Cina rinnovabili erodono quota fossile ===== -->
+    <p>E il sorpasso non &egrave; pi&ugrave; solo una questione di investimenti: &egrave; gi&agrave; nei numeri della produzione. La Cina &mdash; lo stesso paese che costruisce il <a href="https://www.newscientist.com/article/2317274-china-is-building-more-than-half-of-the-worlds-new-coal-power-plants/" target="_blank" rel="noopener" style="font-size:0.92rem;font-weight:600;color:var(--accent);text-decoration:none;">52% degli impianti a carbone mondiali</a> &mdash; ha raggiunto un punto di svolta strutturale: eolico e solare hanno toccato <mark class="note-highlight">2.073 TWh</mark>, superando tutte le altre fonti pulite combinate. Non si tratta pi&ugrave; di rinnovabili che coprono la nuova domanda: le rinnovabili cinesi stanno erodendo la quota di carbone e gas. &Egrave; il passaggio dalla fase &ldquo;coprire la crescita&rdquo; alla fase &ldquo;mangiare la base fossile&rdquo;. Se il paese che ha <a href="https://about.bnef.com/blog/china-is-the-growth-engine-of-worlds-low-carbon-spending/" target="_blank" rel="noopener" style="font-size:0.92rem;font-weight:600;color:var(--accent);text-decoration:none;">investito 266 miliardi di dollari nella transizione</a> &mdash; 2,4 volte gli Stati Uniti &mdash; raggiunge il punto in cui il solare e l&rsquo;eolico non solo crescono ma sostituiscono, il paradosso cinese si scioglie: inquinano pi&ugrave; di tutti, ma decarbonizzano pi&ugrave; veloce di tutti
+    (<span class="fc">&#10067; ff.42.2
+    Inquinano o spingono la transizione?</span>).</p>
+
     <p>Se il costo del clima &egrave; sottostimato, quello dell'intelligenza artificiale &egrave; sovrastimato &mdash; almeno sul piano energetico. Il dibattito pubblico dipinge l'AI come una voragine elettrica, ma i dati raccontano un'altra storia: <a href="https://www.sustainabilitybynumbers.com/p/carbon-footprint-chatgpt" target="_blank" rel="noopener" style="font-size:0.92rem;font-weight:600;color:var(--accent);text-decoration:none;">una singola ricerca su ChatGPT equivale allo <mark class="note-highlight">0,00007% dell'impronta elettrica annuale</mark> pro capite nel Regno Unito</a>.
     Il dato non assolve l'industria &mdash; <mark class="note-highlight">50 milioni di GPU H100</mark> a pieno regime consumerebbero 35 GW, circa il <mark class="note-highlight">2% del consumo elettrico mondiale</mark> &mdash; ma ridimensiona la retorica apocalittica: il problema non &egrave; la singola query, &egrave; la scala infrastrutturale, ed &egrave; un problema di pianificazione energetica, non di rinuncia tecnologica. Il vero rischio &egrave; che la narrazione distorta dell'AI energivora distolga l'attenzione dalle fonti di consumo realmente massive e strutturalmente pi&ugrave; difficili da decarbonizzare, come il riscaldamento domestico e il trasporto merci.</p>
 
@@ -663,6 +668,7 @@
         <li id="fonte-70"><a href="https://www.goldmansachs.com/insights/pages/gs-research/carbonomics-gs-net-zero-models/report.pdf" target="_blank" rel="noopener" class="text-blue-700 hover:underline">Carbonomics: report Goldman Sachs sulla decarbonizzazione</a> &mdash; <span class="text-zinc-500">goldmansachs.com</span> <a href="#ref-fonte-70" style="text-decoration:none;">&#8629;</a></li>
         <li id="fonte-71"><a href="https://www.designingbuildings.co.uk/wiki/Can_Concrete_and_Steel_Ever_be_Carbon_Neutral%3F" target="_blank" rel="noopener" class="text-blue-700 hover:underline">La chimica inquinante di cemento e acciaio</a> &mdash; <span class="text-zinc-500">designingbuildings.co.uk</span> <a href="#ref-fonte-71" style="text-decoration:none;">&#8629;</a></li>
         <li id="fonte-72"><a href="https://fortissimo.substack.com/i/113015963/ff-decrescita-felice-o-crescita-tech" target="_blank" rel="noopener" class="text-blue-700 hover:underline">ff.58.5 — Decrescita felice o crescita tech? (Futuro Fortissimo)</a> &mdash; <span class="text-zinc-500">fortissimo.substack.com</span></li>
+        <li id="fonte-73"><a href="https://x.com/AssaadRazzouk/status/1965923547869790614" target="_blank" rel="noopener" class="text-blue-700 hover:underline">La Cina passa da rinnovabili che coprono nuova domanda a rinnovabili che erodono la quota fossile: eolico+solare a 2.073 TWh</a> &mdash; <span class="text-zinc-500">x.com</span></li>
       </ol>
     </section>
 

--- a/book/chapter-01.html
+++ b/book/chapter-01.html
@@ -50,7 +50,7 @@
       </nav>
       <div class="chapter-num text-zinc-400 mb-1">CAPITOLO 01 / 3</div>
       <h1 class="text-3xl sm:text-4xl font-bold">🌿 Natura</h1>
-      <div class="reading-time mt-3">143 refs &middot; 3 sezioni</div>
+      <div class="reading-time mt-3">144 refs &middot; 3 sezioni</div>
     </div>
   </header>
 
@@ -68,7 +68,7 @@
           <div class="ff-eyebrow text-xs" style="color:var(--accent);">1.2</div>
           <h3 class="text-lg font-bold mt-1">Ambiente ed Energia</h3>
           <p class="text-sm text-zinc-600 mt-2 leading-relaxed">Non demonizziamo la plastica: fa anche del bene, specie per conservare il cibo. Da italiani, poi, dobbiamo esserne un po' fieri   il Nobel per la Chimica di Natta nel 1963. Per , i suoi vantaggi  ...</p>
-          <div class="reading-time mt-3">73 refs &middot; ~40 min &middot; 9.8k parole</div>
+          <div class="reading-time mt-3">74 refs &middot; ~41 min &middot; 10.0k parole</div>
         </a>
 
         <a href="chapter-01-cibo.html" class="brutal-card accent-bar block hover:shadow-lg transition-shadow" style="text-decoration:none;color:inherit;">

--- a/book/index.html
+++ b/book/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Libro — Tre Macro Temi | Futuro Fortissimo</title>
-  <meta name="description" content="Tre saggi su Natura, Tecnologia e Societ&agrave; con 481 fonti dal corpus di Futuro Fortissimo." />
+  <meta name="description" content="Tre saggi su Natura, Tecnologia e Societ&agrave; con 482 fonti dal corpus di Futuro Fortissimo." />
 
   <link rel="canonical" href="https://futurofortissimo.github.io/book/" />
 
@@ -465,7 +465,7 @@
     <!-- Download CTA -->
     <div class="book-cta" id="bookCta">
       <div class="book-cta__headline">Scarica il libro gratuitamente</div>
-      <p class="book-cta__sub">Inserisci la tua email per ricevere il link di download. Tre saggi, 481 fonti, 50k parole.</p>
+      <p class="book-cta__sub">Inserisci la tua email per ricevere il link di download. Tre saggi, 482 fonti, 50k parole.</p>
       <form class="book-cta__form" id="bookDownloadForm" action="https://recastello-forms.micmer-recastello.workers.dev/ff-book" method="POST">
         <input class="book-cta__input" type="email" name="email" placeholder="la-tua@email.it" required aria-label="Email">
         <button class="book-cta__btn" type="submit">Scarica</button>
@@ -1138,7 +1138,7 @@
         </ul>
         <div class="mt-4 flex items-center justify-between gap-3">
           <a class="ff-button underline" data-track="chapter_open" href="/book/chapter-01.html">Leggi capitolo &rarr;</a>
-          <div class="ff-caption" style="color: #888;">146 refs · ~78 min · 18.9k parole</div>
+          <div class="ff-caption" style="color: #888;">147 refs · ~79 min · 19.1k parole</div>
         </div>
       </article>
 
@@ -1240,7 +1240,7 @@
     <!-- Footer note -->
     <section class="mt-6 brutal-card" style="border-color:#ddd;box-shadow:none;">
       <h2 class="text-base font-bold uppercase">Come leggere</h2>
-      <p class="ff-body-sm mt-3" style="color: #333;">Ogni capitolo intreccia le note del corpus di Futuro Fortissimo (485 riferimenti in totale), trovando connessioni nascoste tra i temi. Le citazioni inline (<strong>ff.x.y</strong>) rimandano direttamente alle fonti originali nell'archivio. I capitoli includono immagini dal corpus e citazioni dirette collegate alle note originali.</p>
+      <p class="ff-body-sm mt-3" style="color: #333;">Ogni capitolo intreccia le note del corpus di Futuro Fortissimo (486 riferimenti in totale), trovando connessioni nascoste tra i temi. Le citazioni inline (<strong>ff.x.y</strong>) rimandano direttamente alle fonti originali nell'archivio. I capitoli includono immagini dal corpus e citazioni dirette collegate alle note originali.</p>
     </section>
 
   </main>


### PR DESCRIPTION
## Summary
- **Note 1402**: La Cina passa da rinnovabili che coprono nuova domanda a rinnovabili che erodono la quota di carbone e gas — eolico+solare a 2.073 TWh
- Injected into `chapter-01-ambiente.html` after the IEA $3T investment paragraph
- Cross-ref: ff.42.2 (Inquinano o spingono la transizione?)
- Bidirectional links to existing bibliography sources (newscientist.com, bnef.com)
- Bibliography entry fonte-73 added
- Stats updated across chapter-01-ambiente, chapter-01, and index.html

## Corpus fidelity
- All data points trace to note 1402 in notes.json
- Cross-ref ff.42.2 verified against data.js content
- No invented content or embellishment

## Checklist
- [x] Corpus fidelity verified
- [x] Cross-refs match data.js
- [x] Highlight colors match chapter scheme (green/accent)
- [x] No citation blocks
- [x] Bibliography with external source link
- [x] Neighbors reviewed for coherence
- [x] Index.html toggle + stats updated