### PR TITLE
inject(tecnologia): Stanford AI job displacement giovani

### DIFF
--- a/book/chapter-02-robotica.html
+++ b/book/chapter-02-robotica.html
@@ -80,7 +80,7 @@
         </ol>
       </nav>
       <h1 class="text-2xl sm:text-3xl font-bold">💻 2.1 &mdash; Robotica e AI</h1>
-      <div class="reading-time mt-2">76 refs &middot; ~35 min &middot; 8.4k parole</div>
+      <div class="reading-time mt-2">77 refs &middot; ~36 min &middot; 8.6k parole</div>
     </div>
   </header>
 
@@ -256,6 +256,9 @@ Finir&agrave; come Westworld?</span>).</p>
     <p>Martin Ford, nel suo libro <em>The Rise of the Robots</em> (2015), analizza nel dettaglio i trend di automazione e i loro impatti sulla societ&agrave;. Oltre al processo gi&agrave; avviato nel ventesimo secolo, con l&rsquo;automatizzazione del lavoro fisico, nel ventunesimo secolo anche professioni considerate &ldquo;alte&rdquo; &mdash; medici, ingegneri, traduttori, avvocati &mdash; saranno investite dalla stessa ondata. La concentrazione di valore si accentua: YouTube aveva sessantacinque dipendenti nell&rsquo;anno in cui fu venduta per due miliardi di dollari. Nel primo decennio del Duemila si sono bruciati nove milioni di posti di lavoro; nel 2021, negli Stati Uniti sono stati ordinati ventinovemila robot industriali, con un incremento del trentasette per cento. Amazon impiega trecentocinquantamila robot a fronte di un organico umano quattro volte pi&ugrave; grande
     (<span class="fc">&#128177; ff.9.2
     I robot ci ruberanno il lavoro?</span>).</p>
+
+    <!-- ===== inject 2026-04-14 — note_id:1415 — Stanford AI job displacement giovani ===== -->
+    <p>Ford scriveva nel 2015, quando l&rsquo;ondata era ancora teoria. Dieci anni dopo, uno <a id="ref-fonte-79"></a><a href="https://digitaleconomy.stanford.edu/wp-content/uploads/2025/08/Canaries_BrynjolfssonChandarChen.pdf" target="_blank" rel="noopener" style="font-size:0.92rem;font-weight:600;color:var(--accent);text-decoration:none;">studio di Stanford firmato da Brynjolfsson</a><sup><a href="#fonte-79" style="color:var(--accent);text-decoration:none;">[79]</a></sup> fornisce le prime evidenze empiriche: i lavoratori tra <mark class="note-highlight">22 e 25 anni</mark> in ruoli ad alta esposizione AI &mdash; software engineering, marketing, customer service &mdash; mostrano <mark class="note-highlight">cali significativi nell&rsquo;occupazione</mark>. Non sono i senior a cadere per primi: sono i junior, quelli che dovrebbero essere i nativi digitali. I canarini nella miniera dell&rsquo;AI sono i ventenni. La domanda non &egrave; pi&ugrave; se i robot ruberanno il lavoro, ma a chi lo stanno gi&agrave; rubando &mdash; e la risposta &egrave; contro-intuitiva: ai pi&ugrave; giovani, ai pi&ugrave; esposti, a quelli entrati nel mercato quando il mercato aveva gi&agrave; cominciato a contrarsi sotto i loro piedi.</p>
 
     <!-- ===== inject 2026-03-30 — Robot oltre la disabilit&agrave; (ff.9.4) ===== -->
     <p>Eppure la robotica non &egrave; solo sostituzione: pu&ograve; essere inclusione. DAWN &egrave; un bar giapponese dove i camerieri sono robot, controllati in remoto da persone con disabilit&agrave;. L&rsquo;esempio ricorda che l&rsquo;economia non &egrave; necessariamente un gioco a somma zero. Si possono creare sinergie inattese e imprevedibili, grazie ai robot: nuove forme di lavoro per chi ne era escluso, nuove modalit&agrave; di partecipazione sociale mediate dalla tecnologia
@@ -539,6 +542,7 @@ La terza vIA?</span>).</p>
         <li id="fonte-76"><a href="https://www.ft.com/content/82071cf2-f0da-432b-b815-606d602871fc" target="_blank" rel="noopener" class="text-blue-700 hover:underline">Financial Times — Primi trial clinici di molecole scoperte da AI</a> &mdash; <span class="text-zinc-500">ft.com</span></li>
         <li id="fonte-77"><a href="https://hub.jhu.edu/2025/07/09/robot-performs-first-realistic-surgery-without-human-help/" target="_blank" rel="noopener" class="text-blue-700 hover:underline">Un robot esegue la prima chirurgia realistica senza aiuto umano &mdash; Johns Hopkins</a> &mdash; <span class="text-zinc-500">hub.jhu.edu</span></li>
         <li id="fonte-78"><a href="https://www.linkedin.com/posts/brettadcock_today-figure-is-showing-another-major-milestone-ugcPost-7436806575538843648-61W1" target="_blank" rel="noopener" class="text-blue-700 hover:underline">Figure Helix 02 — pulizia autonoma end-to-end</a> &mdash; <span class="text-zinc-500">linkedin.com</span></li>
+        <li id="fonte-79"><a href="https://digitaleconomy.stanford.edu/wp-content/uploads/2025/08/Canaries_BrynjolfssonChandarChen.pdf" target="_blank" rel="noopener" class="text-blue-700 hover:underline">Stanford (Brynjolfsson): lavoratori 22-25 anni in ruoli AI mostrano cali significativi nell&rsquo;occupazione</a> &mdash; <span class="text-zinc-500">digitaleconomy.stanford.edu</span> <a href="#ref-fonte-79" style="text-decoration:none;">&#8629;</a></li>
       </ol>
     </section>
 

--- a/book/chapter-02.html
+++ b/book/chapter-02.html
@@ -50,7 +50,7 @@
       </nav>
       <div class="chapter-num text-zinc-400 mb-1">CAPITOLO 02 / 3</div>
       <h1 class="text-3xl sm:text-4xl font-bold">💻 Tecnologia</h1>
-      <div class="reading-time mt-3">144 refs &middot; 3 sezioni</div>
+      <div class="reading-time mt-3">145 refs &middot; 3 sezioni</div>
     </div>
   </header>
 
@@ -61,7 +61,7 @@
           <div class="ff-eyebrow text-xs" style="color:var(--accent);">2.1</div>
           <h3 class="text-lg font-bold mt-1">Robotica e AI</h3>
           <p class="text-sm text-zinc-600 mt-2 leading-relaxed">In tre mesi, NVIDIA ha incassato 57 miliardi di dollari, guadagnandone 36 con un margine del 75%. Numeri incomprensibili. Proviamo a capirli. Il valore di mercato di NVIDIA supera quello di tutte le...</p>
-          <div class="reading-time mt-3">72 refs &middot; ~35 min &middot; 8.5k parole</div>
+          <div class="reading-time mt-3">73 refs &middot; ~36 min &middot; 8.6k parole</div>
         </a>
 
         <a href="chapter-02-metaverso.html" class="brutal-card accent-bar block hover:shadow-lg transition-shadow" style="text-decoration:none;color:inherit;">

--- a/book/index.html
+++ b/book/index.html
@@ -1180,7 +1180,7 @@
         </ul>
         <div class="mt-4 flex items-center justify-between gap-3">
           <a class="ff-button underline" data-track="chapter_open" href="/book/chapter-02.html">Leggi capitolo &rarr;</a>
-          <div class="ff-caption" style="color: #888;">156 refs · ~65 min · 15.9k parole</div>
+          <div class="ff-caption" style="color: #888;">157 refs · ~66 min · 16.1k parole</div>
         </div>
       </article>
 


### PR DESCRIPTION
## Summary
- **Note 1415**: Studio Stanford (Brynjolfsson) — lavoratori 22-25 anni in ruoli AI (software, marketing, customer service) mostrano cali significativi nell'occupazione
- Injected into `chapter-02-robotica.html` after the Martin Ford "Rise of the Robots" paragraph
- Flows naturally from "will robots steal jobs?" to "they already are, and the youngest workers fall first"
- Bidirectional bibliography entry fonte-79 with Stanford PDF link
- Stats updated across chapter-02-robotica, chapter-02, and index.html

## Corpus fidelity
- All data points trace directly to note 1415 in notes.json
- No cross-ref invented — the paragraph connects organically to the ff.9.2 context already present
- No citation blocks, no embellishment

## Checklist
- [x] Corpus fidelity verified
- [x] Highlight colors match chapter scheme (blue/accent)
- [x] No citation blocks
- [x] Bibliography with bidirectional anchor
- [x] Neighbors reviewed for coherence
- [x] Index.html stats updated