### PR TITLE
book: 22 ff.x.y visibili + ffxy-index highlight + SEO 10x

### DIFF
--- a/book/chapter-01-ambiente.html
+++ b/book/chapter-01-ambiente.html
@@ -11,6 +11,55 @@
     <meta property="og:url" content="https://futurofortissimo.github.io/book/chapter-01-ambiente.html"/>
     <meta property="og:image" content="https://futurofortissimo.github.io/logo.png"/>
     <meta property="article:author" content="Michele Merelli"/>
+    
+    <!-- data-seo-upgraded: 2026-04-17 -->
+    <meta name="keywords" content="energia rinnovabile, solare, eolico, clima, biodiversità, geoingegneria, transizione energetica, sostenibilità, Futuro Fortissimo, libro"/>
+    <meta name="author" content="Michele Merelli"/>
+    <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large"/>
+    <link rel="alternate" hreflang="it" href="https://futurofortissimo.github.io/book/chapter-01-ambiente.html"/>
+    <link rel="alternate" hreflang="x-default" href="https://futurofortissimo.github.io/book/chapter-01-ambiente.html"/>
+
+    <meta property="og:site_name" content="Futuro Fortissimo"/>
+    <meta property="og:locale" content="it_IT"/>
+    <meta property="og:description" content="1.2 Ambiente ed Energia &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 73 fonti, ~39 min."/>
+    <meta property="article:section" content="Natura"/>
+    <meta property="article:modified_time" content="2026-04-17"/>
+
+    <meta name="twitter:card" content="summary_large_image"/>
+    <meta name="twitter:site" content="@micmer"/>
+    <meta name="twitter:creator" content="@micmer"/>
+    <meta name="twitter:title" content="1.2 — Ambiente ed Energia | 🌿 Natura"/>
+    <meta name="twitter:description" content="1.2 Ambiente ed Energia &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 73 fonti, ~39 min."/>
+    <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "1.2 — Ambiente ed Energia | 🌿 Natura",
+      "description": "1.2 Ambiente ed Energia &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 73 fonti, ~39 min.",
+      "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
+      "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
+      "datePublished": "2024-01-01",
+      "dateModified": "2026-04-17",
+      "inLanguage": "it",
+      "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-01-ambiente.html" },
+      "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },
+      "keywords": "energia rinnovabile, solare, eolico, clima, biodiversità, geoingegneria, transizione energetica, sostenibilità"
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://futurofortissimo.github.io/" },
+        { "@type": "ListItem", "position": 2, "name": "Libro", "item": "https://futurofortissimo.github.io/book/" },
+        { "@type": "ListItem", "position": 3, "name": "Cap. 1 — Natura", "item": "https://futurofortissimo.github.io/book/chapter-01.html" },
+        { "@type": "ListItem", "position": 4, "name": "1.2", "item": "https://futurofortissimo.github.io/book/chapter-01-ambiente.html" }
+      ]
+    }
+    </script>
     <link rel="icon" href="/favicon.ico"/>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-NQ7MQR0VL8"></script>
     <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-NQ7MQR0VL8');</script>

--- a/book/chapter-01-cibo.html
+++ b/book/chapter-01-cibo.html
@@ -11,6 +11,55 @@
     <meta property="og:url" content="https://futurofortissimo.github.io/book/chapter-01-cibo.html"/>
     <meta property="og:image" content="https://futurofortissimo.github.io/logo.png"/>
     <meta property="article:author" content="Michele Merelli"/>
+    
+    <!-- data-seo-upgraded: 2026-04-17 -->
+    <meta name="keywords" content="microbioma, alimentazione, cibo sostenibile, moda sostenibile, nutrizione, metabolismo, fashion, Futuro Fortissimo, libro"/>
+    <meta name="author" content="Michele Merelli"/>
+    <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large"/>
+    <link rel="alternate" hreflang="it" href="https://futurofortissimo.github.io/book/chapter-01-cibo.html"/>
+    <link rel="alternate" hreflang="x-default" href="https://futurofortissimo.github.io/book/chapter-01-cibo.html"/>
+
+    <meta property="og:site_name" content="Futuro Fortissimo"/>
+    <meta property="og:locale" content="it_IT"/>
+    <meta property="og:description" content="1.3 Cibo e Fashion &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 53 fonti, ~28 min."/>
+    <meta property="article:section" content="Natura"/>
+    <meta property="article:modified_time" content="2026-04-17"/>
+
+    <meta name="twitter:card" content="summary_large_image"/>
+    <meta name="twitter:site" content="@micmer"/>
+    <meta name="twitter:creator" content="@micmer"/>
+    <meta name="twitter:title" content="1.3 — Cibo e Fashion | 🌿 Natura"/>
+    <meta name="twitter:description" content="1.3 Cibo e Fashion &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 53 fonti, ~28 min."/>
+    <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "1.3 — Cibo e Fashion | 🌿 Natura",
+      "description": "1.3 Cibo e Fashion &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 53 fonti, ~28 min.",
+      "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
+      "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
+      "datePublished": "2024-01-01",
+      "dateModified": "2026-04-17",
+      "inLanguage": "it",
+      "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-01-cibo.html" },
+      "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },
+      "keywords": "microbioma, alimentazione, cibo sostenibile, moda sostenibile, nutrizione, metabolismo, fashion"
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://futurofortissimo.github.io/" },
+        { "@type": "ListItem", "position": 2, "name": "Libro", "item": "https://futurofortissimo.github.io/book/" },
+        { "@type": "ListItem", "position": 3, "name": "Cap. 1 — Natura", "item": "https://futurofortissimo.github.io/book/chapter-01.html" },
+        { "@type": "ListItem", "position": 4, "name": "1.3", "item": "https://futurofortissimo.github.io/book/chapter-01-cibo.html" }
+      ]
+    }
+    </script>
     <link rel="icon" href="/favicon.ico"/>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-NQ7MQR0VL8"></script>
     <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-NQ7MQR0VL8');</script>

--- a/book/chapter-01-mobilita.html
+++ b/book/chapter-01-mobilita.html
@@ -11,6 +11,55 @@
     <meta property="og:url" content="https://futurofortissimo.github.io/book/chapter-01-mobilita.html"/>
     <meta property="og:image" content="https://futurofortissimo.github.io/logo.png"/>
     <meta property="article:author" content="Michele Merelli"/>
+    
+    <!-- data-seo-upgraded: 2026-04-17 -->
+    <meta name="keywords" content="mobilità urbana, città a 15 minuti, micromobilità, e-bike, auto elettriche, trasporti sostenibili, smart city, Futuro Fortissimo, libro"/>
+    <meta name="author" content="Michele Merelli"/>
+    <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large"/>
+    <link rel="alternate" hreflang="it" href="https://futurofortissimo.github.io/book/chapter-01-mobilita.html"/>
+    <link rel="alternate" hreflang="x-default" href="https://futurofortissimo.github.io/book/chapter-01-mobilita.html"/>
+
+    <meta property="og:site_name" content="Futuro Fortissimo"/>
+    <meta property="og:locale" content="it_IT"/>
+    <meta property="og:description" content="1.1 Mobilità e Città &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 15 fonti, ~8 min."/>
+    <meta property="article:section" content="Natura"/>
+    <meta property="article:modified_time" content="2026-04-17"/>
+
+    <meta name="twitter:card" content="summary_large_image"/>
+    <meta name="twitter:site" content="@micmer"/>
+    <meta name="twitter:creator" content="@micmer"/>
+    <meta name="twitter:title" content="1.1 — Mobilità e Città | 🌿 Natura"/>
+    <meta name="twitter:description" content="1.1 Mobilità e Città &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 15 fonti, ~8 min."/>
+    <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "1.1 — Mobilità e Città | 🌿 Natura",
+      "description": "1.1 Mobilità e Città &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 15 fonti, ~8 min.",
+      "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
+      "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
+      "datePublished": "2024-01-01",
+      "dateModified": "2026-04-17",
+      "inLanguage": "it",
+      "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-01-mobilita.html" },
+      "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },
+      "keywords": "mobilità urbana, città a 15 minuti, micromobilità, e-bike, auto elettriche, trasporti sostenibili, smart city"
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://futurofortissimo.github.io/" },
+        { "@type": "ListItem", "position": 2, "name": "Libro", "item": "https://futurofortissimo.github.io/book/" },
+        { "@type": "ListItem", "position": 3, "name": "Cap. 1 — Natura", "item": "https://futurofortissimo.github.io/book/chapter-01.html" },
+        { "@type": "ListItem", "position": 4, "name": "1.1", "item": "https://futurofortissimo.github.io/book/chapter-01-mobilita.html" }
+      ]
+    }
+    </script>
     <link rel="icon" href="/favicon.ico"/>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-NQ7MQR0VL8"></script>
     <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-NQ7MQR0VL8');</script>

--- a/book/chapter-01.html
+++ b/book/chapter-01.html
@@ -3,10 +3,62 @@
 <head>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <title>Capitolo 1 &mdash; 🌿 Natura | Futuro Fortissimo</title>
-    <meta name="description" content="Capitolo 1: Natura. 3 sezioni, 140 fonti dal corpus di Futuro Fortissimo."/>
+    <title>Natura: mobilit&agrave;, energia, cibo — Cap. 1 | Futuro Fortissimo</title>
+    <meta name="description" content="Capitolo 1 Natura: come la mobilit&agrave; urbana, la citt&agrave; a 15 minuti, le rinnovabili e il microbioma ridisegnano citt&agrave; e piatto. 140 fonti, ~82 min lettura, EPUB gratis."/>
+    <meta name="keywords" content="natura, mobilit&agrave; urbana, citt&agrave; a 15 minuti, energia rinnovabile, solare, microbioma, biodiversit&agrave;, clima, cibo sostenibile, Futuro Fortissimo, libro"/>
+    <meta name="author" content="Michele Merelli"/>
+    <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large"/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-01.html"/>
+    <link rel="alternate" hreflang="it" href="https://futurofortissimo.github.io/book/chapter-01.html"/>
+    <link rel="alternate" hreflang="x-default" href="https://futurofortissimo.github.io/book/chapter-01.html"/>
+
+    <meta property="og:site_name" content="Futuro Fortissimo"/>
+    <meta property="og:locale" content="it_IT"/>
+    <meta property="og:type" content="article"/>
+    <meta property="og:title" content="Natura — Il Verde, la Citt&agrave; e il Piatto | Futuro Fortissimo"/>
+    <meta property="og:description" content="Mobilit&agrave;, energia, cibo: la natura non &egrave; sfondo ma sistema operativo. Biofilia, microbioma, clima ridisegnano citt&agrave; e piatti. Capitolo 1 del libro."/>
+    <meta property="og:url" content="https://futurofortissimo.github.io/book/chapter-01.html"/>
+    <meta property="og:image" content="https://futurofortissimo.github.io/logo.png"/>
+    <meta property="article:author" content="Michele Merelli"/>
+    <meta property="article:section" content="Natura"/>
+    <meta property="article:modified_time" content="2026-04-17"/>
+
+    <meta name="twitter:card" content="summary_large_image"/>
+    <meta name="twitter:site" content="@micmer"/>
+    <meta name="twitter:creator" content="@micmer"/>
+    <meta name="twitter:title" content="Natura — Cap. 1 | Futuro Fortissimo"/>
+    <meta name="twitter:description" content="Mobilit&agrave;, energia, cibo: natura come sistema operativo. 140 fonti. Lettura libera + EPUB."/>
+    <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
+
     <link rel="icon" href="/favicon.ico"/>
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "Natura — Il Verde, la Citt\u00E0 e il Piatto",
+      "description": "Capitolo 1 del libro Futuro Fortissimo: mobilit\u00E0, energia, cibo, moda come sistema operativo.",
+      "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
+      "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
+      "datePublished": "2024-01-01",
+      "dateModified": "2026-04-17",
+      "inLanguage": "it",
+      "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-01.html" },
+      "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },
+      "keywords": "natura, mobilit\u00E0 urbana, citt\u00E0 a 15 minuti, energia rinnovabile, microbioma, clima, cibo"
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://futurofortissimo.github.io/" },
+        { "@type": "ListItem", "position": 2, "name": "Libro", "item": "https://futurofortissimo.github.io/book/" },
+        { "@type": "ListItem", "position": 3, "name": "Cap. 1 — Natura", "item": "https://futurofortissimo.github.io/book/chapter-01.html" }
+      ]
+    }
+    </script>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-NQ7MQR0VL8"></script>
     <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-NQ7MQR0VL8');</script>
     <script src="https://cdn.tailwindcss.com"></script>

--- a/book/chapter-02-metaverso.html
+++ b/book/chapter-02-metaverso.html
@@ -11,6 +11,55 @@
     <meta property="og:url" content="https://futurofortissimo.github.io/book/chapter-02-metaverso.html"/>
     <meta property="og:image" content="https://futurofortissimo.github.io/logo.png"/>
     <meta property="article:author" content="Michele Merelli"/>
+    
+    <!-- data-seo-upgraded: 2026-04-17 -->
+    <meta name="keywords" content="metaverso, criptovalute, blockchain, NFT, avatar, realtà virtuale, simulazione, Web3, Futuro Fortissimo, libro"/>
+    <meta name="author" content="Michele Merelli"/>
+    <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large"/>
+    <link rel="alternate" hreflang="it" href="https://futurofortissimo.github.io/book/chapter-02-metaverso.html"/>
+    <link rel="alternate" hreflang="x-default" href="https://futurofortissimo.github.io/book/chapter-02-metaverso.html"/>
+
+    <meta property="og:site_name" content="Futuro Fortissimo"/>
+    <meta property="og:locale" content="it_IT"/>
+    <meta property="og:description" content="2.2 Metaverso e Criptovalute &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 29 fonti, ~12 min."/>
+    <meta property="article:section" content="Tecnologia"/>
+    <meta property="article:modified_time" content="2026-04-17"/>
+
+    <meta name="twitter:card" content="summary_large_image"/>
+    <meta name="twitter:site" content="@micmer"/>
+    <meta name="twitter:creator" content="@micmer"/>
+    <meta name="twitter:title" content="2.2 — Metaverso e Criptovalute | 💻 Tecnologia"/>
+    <meta name="twitter:description" content="2.2 Metaverso e Criptovalute &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 29 fonti, ~12 min."/>
+    <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "2.2 — Metaverso e Criptovalute | 💻 Tecnologia",
+      "description": "2.2 Metaverso e Criptovalute &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 29 fonti, ~12 min.",
+      "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
+      "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
+      "datePublished": "2024-01-01",
+      "dateModified": "2026-04-17",
+      "inLanguage": "it",
+      "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-02-metaverso.html" },
+      "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },
+      "keywords": "metaverso, criptovalute, blockchain, NFT, avatar, realtà virtuale, simulazione, Web3"
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://futurofortissimo.github.io/" },
+        { "@type": "ListItem", "position": 2, "name": "Libro", "item": "https://futurofortissimo.github.io/book/" },
+        { "@type": "ListItem", "position": 3, "name": "Cap. 2 — Tecnologia", "item": "https://futurofortissimo.github.io/book/chapter-02.html" },
+        { "@type": "ListItem", "position": 4, "name": "2.2", "item": "https://futurofortissimo.github.io/book/chapter-02-metaverso.html" }
+      ]
+    }
+    </script>
     <link rel="icon" href="/favicon.ico"/>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-NQ7MQR0VL8"></script>
     <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-NQ7MQR0VL8');</script>

--- a/book/chapter-02-prodotti.html
+++ b/book/chapter-02-prodotti.html
@@ -11,6 +11,55 @@
     <meta property="og:url" content="https://futurofortissimo.github.io/book/chapter-02-prodotti.html"/>
     <meta property="og:image" content="https://futurofortissimo.github.io/logo.png"/>
     <meta property="article:author" content="Michele Merelli"/>
+    
+    <!-- data-seo-upgraded: 2026-04-17 -->
+    <meta name="keywords" content="prodotti di consumo AI, agenti personali, AI medica, stablecoin, interfacce, consumer tech, Futuro Fortissimo, libro"/>
+    <meta name="author" content="Michele Merelli"/>
+    <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large"/>
+    <link rel="alternate" hreflang="it" href="https://futurofortissimo.github.io/book/chapter-02-prodotti.html"/>
+    <link rel="alternate" hreflang="x-default" href="https://futurofortissimo.github.io/book/chapter-02-prodotti.html"/>
+
+    <meta property="og:site_name" content="Futuro Fortissimo"/>
+    <meta property="og:locale" content="it_IT"/>
+    <meta property="og:description" content="2.3 Prodotti di consumo &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 42 fonti, ~16 min."/>
+    <meta property="article:section" content="Tecnologia"/>
+    <meta property="article:modified_time" content="2026-04-17"/>
+
+    <meta name="twitter:card" content="summary_large_image"/>
+    <meta name="twitter:site" content="@micmer"/>
+    <meta name="twitter:creator" content="@micmer"/>
+    <meta name="twitter:title" content="2.3 — Prodotti di consumo | 💻 Tecnologia"/>
+    <meta name="twitter:description" content="2.3 Prodotti di consumo &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 42 fonti, ~16 min."/>
+    <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "2.3 — Prodotti di consumo | 💻 Tecnologia",
+      "description": "2.3 Prodotti di consumo &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 42 fonti, ~16 min.",
+      "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
+      "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
+      "datePublished": "2024-01-01",
+      "dateModified": "2026-04-17",
+      "inLanguage": "it",
+      "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-02-prodotti.html" },
+      "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },
+      "keywords": "prodotti di consumo AI, agenti personali, AI medica, stablecoin, interfacce, consumer tech"
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://futurofortissimo.github.io/" },
+        { "@type": "ListItem", "position": 2, "name": "Libro", "item": "https://futurofortissimo.github.io/book/" },
+        { "@type": "ListItem", "position": 3, "name": "Cap. 2 — Tecnologia", "item": "https://futurofortissimo.github.io/book/chapter-02.html" },
+        { "@type": "ListItem", "position": 4, "name": "2.3", "item": "https://futurofortissimo.github.io/book/chapter-02-prodotti.html" }
+      ]
+    }
+    </script>
     <link rel="icon" href="/favicon.ico"/>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-NQ7MQR0VL8"></script>
     <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-NQ7MQR0VL8');</script>

--- a/book/chapter-02-robotica.html
+++ b/book/chapter-02-robotica.html
@@ -11,6 +11,55 @@
     <meta property="og:url" content="https://futurofortissimo.github.io/book/chapter-02-robotica.html"/>
     <meta property="og:image" content="https://futurofortissimo.github.io/logo.png"/>
     <meta property="article:author" content="Michele Merelli"/>
+    
+    <!-- data-seo-upgraded: 2026-04-17 -->
+    <meta name="keywords" content="robotica, intelligenza artificiale, AI, LLM, agenti autonomi, Claude, GPT, world models, compute, Futuro Fortissimo, libro"/>
+    <meta name="author" content="Michele Merelli"/>
+    <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large"/>
+    <link rel="alternate" hreflang="it" href="https://futurofortissimo.github.io/book/chapter-02-robotica.html"/>
+    <link rel="alternate" hreflang="x-default" href="https://futurofortissimo.github.io/book/chapter-02-robotica.html"/>
+
+    <meta property="og:site_name" content="Futuro Fortissimo"/>
+    <meta property="og:locale" content="it_IT"/>
+    <meta property="og:description" content="2.1 Robotica e AI &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 70 fonti, ~33 min."/>
+    <meta property="article:section" content="Tecnologia"/>
+    <meta property="article:modified_time" content="2026-04-17"/>
+
+    <meta name="twitter:card" content="summary_large_image"/>
+    <meta name="twitter:site" content="@micmer"/>
+    <meta name="twitter:creator" content="@micmer"/>
+    <meta name="twitter:title" content="2.1 — Robotica e AI | 💻 Tecnologia"/>
+    <meta name="twitter:description" content="2.1 Robotica e AI &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 70 fonti, ~33 min."/>
+    <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "2.1 — Robotica e AI | 💻 Tecnologia",
+      "description": "2.1 Robotica e AI &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 70 fonti, ~33 min.",
+      "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
+      "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
+      "datePublished": "2024-01-01",
+      "dateModified": "2026-04-17",
+      "inLanguage": "it",
+      "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-02-robotica.html" },
+      "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },
+      "keywords": "robotica, intelligenza artificiale, AI, LLM, agenti autonomi, Claude, GPT, world models, compute"
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://futurofortissimo.github.io/" },
+        { "@type": "ListItem", "position": 2, "name": "Libro", "item": "https://futurofortissimo.github.io/book/" },
+        { "@type": "ListItem", "position": 3, "name": "Cap. 2 — Tecnologia", "item": "https://futurofortissimo.github.io/book/chapter-02.html" },
+        { "@type": "ListItem", "position": 4, "name": "2.1", "item": "https://futurofortissimo.github.io/book/chapter-02-robotica.html" }
+      ]
+    }
+    </script>
     <link rel="icon" href="/favicon.ico"/>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-NQ7MQR0VL8"></script>
     <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-NQ7MQR0VL8');</script>

--- a/book/chapter-02.html
+++ b/book/chapter-02.html
@@ -3,10 +3,61 @@
 <head>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <title>Capitolo 2 &mdash; 💻 Tecnologia | Futuro Fortissimo</title>
-    <meta name="description" content="Capitolo 2: Tecnologia. 3 sezioni, 141 fonti dal corpus di Futuro Fortissimo."/>
+    <title>Tecnologia: AI, robot, metaverso — Cap. 2 | Futuro Fortissimo</title>
+    <meta name="description" content="Capitolo 2 Tecnologia: robotica, AI, metaverso, crypto. Dal compute agli agenti autonomi, dal token alla singolarit&agrave; gentile. 141 fonti, ~61 min, EPUB gratis."/>
+    <meta name="keywords" content="tecnologia, intelligenza artificiale, AI, robotica, metaverso, criptovalute, blockchain, agenti autonomi, LLM, Claude, GPT, Futuro Fortissimo, libro"/>
+    <meta name="author" content="Michele Merelli"/>
+    <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large"/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-02.html"/>
+    <link rel="alternate" hreflang="it" href="https://futurofortissimo.github.io/book/chapter-02.html"/>
+    <link rel="alternate" hreflang="x-default" href="https://futurofortissimo.github.io/book/chapter-02.html"/>
+
+    <meta property="og:site_name" content="Futuro Fortissimo"/>
+    <meta property="og:locale" content="it_IT"/>
+    <meta property="og:type" content="article"/>
+    <meta property="og:title" content="Tecnologia — Dalla Macchina all'Agente | Futuro Fortissimo"/>
+    <meta property="og:description" content="Robotica, AI, metaverso, crypto: la tecnologia non &egrave; pi&ugrave; tool ma agente. Dal compute al token, dal simulacro alla singolarit&agrave;. Cap. 2 del libro."/>
+    <meta property="og:url" content="https://futurofortissimo.github.io/book/chapter-02.html"/>
+    <meta property="og:image" content="https://futurofortissimo.github.io/logo.png"/>
+    <meta property="article:author" content="Michele Merelli"/>
+    <meta property="article:section" content="Tecnologia"/>
+    <meta property="article:modified_time" content="2026-04-17"/>
+
+    <meta name="twitter:card" content="summary_large_image"/>
+    <meta name="twitter:site" content="@micmer"/>
+    <meta name="twitter:title" content="Tecnologia — Cap. 2 | Futuro Fortissimo"/>
+    <meta name="twitter:description" content="AI, robot, metaverso, crypto: dal compute agli agenti. 141 fonti. Lettura libera + EPUB."/>
+    <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
+
     <link rel="icon" href="/favicon.ico"/>
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "Tecnologia — Dalla Macchina all'Agente",
+      "description": "Capitolo 2 del libro Futuro Fortissimo: robotica, AI, metaverso, crypto.",
+      "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
+      "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
+      "datePublished": "2024-01-01",
+      "dateModified": "2026-04-17",
+      "inLanguage": "it",
+      "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-02.html" },
+      "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },
+      "keywords": "tecnologia, AI, robotica, metaverso, criptovalute, agenti autonomi, LLM"
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://futurofortissimo.github.io/" },
+        { "@type": "ListItem", "position": 2, "name": "Libro", "item": "https://futurofortissimo.github.io/book/" },
+        { "@type": "ListItem", "position": 3, "name": "Cap. 2 — Tecnologia", "item": "https://futurofortissimo.github.io/book/chapter-02.html" }
+      ]
+    }
+    </script>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-NQ7MQR0VL8"></script>
     <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-NQ7MQR0VL8');</script>
     <script src="https://cdn.tailwindcss.com"></script>

--- a/book/chapter-03-alimentazione.html
+++ b/book/chapter-03-alimentazione.html
@@ -11,6 +11,55 @@
     <meta property="og:url" content="https://futurofortissimo.github.io/book/chapter-03-alimentazione.html"/>
     <meta property="og:image" content="https://futurofortissimo.github.io/logo.png"/>
     <meta property="article:author" content="Michele Merelli"/>
+    
+    <!-- data-seo-upgraded: 2026-04-17 -->
+    <meta name="keywords" content="alimentazione, sport, HIIT, longevità, performance fisica, metabolismo, dieta, Futuro Fortissimo, libro"/>
+    <meta name="author" content="Michele Merelli"/>
+    <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large"/>
+    <link rel="alternate" hreflang="it" href="https://futurofortissimo.github.io/book/chapter-03-alimentazione.html"/>
+    <link rel="alternate" hreflang="x-default" href="https://futurofortissimo.github.io/book/chapter-03-alimentazione.html"/>
+
+    <meta property="og:site_name" content="Futuro Fortissimo"/>
+    <meta property="og:locale" content="it_IT"/>
+    <meta property="og:description" content="3.2 Alimentazione e Sport &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 26 fonti, ~10 min."/>
+    <meta property="article:section" content="Società"/>
+    <meta property="article:modified_time" content="2026-04-17"/>
+
+    <meta name="twitter:card" content="summary_large_image"/>
+    <meta name="twitter:site" content="@micmer"/>
+    <meta name="twitter:creator" content="@micmer"/>
+    <meta name="twitter:title" content="3.2 — Alimentazione e Sport | ❤️ Società"/>
+    <meta name="twitter:description" content="3.2 Alimentazione e Sport &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 26 fonti, ~10 min."/>
+    <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "3.2 — Alimentazione e Sport | ❤️ Società",
+      "description": "3.2 Alimentazione e Sport &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 26 fonti, ~10 min.",
+      "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
+      "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
+      "datePublished": "2024-01-01",
+      "dateModified": "2026-04-17",
+      "inLanguage": "it",
+      "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-03-alimentazione.html" },
+      "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },
+      "keywords": "alimentazione, sport, HIIT, longevità, performance fisica, metabolismo, dieta"
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://futurofortissimo.github.io/" },
+        { "@type": "ListItem", "position": 2, "name": "Libro", "item": "https://futurofortissimo.github.io/book/" },
+        { "@type": "ListItem", "position": 3, "name": "Cap. 3 — Società", "item": "https://futurofortissimo.github.io/book/chapter-03.html" },
+        { "@type": "ListItem", "position": 4, "name": "3.2", "item": "https://futurofortissimo.github.io/book/chapter-03-alimentazione.html" }
+      ]
+    }
+    </script>
     <link rel="icon" href="/favicon.ico"/>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-NQ7MQR0VL8"></script>
     <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-NQ7MQR0VL8');</script>

--- a/book/chapter-03-cultura.html
+++ b/book/chapter-03-cultura.html
@@ -11,6 +11,55 @@
     <meta property="og:url" content="https://futurofortissimo.github.io/book/chapter-03-cultura.html"/>
     <meta property="og:image" content="https://futurofortissimo.github.io/logo.png"/>
     <meta property="article:author" content="Michele Merelli"/>
+    
+    <!-- data-seo-upgraded: 2026-04-17 -->
+    <meta name="keywords" content="cultura, demografia, solitudine, politica, lavoro, identità, arte, social media, Futuro Fortissimo, libro"/>
+    <meta name="author" content="Michele Merelli"/>
+    <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large"/>
+    <link rel="alternate" hreflang="it" href="https://futurofortissimo.github.io/book/chapter-03-cultura.html"/>
+    <link rel="alternate" hreflang="x-default" href="https://futurofortissimo.github.io/book/chapter-03-cultura.html"/>
+
+    <meta property="og:site_name" content="Futuro Fortissimo"/>
+    <meta property="og:locale" content="it_IT"/>
+    <meta property="og:description" content="3.3 Cultura, Politica e Demografia &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 61 fonti, ~26 min."/>
+    <meta property="article:section" content="Società"/>
+    <meta property="article:modified_time" content="2026-04-17"/>
+
+    <meta name="twitter:card" content="summary_large_image"/>
+    <meta name="twitter:site" content="@micmer"/>
+    <meta name="twitter:creator" content="@micmer"/>
+    <meta name="twitter:title" content="3.3 — Cultura, Politica e Demografia | ❤️ Società"/>
+    <meta name="twitter:description" content="3.3 Cultura, Politica e Demografia &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 61 fonti, ~26 min."/>
+    <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "3.3 — Cultura, Politica e Demografia | ❤️ Società",
+      "description": "3.3 Cultura, Politica e Demografia &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 61 fonti, ~26 min.",
+      "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
+      "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
+      "datePublished": "2024-01-01",
+      "dateModified": "2026-04-17",
+      "inLanguage": "it",
+      "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-03-cultura.html" },
+      "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },
+      "keywords": "cultura, demografia, solitudine, politica, lavoro, identità, arte, social media"
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://futurofortissimo.github.io/" },
+        { "@type": "ListItem", "position": 2, "name": "Libro", "item": "https://futurofortissimo.github.io/book/" },
+        { "@type": "ListItem", "position": 3, "name": "Cap. 3 — Società", "item": "https://futurofortissimo.github.io/book/chapter-03.html" },
+        { "@type": "ListItem", "position": 4, "name": "3.3", "item": "https://futurofortissimo.github.io/book/chapter-03-cultura.html" }
+      ]
+    }
+    </script>
     <link rel="icon" href="/favicon.ico"/>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-NQ7MQR0VL8"></script>
     <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-NQ7MQR0VL8');</script>

--- a/book/chapter-03-psicologia.html
+++ b/book/chapter-03-psicologia.html
@@ -11,6 +11,55 @@
     <meta property="og:url" content="https://futurofortissimo.github.io/book/chapter-03-psicologia.html"/>
     <meta property="og:image" content="https://futurofortissimo.github.io/logo.png"/>
     <meta property="article:author" content="Michele Merelli"/>
+    
+    <!-- data-seo-upgraded: 2026-04-17 -->
+    <meta name="keywords" content="psicologia, attenzione, mindfulness, significato, noia, routine, salute mentale, flow, Futuro Fortissimo, libro"/>
+    <meta name="author" content="Michele Merelli"/>
+    <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large"/>
+    <link rel="alternate" hreflang="it" href="https://futurofortissimo.github.io/book/chapter-03-psicologia.html"/>
+    <link rel="alternate" hreflang="x-default" href="https://futurofortissimo.github.io/book/chapter-03-psicologia.html"/>
+
+    <meta property="og:site_name" content="Futuro Fortissimo"/>
+    <meta property="og:locale" content="it_IT"/>
+    <meta property="og:description" content="3.1 Psicologia e Wellbeing &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 54 fonti, ~23 min."/>
+    <meta property="article:section" content="Società"/>
+    <meta property="article:modified_time" content="2026-04-17"/>
+
+    <meta name="twitter:card" content="summary_large_image"/>
+    <meta name="twitter:site" content="@micmer"/>
+    <meta name="twitter:creator" content="@micmer"/>
+    <meta name="twitter:title" content="3.1 — Psicologia e Wellbeing | ❤️ Società"/>
+    <meta name="twitter:description" content="3.1 Psicologia e Wellbeing &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 54 fonti, ~23 min."/>
+    <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "3.1 — Psicologia e Wellbeing | ❤️ Società",
+      "description": "3.1 Psicologia e Wellbeing &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 54 fonti, ~23 min.",
+      "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
+      "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
+      "datePublished": "2024-01-01",
+      "dateModified": "2026-04-17",
+      "inLanguage": "it",
+      "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-03-psicologia.html" },
+      "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },
+      "keywords": "psicologia, attenzione, mindfulness, significato, noia, routine, salute mentale, flow"
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://futurofortissimo.github.io/" },
+        { "@type": "ListItem", "position": 2, "name": "Libro", "item": "https://futurofortissimo.github.io/book/" },
+        { "@type": "ListItem", "position": 3, "name": "Cap. 3 — Società", "item": "https://futurofortissimo.github.io/book/chapter-03.html" },
+        { "@type": "ListItem", "position": 4, "name": "3.1", "item": "https://futurofortissimo.github.io/book/chapter-03-psicologia.html" }
+      ]
+    }
+    </script>
     <link rel="icon" href="/favicon.ico"/>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-NQ7MQR0VL8"></script>
     <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-NQ7MQR0VL8');</script>

--- a/book/chapter-03.html
+++ b/book/chapter-03.html
@@ -3,10 +3,61 @@
 <head>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <title>Capitolo 3 &mdash; ❤️ Società | Futuro Fortissimo</title>
-    <meta name="description" content="Capitolo 3: Società. 3 sezioni, 140 fonti dal corpus di Futuro Fortissimo."/>
+    <title>Societ&agrave;: psicologia, corpo, cultura — Cap. 3 | Futuro Fortissimo</title>
+    <meta name="description" content="Capitolo 3 Societ&agrave;: psicologia dell'attenzione, alimentazione e sport, cultura e demografia. 140 fonti, ~59 min lettura, EPUB gratis."/>
+    <meta name="keywords" content="societ&agrave;, psicologia, attenzione, demografia, cultura, solitudine, alimentazione, sport, longevit&agrave;, HIIT, Futuro Fortissimo, libro"/>
+    <meta name="author" content="Michele Merelli"/>
+    <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large"/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-03.html"/>
+    <link rel="alternate" hreflang="it" href="https://futurofortissimo.github.io/book/chapter-03.html"/>
+    <link rel="alternate" hreflang="x-default" href="https://futurofortissimo.github.io/book/chapter-03.html"/>
+
+    <meta property="og:site_name" content="Futuro Fortissimo"/>
+    <meta property="og:locale" content="it_IT"/>
+    <meta property="og:type" content="article"/>
+    <meta property="og:title" content="Societ&agrave; — Attenzione, Corpo, Cultura | Futuro Fortissimo"/>
+    <meta property="og:description" content="Psicologia dell'attenzione, alimentazione e sport, cultura e demografia. Come l'infrastruttura mentale e sociale si sta riscrivendo. Cap. 3 del libro."/>
+    <meta property="og:url" content="https://futurofortissimo.github.io/book/chapter-03.html"/>
+    <meta property="og:image" content="https://futurofortissimo.github.io/logo.png"/>
+    <meta property="article:author" content="Michele Merelli"/>
+    <meta property="article:section" content="Societ&agrave;"/>
+    <meta property="article:modified_time" content="2026-04-17"/>
+
+    <meta name="twitter:card" content="summary_large_image"/>
+    <meta name="twitter:site" content="@micmer"/>
+    <meta name="twitter:title" content="Societ&agrave; — Cap. 3 | Futuro Fortissimo"/>
+    <meta name="twitter:description" content="Psicologia, corpo, cultura: l'infrastruttura mentale che si riscrive. 140 fonti. Lettura libera + EPUB."/>
+    <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
+
     <link rel="icon" href="/favicon.ico"/>
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "Societ\u00E0 — Attenzione, Corpo, Cultura",
+      "description": "Capitolo 3 del libro Futuro Fortissimo: psicologia dell'attenzione, alimentazione, cultura.",
+      "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
+      "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
+      "datePublished": "2024-01-01",
+      "dateModified": "2026-04-17",
+      "inLanguage": "it",
+      "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-03.html" },
+      "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },
+      "keywords": "societ\u00E0, psicologia, attenzione, alimentazione, cultura, demografia"
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://futurofortissimo.github.io/" },
+        { "@type": "ListItem", "position": 2, "name": "Libro", "item": "https://futurofortissimo.github.io/book/" },
+        { "@type": "ListItem", "position": 3, "name": "Cap. 3 — Societ\u00E0", "item": "https://futurofortissimo.github.io/book/chapter-03.html" }
+      ]
+    }
+    </script>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-NQ7MQR0VL8"></script>
     <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-NQ7MQR0VL8');</script>
     <script src="https://cdn.tailwindcss.com"></script>

--- a/book/ffxy-index.html
+++ b/book/ffxy-index.html
@@ -7,6 +7,50 @@
   <meta name="description" content="Indice completo di tutti i riferimenti ff.x.y nel libro Tre Macro Temi di Futuro Fortissimo." />
 
   <link rel="canonical" href="https://futurofortissimo.github.io/book/ffxy-index.html" />
+  
+    <!-- data-seo-upgraded: 2026-04-17 -->
+  <meta name="keywords" content="ff.x.y, indice Futuro Fortissimo, riferimenti corpus, AI, natura, tecnologia, società"/>
+  <meta name="author" content="Michele Merelli"/>
+  <meta name="robots" content="index, follow, max-snippet:-1"/>
+  <link rel="alternate" hreflang="it" href="https://futurofortissimo.github.io/book/ffxy-index.html"/>
+
+  <meta property="og:site_name" content="Futuro Fortissimo"/>
+  <meta property="og:locale" content="it_IT"/>
+  <meta property="og:type" content="website"/>
+  <meta property="og:title" content="Indice ff.x.y | Futuro Fortissimo"/>
+  <meta property="og:description" content="Tutti i riferimenti ff.x.y del libro, cercabili e raggruppati per capitolo. 629+ voci dal corpus Futuro Fortissimo."/>
+  <meta property="og:url" content="https://futurofortissimo.github.io/book/ffxy-index.html"/>
+  <meta property="og:image" content="https://futurofortissimo.github.io/logo.png"/>
+
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:site" content="@micmer"/>
+  <meta name="twitter:title" content="Indice ff.x.y | Futuro Fortissimo"/>
+  <meta name="twitter:description" content="Tutti i riferimenti ff.x.y del libro, cercabili e raggruppati per capitolo."/>
+  <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "name": "Indice ff.x.y",
+    "description": "Tutti i riferimenti ff.x.y nel libro Futuro Fortissimo.",
+    "url": "https://futurofortissimo.github.io/book/ffxy-index.html",
+    "inLanguage": "it",
+    "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },
+    "author": { "@type": "Person", "name": "Michele Merelli" }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://futurofortissimo.github.io/" },
+      { "@type": "ListItem", "position": 2, "name": "Libro", "item": "https://futurofortissimo.github.io/book/" },
+      { "@type": "ListItem", "position": 3, "name": "Indice ff.x.y", "item": "https://futurofortissimo.github.io/book/ffxy-index.html" }
+    ]
+  }
+  </script>
   <link rel="icon" href="/favicon.ico" />
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -198,6 +242,51 @@
       font-size: 0.9rem;
       padding: 3rem 0;
     }
+
+    /* Recent injections (last cycle) */
+    .entry.entry--recent { background: rgba(245,166,35,0.08); border-left: 3px solid #f5a623; padding-left: 6px; }
+    .entry.entry--recent .entry-title { font-weight: 700; color: #111; }
+    .entry.entry--recent .entry-code { text-shadow: 0 0 0 currentColor; }
+    .entry-new-badge {
+      display: inline-block;
+      background: #f5a623;
+      color: #000;
+      font-family: 'IBM Plex Mono', monospace;
+      font-size: 0.62rem;
+      font-weight: 700;
+      padding: 1px 5px;
+      border-radius: 3px;
+      letter-spacing: 0.3px;
+      margin-right: 4px;
+    }
+    .recent-banner {
+      border: 2px solid #f5a623;
+      background: rgba(245,166,35,0.06);
+      padding: 0.8rem 1rem;
+      margin-bottom: 1.2rem;
+      font-size: 0.82rem;
+    }
+    .recent-banner strong {
+      font-family: 'IBM Plex Mono', monospace;
+      color: #b97808;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      font-size: 0.72rem;
+      display: block;
+      margin-bottom: 0.3rem;
+    }
+    .recent-banner code {
+      font-family: 'IBM Plex Mono', monospace;
+      font-size: 0.78rem;
+      font-weight: 600;
+      color: #111;
+      background: #fff;
+      border: 1px solid rgba(245,166,35,0.4);
+      padding: 1px 5px;
+      border-radius: 3px;
+      margin: 0 3px 3px 0;
+      display: inline-block;
+    }
   </style>
 </head>
 <body>
@@ -211,6 +300,7 @@
     </div>
 
     <div class="stats-bar" id="statsBar"></div>
+    <div id="recentBanner"></div>
     <div id="content"></div>
     <div class="no-results" id="noResults" style="display:none;">Nessun risultato.</div>
   </div>
@@ -225,6 +315,7 @@
     var data = [];
     var contentEl = document.getElementById('content');
     var statsEl = document.getElementById('statsBar');
+    var bannerEl = document.getElementById('recentBanner');
     var noResults = document.getElementById('noResults');
     var searchInput = document.getElementById('ffSearch');
     var debounceTimer;
@@ -234,6 +325,20 @@
       { name: 'Tecnologia', color: '#4a90e2', emoji: '\uD83D\uDCBB', num: 2 },
       { name: 'Societ\u00E0',    color: '#d0021b', emoji: '\u2764\uFE0F',  num: 3 }
     ];
+
+    // Codici iniettati nell'ultimo ciclo bulk (2026-04-17).
+    // Aggiornare questa lista ad ogni inject; alimenta sia il banner che il bold/badge degli entry.
+    var RECENT = {
+      date: '2026-04-17',
+      cycle: 'bulk inject 22 ff.X.Y + 20 note',
+      codes: [
+        'ff.26.5',
+        'ff.148.1','ff.148.3','ff.37.4','ff.148.4','ff.3.1','ff.3.4','ff.15.2','ff.26.1','ff.41.5',
+        'ff.68.3','ff.76.4','ff.112.3','ff.146.4','ff.62.5','ff.23.3','ff.23.4','ff.27.1','ff.27.2','ff.64.1','ff.18.2','ff.20.4'
+      ]
+    };
+    var RECENT_SET = {};
+    RECENT.codes.forEach(function (c) { RECENT_SET[c] = 1; });
 
     fetch('/book/ffxy-index.json')
       .then(function (r) { return r.json(); })
@@ -255,8 +360,29 @@
       }, 200);
     });
 
+    function renderBanner(entries) {
+      if (!bannerEl) return;
+      // Build a chip cloud of recent codes, linking to the corresponding entry (if present in data)
+      var byCode = {};
+      entries.forEach(function (e) { byCode[e.code] = e; });
+      var chips = RECENT.codes.map(function (c) {
+        var e = byCode[c];
+        if (e) {
+          var href = '/book/' + e.file + '#' + (e.anchorId || e.sectionId || '');
+          return '<a href="' + href + '" style="text-decoration:none;"><code>' + c + '</code></a>';
+        }
+        return '<code>' + c + '</code>';
+      }).join('');
+      bannerEl.innerHTML =
+        '<div class="recent-banner">' +
+          '<strong>// Appena iniettati &middot; ' + RECENT.date + ' &middot; ' + RECENT.cycle + '</strong>' +
+          chips +
+        '</div>';
+    }
+
     function render(entries) {
       contentEl.innerHTML = '';
+      renderBanner(entries);
       if (!entries.length) {
         noResults.style.display = '';
         statsEl.innerHTML = '';
@@ -297,9 +423,11 @@
 
         chEntries.forEach(function (e) {
           var a = document.createElement('a');
-          a.className = 'entry';
+          var isRecent = !!RECENT_SET[e.code];
+          a.className = 'entry' + (isRecent ? ' entry--recent' : '');
           a.href = '/book/' + e.file + '#' + (e.anchorId || e.sectionId || '');
           a.innerHTML =
+            (isRecent ? '<span class="entry-new-badge">NEW</span>' : '') +
             '<span class="entry-code" style="color:' + e.chapterColor + ';">' + e.code + '</span>' +
             '<span class="entry-emoji">' + e.emoji + '</span>' +
             '<span class="entry-title">' + escapeHtml(e.title) + '</span>' +

--- a/book/index.html
+++ b/book/index.html
@@ -3,24 +3,91 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Libro — Tre Macro Temi | Futuro Fortissimo</title>
-  <meta name="description" content="Tre saggi su Natura, Tecnologia e Societ&agrave; con 484 fonti dal corpus di Futuro Fortissimo." />
+  <title>Futuro Fortissimo — Il libro | Tre saggi su Natura, Tecnologia, Societ&agrave;</title>
+  <meta name="description" content="Leggi gratis il libro Futuro Fortissimo: tre saggi su mobilit&agrave;, energia, AI, robotica, metaverso, psicologia e cultura. 629+ riferimenti ff.x.y, 54k parole, EPUB scaricabile." />
+  <meta name="keywords" content="futuro fortissimo, libro, natura, tecnologia, societ&agrave;, AI, mobilit&agrave; urbana, energia rinnovabile, robotica, metaverso, psicologia, cultura, saggi italiani, futurologia, Michele Merelli, newsletter" />
+  <meta name="author" content="Michele Merelli" />
+  <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
 
   <link rel="canonical" href="https://futurofortissimo.github.io/book/" />
+  <link rel="alternate" hreflang="it" href="https://futurofortissimo.github.io/book/" />
+  <link rel="alternate" hreflang="x-default" href="https://futurofortissimo.github.io/book/" />
 
-  <meta property="og:title" content="Libro — Tre Macro Temi" />
-  <meta property="og:description" content="Tre saggi su Natura, Tecnologia e Societ&agrave;: un percorso di lettura dal corpus di Futuro Fortissimo." />
-  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Futuro Fortissimo" />
+  <meta property="og:locale" content="it_IT" />
+  <meta property="og:type" content="book" />
+  <meta property="og:title" content="Futuro Fortissimo — Il libro | Natura, Tecnologia, Societ&agrave;" />
+  <meta property="og:description" content="Tre saggi. 629+ riferimenti al corpus Futuro Fortissimo. AI, mobilit&agrave; urbana, energia, metaverso, psicologia, cultura — densi, dati-first, scaricabili in EPUB." />
   <meta property="og:url" content="https://futurofortissimo.github.io/book/" />
   <meta property="og:image" content="https://futurofortissimo.github.io/logo.png" />
+  <meta property="og:image:alt" content="Copertina del libro Futuro Fortissimo — Tre Macro Temi" />
+  <meta property="book:author" content="Michele Merelli" />
+  <meta property="book:release_date" content="2026-04-17" />
 
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Libro — Tre Macro Temi" />
-  <meta name="twitter:description" content="Tre saggi su Natura, Tecnologia e Societ&agrave;: un percorso di lettura dal corpus di Futuro Fortissimo." />
+  <meta name="twitter:site" content="@micmer" />
+  <meta name="twitter:creator" content="@micmer" />
+  <meta name="twitter:title" content="Futuro Fortissimo — Il libro" />
+  <meta name="twitter:description" content="Tre saggi su Natura, Tecnologia e Societ&agrave;. 629+ riferimenti ff.x.y. Scaricabile in EPUB." />
   <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png" />
 
   <link rel="icon" href="/favicon.ico" />
   <link rel="alternate" type="application/atom+xml" title="Futuro Fortissimo Feed" href="/feed.xml" />
+
+  <!-- Structured data: Book + BreadcrumbList -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Book",
+    "name": "Futuro Fortissimo — Tre Macro Temi",
+    "alternateName": "Tre saggi su Natura, Tecnologia e Societ\u00E0",
+    "url": "https://futurofortissimo.github.io/book/",
+    "author": {
+      "@type": "Person",
+      "name": "Michele Merelli",
+      "url": "https://futurofortissimo.substack.com/",
+      "sameAs": [
+        "https://www.linkedin.com/in/michelemerelli/",
+        "https://fortissimo.substack.com/",
+        "https://micmer-git.github.io/"
+      ]
+    },
+    "inLanguage": "it",
+    "datePublished": "2024-01-01",
+    "dateModified": "2026-04-17",
+    "description": "Tre saggi su Natura, Tecnologia e Societ\u00E0 con 629+ riferimenti al corpus di Futuro Fortissimo.",
+    "numberOfPages": 180,
+    "bookFormat": "https://schema.org/EBook",
+    "isAccessibleForFree": true,
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "EUR",
+      "availability": "https://schema.org/InStock",
+      "url": "https://futurofortissimo.github.io/book/"
+    },
+    "hasPart": [
+      { "@type": "Chapter", "name": "Natura — Il Verde, la Citt\u00E0 e il Piatto", "url": "https://futurofortissimo.github.io/book/chapter-01.html" },
+      { "@type": "Chapter", "name": "Tecnologia — Dalla Macchina all'Agente", "url": "https://futurofortissimo.github.io/book/chapter-02.html" },
+      { "@type": "Chapter", "name": "Societ\u00E0 — Attenzione, Corpo, Cultura", "url": "https://futurofortissimo.github.io/book/chapter-03.html" }
+    ],
+    "publisher": {
+      "@type": "Organization",
+      "name": "Futuro Fortissimo",
+      "url": "https://futurofortissimo.github.io/"
+    }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Futuro Fortissimo", "item": "https://futurofortissimo.github.io/" },
+      { "@type": "ListItem", "position": 2, "name": "Libro", "item": "https://futurofortissimo.github.io/book/" }
+    ]
+  }
+  </script>
 
   
     <!-- Google tag (gtag.js) -->
@@ -581,6 +648,38 @@
 
         </div>
 
+        <!-- Tutte le 22 iniezioni 2026-04-17 — compact pill grid -->
+        <div class="mt-6 pt-4" style="border-top:1px dashed rgba(0,0,0,0.12);">
+          <div class="ff-eyebrow mb-3" style="color:var(--ff-yellow);font-size:0.72rem;letter-spacing:0.22em;">// tutti i 22 ff.x.y iniettati (17 apr)</div>
+          <div style="display:flex;flex-wrap:wrap;gap:6px;">
+            <!-- Natura -->
+            <a href="/book/chapter-01-mobilita.html#s1-4" class="ff-recent-pill" data-axis="natura" data-code="ff.26.5" style="padding:3px 8px;border:1px solid var(--ff-green);border-radius:4px;font-family:'IBM Plex Mono',monospace;font-size:0.72rem;font-weight:700;color:var(--ff-green);text-decoration:none;background:rgba(46,204,113,0.06);">ff.26.5 · yacht volanti</a>
+            <!-- Tecnologia -->
+            <a href="/book/chapter-02-robotica.html#s1-1" class="ff-recent-pill" data-axis="tecnologia" data-code="ff.148.1" style="padding:3px 8px;border:1px solid var(--ff-blue);border-radius:4px;font-family:'IBM Plex Mono',monospace;font-size:0.72rem;font-weight:700;color:var(--ff-blue);text-decoration:none;background:rgba(74,144,226,0.06);">ff.148.1 · Claude Mythos</a>
+            <a href="/book/chapter-02-robotica.html#s1-2" class="ff-recent-pill" data-axis="tecnologia" data-code="ff.148.3" style="padding:3px 8px;border:1px solid var(--ff-blue);border-radius:4px;font-family:'IBM Plex Mono',monospace;font-size:0.72rem;font-weight:700;color:var(--ff-blue);text-decoration:none;background:rgba(74,144,226,0.06);">ff.148.3 · World Models</a>
+            <a href="/book/chapter-02-robotica.html#s1-3" class="ff-recent-pill" data-axis="tecnologia" data-code="ff.37.4" style="padding:3px 8px;border:1px solid var(--ff-blue);border-radius:4px;font-family:'IBM Plex Mono',monospace;font-size:0.72rem;font-weight:700;color:var(--ff-blue);text-decoration:none;background:rgba(74,144,226,0.06);">ff.37.4 · robot diffusi</a>
+            <a href="/book/chapter-02-metaverso.html#s2-1" class="ff-recent-pill" data-axis="tecnologia" data-code="ff.148.4" style="padding:3px 8px;border:1px solid var(--ff-blue);border-radius:4px;font-family:'IBM Plex Mono',monospace;font-size:0.72rem;font-weight:700;color:var(--ff-blue);text-decoration:none;background:rgba(74,144,226,0.06);">ff.148.4 · mondo dentro</a>
+            <a href="/book/chapter-02-metaverso.html#s2-1" class="ff-recent-pill" data-axis="tecnologia" data-code="ff.3.1" style="padding:3px 8px;border:1px solid var(--ff-blue);border-radius:4px;font-family:'IBM Plex Mono',monospace;font-size:0.72rem;font-weight:700;color:var(--ff-blue);text-decoration:none;background:rgba(74,144,226,0.06);">ff.3.1 · cosa sei Meta</a>
+            <a href="/book/chapter-02-metaverso.html#s2-1" class="ff-recent-pill" data-axis="tecnologia" data-code="ff.3.4" style="padding:3px 8px;border:1px solid var(--ff-blue);border-radius:4px;font-family:'IBM Plex Mono',monospace;font-size:0.72rem;font-weight:700;color:var(--ff-blue);text-decoration:none;background:rgba(74,144,226,0.06);">ff.3.4 · Discord facciata</a>
+            <a href="/book/chapter-02-metaverso.html#s2-1" class="ff-recent-pill" data-axis="tecnologia" data-code="ff.15.2" style="padding:3px 8px;border:1px solid var(--ff-blue);border-radius:4px;font-family:'IBM Plex Mono',monospace;font-size:0.72rem;font-weight:700;color:var(--ff-blue);text-decoration:none;background:rgba(74,144,226,0.06);">ff.15.2 · LV game</a>
+            <a href="/book/chapter-02-metaverso.html#s2-1" class="ff-recent-pill" data-axis="tecnologia" data-code="ff.26.1" style="padding:3px 8px;border:1px solid var(--ff-blue);border-radius:4px;font-family:'IBM Plex Mono',monospace;font-size:0.72rem;font-weight:700;color:var(--ff-blue);text-decoration:none;background:rgba(74,144,226,0.06);">ff.26.1 · influencer virtuali</a>
+            <a href="/book/chapter-02-prodotti.html#s3-2" class="ff-recent-pill" data-axis="tecnologia" data-code="ff.41.5" style="padding:3px 8px;border:1px solid var(--ff-blue);border-radius:4px;font-family:'IBM Plex Mono',monospace;font-size:0.72rem;font-weight:700;color:var(--ff-blue);text-decoration:none;background:rgba(74,144,226,0.06);">ff.41.5 · CFTR ChatGPT</a>
+            <!-- Societa -->
+            <a href="/book/chapter-03-psicologia.html#s1-2" class="ff-recent-pill" data-axis="societa" data-code="ff.68.3" style="padding:3px 8px;border:1px solid var(--ff-red);border-radius:4px;font-family:'IBM Plex Mono',monospace;font-size:0.72rem;font-weight:700;color:var(--ff-red);text-decoration:none;background:rgba(208,2,27,0.06);">ff.68.3 · maratona 2h45</a>
+            <a href="/book/chapter-03-psicologia.html#s1-4" class="ff-recent-pill" data-axis="societa" data-code="ff.76.4" style="padding:3px 8px;border:1px solid var(--ff-red);border-radius:4px;font-family:'IBM Plex Mono',monospace;font-size:0.72rem;font-weight:700;color:var(--ff-red);text-decoration:none;background:rgba(208,2,27,0.06);">ff.76.4 · Latour scarafaggio</a>
+            <a href="/book/chapter-03-psicologia.html#s1-4" class="ff-recent-pill" data-axis="societa" data-code="ff.112.3" style="padding:3px 8px;border:1px solid var(--ff-red);border-radius:4px;font-family:'IBM Plex Mono',monospace;font-size:0.72rem;font-weight:700;color:var(--ff-red);text-decoration:none;background:rgba(208,2,27,0.06);">ff.112.3 · NotebookLM</a>
+            <a href="/book/chapter-03-psicologia.html#s1-4" class="ff-recent-pill" data-axis="societa" data-code="ff.146.4" style="padding:3px 8px;border:1px solid var(--ff-red);border-radius:4px;font-family:'IBM Plex Mono',monospace;font-size:0.72rem;font-weight:700;color:var(--ff-red);text-decoration:none;background:rgba(208,2,27,0.06);">ff.146.4 · pathos</a>
+            <a href="/book/chapter-03-cultura.html#s3-1" class="ff-recent-pill" data-axis="societa" data-code="ff.62.5" style="padding:3px 8px;border:1px solid var(--ff-red);border-radius:4px;font-family:'IBM Plex Mono',monospace;font-size:0.72rem;font-weight:700;color:var(--ff-red);text-decoration:none;background:rgba(208,2,27,0.06);">ff.62.5 · indipendenza</a>
+            <a href="/book/chapter-03-cultura.html#s3-2" class="ff-recent-pill" data-axis="societa" data-code="ff.23.3" style="padding:3px 8px;border:1px solid var(--ff-red);border-radius:4px;font-family:'IBM Plex Mono',monospace;font-size:0.72rem;font-weight:700;color:var(--ff-red);text-decoration:none;background:rgba(208,2,27,0.06);">ff.23.3 · non si s***a</a>
+            <a href="/book/chapter-03-cultura.html#s3-2" class="ff-recent-pill" data-axis="societa" data-code="ff.23.4" style="padding:3px 8px;border:1px solid var(--ff-red);border-radius:4px;font-family:'IBM Plex Mono',monospace;font-size:0.72rem;font-weight:700;color:var(--ff-red);text-decoration:none;background:rgba(208,2,27,0.06);">ff.23.4 · Tinder parete</a>
+            <a href="/book/chapter-03-cultura.html#s3-4" class="ff-recent-pill" data-axis="societa" data-code="ff.27.1" style="padding:3px 8px;border:1px solid var(--ff-red);border-radius:4px;font-family:'IBM Plex Mono',monospace;font-size:0.72rem;font-weight:700;color:var(--ff-red);text-decoration:none;background:rgba(208,2,27,0.06);">ff.27.1 · pixel NYT</a>
+            <a href="/book/chapter-03-cultura.html#s3-4" class="ff-recent-pill" data-axis="societa" data-code="ff.27.2" style="padding:3px 8px;border:1px solid var(--ff-red);border-radius:4px;font-family:'IBM Plex Mono',monospace;font-size:0.72rem;font-weight:700;color:var(--ff-red);text-decoration:none;background:rgba(208,2,27,0.06);">ff.27.2 · scroll morti</a>
+            <a href="/book/chapter-03-cultura.html#s3-4" class="ff-recent-pill" data-axis="societa" data-code="ff.64.1" style="padding:3px 8px;border:1px solid var(--ff-red);border-radius:4px;font-family:'IBM Plex Mono',monospace;font-size:0.72rem;font-weight:700;color:var(--ff-red);text-decoration:none;background:rgba(208,2,27,0.06);">ff.64.1 · mostra vuoto</a>
+            <a href="/book/chapter-03-cultura.html#s3-4" class="ff-recent-pill" data-axis="societa" data-code="ff.18.2" style="padding:3px 8px;border:1px solid var(--ff-red);border-radius:4px;font-family:'IBM Plex Mono',monospace;font-size:0.72rem;font-weight:700;color:var(--ff-red);text-decoration:none;background:rgba(208,2,27,0.06);">ff.18.2 · Rankin cessi</a>
+            <a href="/book/chapter-03-cultura.html#s3-4" class="ff-recent-pill" data-axis="societa" data-code="ff.20.4" style="padding:3px 8px;border:1px solid var(--ff-red);border-radius:4px;font-family:'IBM Plex Mono',monospace;font-size:0.72rem;font-weight:700;color:var(--ff-red);text-decoration:none;background:rgba(208,2,27,0.06);">ff.20.4 · Wes Anderson</a>
+          </div>
+        </div>
+
         <p class="ff-body-sm mt-4" style="color:#777;font-style:italic;">Ultimo aggiornamento: 17 aprile 2026. Bulk inject consolidato: 22 ff.x.y + 20 note non citate, distribuiti su 3 assi con fidelity corpus verificata. EPUB ricostruito.</p>
 
         <div style="text-align:center;margin-top:1rem;">
@@ -884,55 +983,72 @@
     var section = document.getElementById("ultime-aggiunte");
     if (!section) return;
 
-    // Collect recent entries: href → ff.x.y code (ordered, unique)
-    var recentHrefs = {};
-    var recentCodes = [];
+    // Collect recent entries: href → [ff.x.y codes…] (multi-code aware)
+    var recentHrefs = {};   // href → array of codes
+    var recentCodes = [];   // ordered unique list of all codes
     var seen = {};
-    section.querySelectorAll('a[href*="chapter-"]').forEach(function (a) {
-      var href = a.getAttribute("href");
+
+    function addEntry(href, code) {
       if (!href) return;
+      if (!recentHrefs[href]) recentHrefs[href] = [];
+      if (code && recentHrefs[href].indexOf(code) === -1) recentHrefs[href].push(code);
+      if (code && !seen[code]) { seen[code] = 1; recentCodes.push(code); }
+    }
+
+    // (a) feature cards: ff.x.y inside an IBM Plex Mono span
+    section.querySelectorAll('a[href*="chapter-"]').forEach(function (a) {
+      if (a.classList.contains("ff-recent-pill")) return; // handled below
+      var href = a.getAttribute("href");
       var mono = a.querySelector("span[style*='IBM Plex Mono']");
       var code = mono ? mono.textContent.trim() : "";
-      recentHrefs[href] = code;
-      if (code && !seen[code]) { seen[code] = 1; recentCodes.push(code); }
+      addEntry(href, code);
+    });
+
+    // (b) compact pill grid: ff.x.y declared via data-code
+    section.querySelectorAll("a.ff-recent-pill").forEach(function (a) {
+      addEntry(a.getAttribute("href"), a.getAttribute("data-code") || "");
     });
 
     // Populate the toggle summary with the list of recent codes
     var codesEl = document.getElementById("ultime-codes");
     if (codesEl && recentCodes.length) {
-      codesEl.textContent = "// " + recentCodes.join(" · ");
+      codesEl.textContent = "// " + recentCodes.length + " nuovi: " + recentCodes.join(" · ");
     }
 
-    // Mark matching sublist links
+    // Mark matching sublist links → bold + badge with all codes
     var matched = 0;
     document.querySelectorAll('.sub-list a[href*="chapter-"]').forEach(function (a) {
       var href = a.getAttribute("href");
       if (!(href in recentHrefs)) return;
       a.classList.add("ff-recent");
-      var code = recentHrefs[href];
-      if (code) {
+      var codes = recentHrefs[href].filter(Boolean);
+      if (codes.length) {
         var badge = document.createElement("span");
         badge.className = "ff-ref-badge";
-        badge.textContent = code;
+        badge.textContent = codes.length > 1 ? codes.join(" ") : codes[0];
         a.insertBefore(badge, a.firstChild);
       }
       matched++;
     });
 
-    // Per-chapter counter in the h2 title
+    // Per-chapter counter in the h2 title (count codes, not anchors)
     document.querySelectorAll("article.brutal-card").forEach(function (article) {
-      var n = article.querySelectorAll(".sub-list a.ff-recent").length;
-      if (n === 0) return;
+      var codesInChapter = 0;
+      article.querySelectorAll(".sub-list a.ff-recent").forEach(function (a) {
+        var href = a.getAttribute("href");
+        codesInChapter += (recentHrefs[href] || []).length;
+      });
+      if (codesInChapter === 0) return;
       var h2 = article.querySelector("h2");
       if (!h2) return;
       var tag = document.createElement("span");
       tag.className = "ff-chapter-recent-count";
-      tag.textContent = "+" + n + " nuovi";
+      tag.textContent = "+" + codesInChapter + " nuovi";
       h2.appendChild(tag);
     });
 
     if (window.console) {
-      console.log("[ff-recent] codici: " + recentCodes.join(", ") + " · bold attivati: " + matched);
+      console.log("[ff-recent] " + recentCodes.length + " codici · " + matched + " subchapter in bold");
     }
   })();
   </script>

--- a/scripts/seo_upgrade_book.py
+++ b/scripts/seo_upgrade_book.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+SEO upgrade per le 9 subchapter pages + ffxy-index.html.
+Inietta: twitter card, og:description/site_name/locale, meta keywords/author/robots,
+hreflang, JSON-LD BreadcrumbList. Preserva titolo + description esistenti.
+Idempotente: se i tag ci sono gia', non li aggiunge di nuovo.
+"""
+import re
+from pathlib import Path
+
+BOOK_DIR = Path(__file__).resolve().parent.parent / "book"
+BASE_URL = "https://futurofortissimo.github.io/book"
+
+# slug → (axis color, keywords, axis name, chapter num, section num)
+PAGES = {
+    "chapter-01-mobilita.html": ("natura", "mobilit\u00e0 urbana, citt\u00e0 a 15 minuti, micromobilit\u00e0, e-bike, auto elettriche, trasporti sostenibili, smart city", "Natura", 1, "1.1"),
+    "chapter-01-ambiente.html": ("natura", "energia rinnovabile, solare, eolico, clima, biodiversit\u00e0, geoingegneria, transizione energetica, sostenibilit\u00e0", "Natura", 1, "1.2"),
+    "chapter-01-cibo.html":     ("natura", "microbioma, alimentazione, cibo sostenibile, moda sostenibile, nutrizione, metabolismo, fashion", "Natura", 1, "1.3"),
+    "chapter-02-robotica.html": ("tecnologia", "robotica, intelligenza artificiale, AI, LLM, agenti autonomi, Claude, GPT, world models, compute", "Tecnologia", 2, "2.1"),
+    "chapter-02-metaverso.html":("tecnologia", "metaverso, criptovalute, blockchain, NFT, avatar, realt\u00e0 virtuale, simulazione, Web3", "Tecnologia", 2, "2.2"),
+    "chapter-02-prodotti.html": ("tecnologia", "prodotti di consumo AI, agenti personali, AI medica, stablecoin, interfacce, consumer tech", "Tecnologia", 2, "2.3"),
+    "chapter-03-psicologia.html":   ("societa", "psicologia, attenzione, mindfulness, significato, noia, routine, salute mentale, flow", "Societ\u00e0", 3, "3.1"),
+    "chapter-03-alimentazione.html":("societa", "alimentazione, sport, HIIT, longevit\u00e0, performance fisica, metabolismo, dieta", "Societ\u00e0", 3, "3.2"),
+    "chapter-03-cultura.html":      ("societa", "cultura, demografia, solitudine, politica, lavoro, identit\u00e0, arte, social media", "Societ\u00e0", 3, "3.3"),
+}
+
+AXIS_COLORS = {"natura": "Natura", "tecnologia": "Tecnologia", "societa": "Societ\u00e0"}
+
+def extract_title_desc(html):
+    t = re.search(r"<title>(.*?)</title>", html, re.DOTALL)
+    d = re.search(r'<meta\s+name="description"\s+content="(.*?)"', html, re.DOTALL)
+    return (t.group(1).strip() if t else ""), (d.group(1).strip() if d else "")
+
+def upgrade_subchapter(path: Path):
+    html = path.read_text(encoding="utf-8")
+    if 'name="twitter:card"' in html and 'data-seo-upgraded' in html:
+        return False  # already upgraded
+    meta = PAGES[path.name]
+    axis, keywords, axis_name, ch_num, sec = meta
+    title, desc = extract_title_desc(html)
+    # Short titles/descriptions for twitter/og
+    og_title = title.replace(" | Futuro Fortissimo", "").replace("&mdash;", "\u2014")
+    # Short desc (fallback to title if description too long)
+    short_desc = desc if len(desc) < 200 else desc[:197] + "..."
+
+    block = f'''
+    <!-- data-seo-upgraded: 2026-04-17 -->
+    <meta name="keywords" content="{keywords}, Futuro Fortissimo, libro"/>
+    <meta name="author" content="Michele Merelli"/>
+    <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large"/>
+    <link rel="alternate" hreflang="it" href="{BASE_URL}/{path.name}"/>
+    <link rel="alternate" hreflang="x-default" href="{BASE_URL}/{path.name}"/>
+
+    <meta property="og:site_name" content="Futuro Fortissimo"/>
+    <meta property="og:locale" content="it_IT"/>
+    <meta property="og:description" content="{short_desc}"/>
+    <meta property="article:section" content="{axis_name}"/>
+    <meta property="article:modified_time" content="2026-04-17"/>
+
+    <meta name="twitter:card" content="summary_large_image"/>
+    <meta name="twitter:site" content="@micmer"/>
+    <meta name="twitter:creator" content="@micmer"/>
+    <meta name="twitter:title" content="{og_title}"/>
+    <meta name="twitter:description" content="{short_desc}"/>
+    <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
+
+    <script type="application/ld+json">
+    {{
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "{og_title}",
+      "description": "{short_desc}",
+      "author": {{ "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" }},
+      "publisher": {{ "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" }},
+      "datePublished": "2024-01-01",
+      "dateModified": "2026-04-17",
+      "inLanguage": "it",
+      "mainEntityOfPage": {{ "@type": "WebPage", "@id": "{BASE_URL}/{path.name}" }},
+      "isPartOf": {{ "@type": "Book", "name": "Futuro Fortissimo \u2014 Tre Macro Temi", "url": "{BASE_URL}/" }},
+      "keywords": "{keywords}"
+    }}
+    </script>
+    <script type="application/ld+json">
+    {{
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {{ "@type": "ListItem", "position": 1, "name": "Home", "item": "https://futurofortissimo.github.io/" }},
+        {{ "@type": "ListItem", "position": 2, "name": "Libro", "item": "{BASE_URL}/" }},
+        {{ "@type": "ListItem", "position": 3, "name": "Cap. {ch_num} \u2014 {axis_name}", "item": "{BASE_URL}/chapter-0{ch_num}.html" }},
+        {{ "@type": "ListItem", "position": 4, "name": "{sec}", "item": "{BASE_URL}/{path.name}" }}
+      ]
+    }}
+    </script>'''
+
+    # Inject before <link rel="icon" if present, else before </head>
+    anchor_icon = '<link rel="icon" href="/favicon.ico"/>'
+    if anchor_icon in html:
+        new_html = html.replace(anchor_icon, block + "\n    " + anchor_icon, 1)
+    else:
+        new_html = html.replace("</head>", block + "\n</head>", 1)
+    path.write_text(new_html, encoding="utf-8")
+    return True
+
+def upgrade_ffxy_index():
+    path = BOOK_DIR / "ffxy-index.html"
+    html = path.read_text(encoding="utf-8")
+    if 'data-seo-upgraded' in html:
+        return False
+    block = '''
+    <!-- data-seo-upgraded: 2026-04-17 -->
+  <meta name="keywords" content="ff.x.y, indice Futuro Fortissimo, riferimenti corpus, AI, natura, tecnologia, societ\u00e0"/>
+  <meta name="author" content="Michele Merelli"/>
+  <meta name="robots" content="index, follow, max-snippet:-1"/>
+  <link rel="alternate" hreflang="it" href="https://futurofortissimo.github.io/book/ffxy-index.html"/>
+
+  <meta property="og:site_name" content="Futuro Fortissimo"/>
+  <meta property="og:locale" content="it_IT"/>
+  <meta property="og:type" content="website"/>
+  <meta property="og:title" content="Indice ff.x.y | Futuro Fortissimo"/>
+  <meta property="og:description" content="Tutti i riferimenti ff.x.y del libro, cercabili e raggruppati per capitolo. 629+ voci dal corpus Futuro Fortissimo."/>
+  <meta property="og:url" content="https://futurofortissimo.github.io/book/ffxy-index.html"/>
+  <meta property="og:image" content="https://futurofortissimo.github.io/logo.png"/>
+
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:site" content="@micmer"/>
+  <meta name="twitter:title" content="Indice ff.x.y | Futuro Fortissimo"/>
+  <meta name="twitter:description" content="Tutti i riferimenti ff.x.y del libro, cercabili e raggruppati per capitolo."/>
+  <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "name": "Indice ff.x.y",
+    "description": "Tutti i riferimenti ff.x.y nel libro Futuro Fortissimo.",
+    "url": "https://futurofortissimo.github.io/book/ffxy-index.html",
+    "inLanguage": "it",
+    "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo \u2014 Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },
+    "author": { "@type": "Person", "name": "Michele Merelli" }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://futurofortissimo.github.io/" },
+      { "@type": "ListItem", "position": 2, "name": "Libro", "item": "https://futurofortissimo.github.io/book/" },
+      { "@type": "ListItem", "position": 3, "name": "Indice ff.x.y", "item": "https://futurofortissimo.github.io/book/ffxy-index.html" }
+    ]
+  }
+  </script>'''
+    anchor = '<link rel="icon" href="/favicon.ico" />'
+    if anchor in html:
+        new_html = html.replace(anchor, block + "\n  " + anchor, 1)
+    else:
+        new_html = html.replace("</head>", block + "\n</head>", 1)
+    path.write_text(new_html, encoding="utf-8")
+    return True
+
+if __name__ == "__main__":
+    upgraded = 0
+    for name in PAGES:
+        p = BOOK_DIR / name
+        if p.exists() and upgrade_subchapter(p):
+            print(f"[OK] {name}")
+            upgraded += 1
+        elif not p.exists():
+            print(f"[SKIP missing] {name}")
+        else:
+            print(f"[SKIP already] {name}")
+    if upgrade_ffxy_index():
+        print("[OK] ffxy-index.html")
+        upgraded += 1
+    else:
+        print("[SKIP already] ffxy-index.html")
+    print(f"\nTotale upgradate: {upgraded}")

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -89,27 +89,91 @@
   <!-- === LIBRO (Book chapters) === -->
   <url>
     <loc>https://futurofortissimo.github.io/book/</loc>
-    <lastmod>2026-03-25</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://futurofortissimo.github.io/book/chapter-01.html</loc>
-    <lastmod>2026-03-25</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://futurofortissimo.github.io/book/chapter-02.html</loc>
-    <lastmod>2026-03-25</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://futurofortissimo.github.io/book/chapter-03.html</loc>
-    <lastmod>2026-03-25</lastmod>
+    <lastmod>2026-04-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <!-- Subchapter pages (Natura) -->
+  <url>
+    <loc>https://futurofortissimo.github.io/book/chapter-01-mobilita.html</loc>
+    <lastmod>2026-04-17</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://futurofortissimo.github.io/book/chapter-01-ambiente.html</loc>
+    <lastmod>2026-04-17</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://futurofortissimo.github.io/book/chapter-01-cibo.html</loc>
+    <lastmod>2026-04-17</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <!-- Subchapter pages (Tecnologia) -->
+  <url>
+    <loc>https://futurofortissimo.github.io/book/chapter-02-robotica.html</loc>
+    <lastmod>2026-04-17</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://futurofortissimo.github.io/book/chapter-02-metaverso.html</loc>
+    <lastmod>2026-04-17</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://futurofortissimo.github.io/book/chapter-02-prodotti.html</loc>
+    <lastmod>2026-04-17</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <!-- Subchapter pages (Societa) -->
+  <url>
+    <loc>https://futurofortissimo.github.io/book/chapter-03-psicologia.html</loc>
+    <lastmod>2026-04-17</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://futurofortissimo.github.io/book/chapter-03-alimentazione.html</loc>
+    <lastmod>2026-04-17</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://futurofortissimo.github.io/book/chapter-03-cultura.html</loc>
+    <lastmod>2026-04-17</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <!-- ff.x.y index -->
+  <url>
+    <loc>https://futurofortissimo.github.io/book/ffxy-index.html</loc>
+    <lastmod>2026-04-17</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
   </url>
 
   <!-- === LIBRI (Individual book pages) === -->


### PR DESCRIPTION
## Summary

### 1. Tutti i 22 ff.x.y visibili in Ultime aggiunte (book/index.html)
- Sotto le 8 card "hero" c'è ora una **pill grid** con tutti i 22 codici del bulk inject 2026-04-17, colorati per asse (verde/blu/rosso), cliccabili.
- Script aggiornato per aggregare **multi-code per href** (es. 5 codici che puntano allo stesso subchapter 2.2.1 → badge compatto con tutti i codici).
- Summary del toggle: `// 22 nuovi: ff.26.5 · ff.148.1 · …`.
- Contatore `+N nuovi` sul titolo capitolo conta **codici**, non solo anchor unici.

### 2. ffxy-index.html — bold + badge per le nuove iniezioni
- Banner giallo "Appena iniettati · 2026-04-17" con chip-cloud dei 22 codici.
- Ogni entry del ciclo corrente ha `.entry--recent` (bold + sfondo + badge `NEW`).
- Lista `RECENT.codes` embedded — aggiornare ad ogni nuovo ciclo inject per propagare il refresh.

### 3. SEO 10x — 14 pagine book (book/index + 3 chapter-0N + 9 subchapter + ffxy-index)
- **book/index.html**: Book schema completo (author, publisher, offers, hasPart, pages), BreadcrumbList, keywords, hreflang, OG `book:*`, robots ottimizzati (`max-snippet:-1, max-image-preview:large`).
- **chapter-01/02/03.html**: full OG + Twitter Cards + JSON-LD `Article` + BreadcrumbList + keywords topical + description keyword-rich (es. `"Come la mobilità urbana, la città a 15 minuti e le rinnovabili ridisegnano le città"` invece di generico "140 fonti, 8 min").
- **9 subchapter + ffxy-index**: upgrade idempotente via `scripts/seo_upgrade_book.py` (tagged `data-seo-upgraded: 2026-04-17`): og:site_name/locale/description, twitter:card/creator/image, JSON-LD Article (CollectionPage per ffxy-index), BreadcrumbList 4-livelli, hreflang, meta keywords/author/robots.
- **sitemap.xml**: aggiunte le 9 subchapter pages + ffxy-index (prima c'erano solo 3 chapter intros). `lastmod` 2026-04-17.

## Impatto SEO atteso
- Google ora vede: canonical + Book schema + Article schema + BreadcrumbList → rich results in SERP.
- Descrizioni keyword-rich (mobilità urbana, città a 15 minuti, metaverso, AI, psicologia, longevità, HIIT…) → match con query di ricerca tematiche.
- Sitemap completa con 13 URL libro → +10 pagine nel crawl vs prima.
- Twitter/Facebook: preview corretta (og:image, og:description, twitter:card).

## Test plan
- [x] `book/index.html` → 8 card hero + 22 pill colorate + summary toggle con i 22 codici
- [x] Chapter grid: tutti i subchapter citati sono **bold** con badge giallo (multi-code dove applicabile)
- [x] `ffxy-index.html` → banner top con 22 chip; `entry--recent` su ciascuno; badge NEW
- [x] Tutte le pagine: `<meta name="twitter:card">` + `og:site_name` + `application/ld+json` presenti
- [ ] Verificare live su https://futurofortissimo.github.io/book/ dopo merge (~1 min GH Pages)
- [ ] Google Rich Results Test su chapter-01.html + book/index.html
- [ ] Forzare re-crawl da Google Search Console: submit sitemap aggiornato

🤖 Generated with [Claude Code](https://claude.com/claude-code)