### PR TITLE
book/index: ff.x.y codes + auto-highlight recent injections

### DIFF
--- a/book/index.html
+++ b/book/index.html
@@ -130,6 +130,33 @@
     .sub-list { list-style: none; padding: 0; margin: 0; }
     .sub-list li { padding: 6px 0; border-bottom: 1px solid rgba(0,0,0,0.06); }
     .sub-list li:last-child { border-bottom: none; }
+    /* Recent injection highlight — aggiornato automaticamente da #ultime-aggiunte */
+    .sub-list a.ff-recent { font-weight: 800 !important; color: #111 !important; }
+    .sub-list a.ff-recent .ff-ref-badge {
+      display: inline-block;
+      background: var(--ff-yellow);
+      color: #000;
+      font-family: 'IBM Plex Mono', monospace;
+      font-size: 0.62rem;
+      font-weight: 700;
+      padding: 1px 5px;
+      border-radius: 3px;
+      margin-right: 5px;
+      vertical-align: middle;
+      letter-spacing: 0.3px;
+    }
+    .sub-list a.ff-recent:hover { color: var(--ff-yellow) !important; }
+    .ff-chapter-recent-count {
+      font-family: 'IBM Plex Mono', monospace;
+      font-size: 0.72rem;
+      font-weight: 700;
+      color: var(--ff-yellow);
+      background: rgba(245,166,35,0.12);
+      padding: 1px 6px;
+      border-radius: 4px;
+      margin-left: 0.5rem;
+      vertical-align: middle;
+    }
     @supports (padding: env(safe-area-inset-bottom)) {
       body {
         padding-left: env(safe-area-inset-left);
@@ -487,12 +514,13 @@
     </section>
 
     <!-- Ultime aggiunte — 2026-04-16 -->
-    <section class="mt-8 brutal-card accent-bar accent-yellow" style="border-width:3px;">
+    <section id="ultime-aggiunte" class="mt-8 brutal-card accent-bar accent-yellow" style="border-width:3px;">
       <details open>
-        <summary style="cursor:pointer;list-style:none;display:flex;align-items:center;gap:0.5rem;">
+        <summary style="cursor:pointer;list-style:none;display:flex;align-items:center;gap:0.5rem;flex-wrap:wrap;">
           <span style="transition:transform 0.2s;display:inline-block;" class="toggle-chevron">&#9654;</span>
           <span class="text-xl">&#9997;&#65039;</span>
           <h2 class="text-base font-bold uppercase" style="margin:0;display:inline;">Ultime aggiunte al corpus</h2>
+          <span id="ultime-codes" style="margin-left:0.5rem;font-family:'IBM Plex Mono',monospace;font-size:0.75rem;font-weight:600;color:var(--ff-yellow);letter-spacing:0.3px;"></span>
         </summary>
         <style>
           details[open] .toggle-chevron { transform: rotate(90deg); }
@@ -817,6 +845,71 @@
         }, 200);
       });
     });
+  })();
+  </script>
+
+  <!--
+    Highlight recently injected ff.x.y in chapter sub-lists, driven by #ultime-aggiunte.
+    Ricorrenza: lo script rilegge la section ad ogni page load, quindi ogni ciclo
+    di inject (che aggiorna le card "Ultime aggiunte") propaga automaticamente
+    bold/badge nell'indice + codici nel summary del toggle + contatore per capitolo.
+  -->
+  <script>
+  (function () {
+    "use strict";
+    var section = document.getElementById("ultime-aggiunte");
+    if (!section) return;
+
+    // Collect recent entries: href → ff.x.y code (ordered, unique)
+    var recentHrefs = {};
+    var recentCodes = [];
+    var seen = {};
+    section.querySelectorAll('a[href*="chapter-"]').forEach(function (a) {
+      var href = a.getAttribute("href");
+      if (!href) return;
+      var mono = a.querySelector("span[style*='IBM Plex Mono']");
+      var code = mono ? mono.textContent.trim() : "";
+      recentHrefs[href] = code;
+      if (code && !seen[code]) { seen[code] = 1; recentCodes.push(code); }
+    });
+
+    // Populate the toggle summary with the list of recent codes
+    var codesEl = document.getElementById("ultime-codes");
+    if (codesEl && recentCodes.length) {
+      codesEl.textContent = "// " + recentCodes.join(" · ");
+    }
+
+    // Mark matching sublist links
+    var matched = 0;
+    document.querySelectorAll('.sub-list a[href*="chapter-"]').forEach(function (a) {
+      var href = a.getAttribute("href");
+      if (!(href in recentHrefs)) return;
+      a.classList.add("ff-recent");
+      var code = recentHrefs[href];
+      if (code) {
+        var badge = document.createElement("span");
+        badge.className = "ff-ref-badge";
+        badge.textContent = code;
+        a.insertBefore(badge, a.firstChild);
+      }
+      matched++;
+    });
+
+    // Per-chapter counter in the h2 title
+    document.querySelectorAll("article.brutal-card").forEach(function (article) {
+      var n = article.querySelectorAll(".sub-list a.ff-recent").length;
+      if (n === 0) return;
+      var h2 = article.querySelector("h2");
+      if (!h2) return;
+      var tag = document.createElement("span");
+      tag.className = "ff-chapter-recent-count";
+      tag.textContent = "+" + n + " nuovi";
+      h2.appendChild(tag);
+    });
+
+    if (window.console) {
+      console.log("[ff-recent] codici: " + recentCodes.join(", ") + " · bold attivati: " + matched);
+    }
   })();
   </script>
 </body>


### PR DESCRIPTION
## Summary

- **Toggle summary** della card *Ultime aggiunte al corpus* ora mostra i codici ff.x.y (es. `// ff.1.3 · ff.56.1 · ff.69.1 · ff.57.2`), popolato dinamicamente dallo script (zero manutenzione manuale).
- **Indice capitoli**: i subchapter citati in "Ultime aggiunte" sono evidenziati in bold + badge giallo `ff.X.Y` accanto al titolo.
- **Contatore per capitolo**: accanto all'h2 del capitolo compare `+N nuovi` quando ha subchapter recenti.
- **Ricorrenza automatica**: lo script rilegge `#ultime-aggiunte` ad ogni page load. Ogni nuovo inject cycle che aggiorna quella section propaga il refresh senza ulteriori edit.

## Test plan

- [x] Aprire `book/index.html` → summary del toggle mostra i 4 codici ff correnti
- [x] Scendere alla grid capitoli → 4 subchapter bold + badge giallo
- [x] Verificare contatore `+N nuovi` sui capitoli 01 / 02 / 03
- [ ] Verificare live su https://futurofortissimo.github.io/book/ dopo merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)