### PR TITLE
chore: refresh chapter meta descriptions + correct fonti/min counts

### DIFF
--- a/book/chapter-01-1-1.html
+++ b/book/chapter-01-1-1.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>1.1 &mdash; Mobilità e Città | 🌿 Natura | Futuro Fortissimo</title>
-    <meta name="description" content="1.1 Mobilità e Città &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 15 fonti, ~8 min."/>
+    <meta name="description" content="1.1.1 &mdash; L'euthym&igrave;crona del pendolare: Gli orizzonti naturali possiedono una &ldquo;dimensione frattale&rdquo;&hellip; Sottocapitolo 1.1.1 di Futuro Fortissimo. 2 fonti, ~2 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-01-mobilita.html"/>
     <meta property="og:title" content="1.1 &mdash; Mobilità e Città | Natura"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="1.1 Mobilità e Città &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 15 fonti, ~8 min."/>
+    <meta property="og:description" content="1.1.1 &mdash; L'euthym&igrave;crona del pendolare: Gli orizzonti naturali possiedono una &ldquo;dimensione frattale&rdquo;&hellip; Sottocapitolo 1.1.1 di Futuro Fortissimo. 2 fonti, ~2 min."/>
     <meta property="article:section" content="Natura"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="1.1 — Mobilità e Città | 🌿 Natura"/>
-    <meta name="twitter:description" content="1.1 Mobilità e Città &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 15 fonti, ~8 min."/>
+    <meta name="twitter:description" content="1.1.1 &mdash; L'euthym&igrave;crona del pendolare: Gli orizzonti naturali possiedono una &ldquo;dimensione frattale&rdquo;&hellip; Sottocapitolo 1.1.1 di Futuro Fortissimo. 2 fonti, ~2 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "1.1 — Mobilità e Città | 🌿 Natura",
-      "description": "1.1 Mobilità e Città &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 15 fonti, ~8 min.",
+      "description": "1.1.1 &mdash; L'euthym&igrave;crona del pendolare: Gli orizzonti naturali possiedono una &ldquo;dimensione frattale&rdquo;&hellip; Sottocapitolo 1.1.1 di Futuro Fortissimo. 2 fonti, ~2 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-01-mobilita.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-01-1-2.html
+++ b/book/chapter-01-1-2.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>1.1 &mdash; Mobilità e Città | 🌿 Natura | Futuro Fortissimo</title>
-    <meta name="description" content="1.1 Mobilità e Città &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 15 fonti, ~8 min."/>
+    <meta name="description" content="1.1.2 &mdash; La citt&agrave; a 15 minuti: Ma la felicit&agrave; del tragitto &egrave; solo l'inizio. Sottocapitolo 1.1.2 di Futuro Fortissimo. 4 fonti, ~3 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-01-mobilita.html"/>
     <meta property="og:title" content="1.1 &mdash; Mobilità e Città | Natura"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="1.1 Mobilità e Città &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 15 fonti, ~8 min."/>
+    <meta property="og:description" content="1.1.2 &mdash; La citt&agrave; a 15 minuti: Ma la felicit&agrave; del tragitto &egrave; solo l'inizio. Sottocapitolo 1.1.2 di Futuro Fortissimo. 4 fonti, ~3 min."/>
     <meta property="article:section" content="Natura"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="1.1 — Mobilità e Città | 🌿 Natura"/>
-    <meta name="twitter:description" content="1.1 Mobilità e Città &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 15 fonti, ~8 min."/>
+    <meta name="twitter:description" content="1.1.2 &mdash; La citt&agrave; a 15 minuti: Ma la felicit&agrave; del tragitto &egrave; solo l'inizio. Sottocapitolo 1.1.2 di Futuro Fortissimo. 4 fonti, ~3 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "1.1 — Mobilità e Città | 🌿 Natura",
-      "description": "1.1 Mobilità e Città &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 15 fonti, ~8 min.",
+      "description": "1.1.2 &mdash; La citt&agrave; a 15 minuti: Ma la felicit&agrave; del tragitto &egrave; solo l'inizio. Sottocapitolo 1.1.2 di Futuro Fortissimo. 4 fonti, ~3 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-01-mobilita.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-01-1-3.html
+++ b/book/chapter-01-1-3.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>1.1 &mdash; Mobilità e Città | 🌿 Natura | Futuro Fortissimo</title>
-    <meta name="description" content="1.1 Mobilità e Città &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 15 fonti, ~8 min."/>
+    <meta name="description" content="1.1.3 &mdash; Ruote autonome: Un'auto resta parcheggiata il 96% del tempo, e un veicolo autonomo che&hellip; Sottocapitolo 1.1.3 di Futuro Fortissimo. 3 fonti, ~3 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-01-mobilita.html"/>
     <meta property="og:title" content="1.1 &mdash; Mobilità e Città | Natura"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="1.1 Mobilità e Città &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 15 fonti, ~8 min."/>
+    <meta property="og:description" content="1.1.3 &mdash; Ruote autonome: Un'auto resta parcheggiata il 96% del tempo, e un veicolo autonomo che&hellip; Sottocapitolo 1.1.3 di Futuro Fortissimo. 3 fonti, ~3 min."/>
     <meta property="article:section" content="Natura"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="1.1 — Mobilità e Città | 🌿 Natura"/>
-    <meta name="twitter:description" content="1.1 Mobilità e Città &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 15 fonti, ~8 min."/>
+    <meta name="twitter:description" content="1.1.3 &mdash; Ruote autonome: Un'auto resta parcheggiata il 96% del tempo, e un veicolo autonomo che&hellip; Sottocapitolo 1.1.3 di Futuro Fortissimo. 3 fonti, ~3 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "1.1 — Mobilità e Città | 🌿 Natura",
-      "description": "1.1 Mobilità e Città &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 15 fonti, ~8 min.",
+      "description": "1.1.3 &mdash; Ruote autonome: Un'auto resta parcheggiata il 96% del tempo, e un veicolo autonomo che&hellip; Sottocapitolo 1.1.3 di Futuro Fortissimo. 3 fonti, ~3 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-01-mobilita.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-01-1-4.html
+++ b/book/chapter-01-1-4.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>1.1 &mdash; Mobilità e Città | 🌿 Natura | Futuro Fortissimo</title>
-    <meta name="description" content="1.1 Mobilità e Città &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 15 fonti, ~8 min."/>
+    <meta name="description" content="1.1.4 &mdash; Impronte e cieli: Un chilometro in auto produce circa 271 grammi di CO₂, uno in bici circa&hellip; Sottocapitolo 1.1.4 di Futuro Fortissimo. 9 fonti, ~8 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-01-mobilita.html"/>
     <meta property="og:title" content="1.1 &mdash; Mobilità e Città | Natura"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="1.1 Mobilità e Città &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 15 fonti, ~8 min."/>
+    <meta property="og:description" content="1.1.4 &mdash; Impronte e cieli: Un chilometro in auto produce circa 271 grammi di CO₂, uno in bici circa&hellip; Sottocapitolo 1.1.4 di Futuro Fortissimo. 9 fonti, ~8 min."/>
     <meta property="article:section" content="Natura"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="1.1 — Mobilità e Città | 🌿 Natura"/>
-    <meta name="twitter:description" content="1.1 Mobilità e Città &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 15 fonti, ~8 min."/>
+    <meta name="twitter:description" content="1.1.4 &mdash; Impronte e cieli: Un chilometro in auto produce circa 271 grammi di CO₂, uno in bici circa&hellip; Sottocapitolo 1.1.4 di Futuro Fortissimo. 9 fonti, ~8 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "1.1 — Mobilità e Città | 🌿 Natura",
-      "description": "1.1 Mobilità e Città &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 15 fonti, ~8 min.",
+      "description": "1.1.4 &mdash; Impronte e cieli: Un chilometro in auto produce circa 271 grammi di CO₂, uno in bici circa&hellip; Sottocapitolo 1.1.4 di Futuro Fortissimo. 9 fonti, ~8 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-01-mobilita.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-01-2-1.html
+++ b/book/chapter-01-2-1.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>1.2 &mdash; Ambiente ed Energia | 🌿 Natura | Futuro Fortissimo</title>
-    <meta name="description" content="1.2 Ambiente ed Energia &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 73 fonti, ~39 min."/>
+    <meta name="description" content="1.2.1 &mdash; La carta di credito invisibile: Non demonizziamo la plastica: fa anche del bene, specie per&hellip; Sottocapitolo 1.2.1 di Futuro Fortissimo. 9 fonti, ~3 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-01-ambiente.html"/>
     <meta property="og:title" content="1.2 &mdash; Ambiente ed Energia | Natura"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="1.2 Ambiente ed Energia &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 73 fonti, ~39 min."/>
+    <meta property="og:description" content="1.2.1 &mdash; La carta di credito invisibile: Non demonizziamo la plastica: fa anche del bene, specie per&hellip; Sottocapitolo 1.2.1 di Futuro Fortissimo. 9 fonti, ~3 min."/>
     <meta property="article:section" content="Natura"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="1.2 — Ambiente ed Energia | 🌿 Natura"/>
-    <meta name="twitter:description" content="1.2 Ambiente ed Energia &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 73 fonti, ~39 min."/>
+    <meta name="twitter:description" content="1.2.1 &mdash; La carta di credito invisibile: Non demonizziamo la plastica: fa anche del bene, specie per&hellip; Sottocapitolo 1.2.1 di Futuro Fortissimo. 9 fonti, ~3 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "1.2 — Ambiente ed Energia | 🌿 Natura",
-      "description": "1.2 Ambiente ed Energia &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 73 fonti, ~39 min.",
+      "description": "1.2.1 &mdash; La carta di credito invisibile: Non demonizziamo la plastica: fa anche del bene, specie per&hellip; Sottocapitolo 1.2.1 di Futuro Fortissimo. 9 fonti, ~3 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-01-ambiente.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-01-2-2.html
+++ b/book/chapter-01-2-2.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>1.2 &mdash; Ambiente ed Energia | 🌿 Natura | Futuro Fortissimo</title>
-    <meta name="description" content="1.2 Ambiente ed Energia &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 73 fonti, ~39 min."/>
+    <meta name="description" content="1.2.2 &mdash; Il nodo gordiano dell'energia: Produrre un terajoule di energia con l'uranio costa appena&hellip; Sottocapitolo 1.2.2 di Futuro Fortissimo. 22 fonti, ~18 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-01-ambiente.html"/>
     <meta property="og:title" content="1.2 &mdash; Ambiente ed Energia | Natura"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="1.2 Ambiente ed Energia &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 73 fonti, ~39 min."/>
+    <meta property="og:description" content="1.2.2 &mdash; Il nodo gordiano dell'energia: Produrre un terajoule di energia con l'uranio costa appena&hellip; Sottocapitolo 1.2.2 di Futuro Fortissimo. 22 fonti, ~18 min."/>
     <meta property="article:section" content="Natura"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="1.2 — Ambiente ed Energia | 🌿 Natura"/>
-    <meta name="twitter:description" content="1.2 Ambiente ed Energia &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 73 fonti, ~39 min."/>
+    <meta name="twitter:description" content="1.2.2 &mdash; Il nodo gordiano dell'energia: Produrre un terajoule di energia con l'uranio costa appena&hellip; Sottocapitolo 1.2.2 di Futuro Fortissimo. 22 fonti, ~18 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "1.2 — Ambiente ed Energia | 🌿 Natura",
-      "description": "1.2 Ambiente ed Energia &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 73 fonti, ~39 min.",
+      "description": "1.2.2 &mdash; Il nodo gordiano dell'energia: Produrre un terajoule di energia con l'uranio costa appena&hellip; Sottocapitolo 1.2.2 di Futuro Fortissimo. 22 fonti, ~18 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-01-ambiente.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-01-2-3.html
+++ b/book/chapter-01-2-3.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>1.2 &mdash; Ambiente ed Energia | 🌿 Natura | Futuro Fortissimo</title>
-    <meta name="description" content="1.2 Ambiente ed Energia &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 73 fonti, ~39 min."/>
+    <meta name="description" content="1.2.3 &mdash; Geoingegneria e clima: La deglaciazione ha impiegato millenni per i suoi +4 &deg;C; noi&hellip; Sottocapitolo 1.2.3 di Futuro Fortissimo. 49 fonti, ~44 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-01-ambiente.html"/>
     <meta property="og:title" content="1.2 &mdash; Ambiente ed Energia | Natura"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="1.2 Ambiente ed Energia &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 73 fonti, ~39 min."/>
+    <meta property="og:description" content="1.2.3 &mdash; Geoingegneria e clima: La deglaciazione ha impiegato millenni per i suoi +4 &deg;C; noi&hellip; Sottocapitolo 1.2.3 di Futuro Fortissimo. 49 fonti, ~44 min."/>
     <meta property="article:section" content="Natura"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="1.2 — Ambiente ed Energia | 🌿 Natura"/>
-    <meta name="twitter:description" content="1.2 Ambiente ed Energia &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 73 fonti, ~39 min."/>
+    <meta name="twitter:description" content="1.2.3 &mdash; Geoingegneria e clima: La deglaciazione ha impiegato millenni per i suoi +4 &deg;C; noi&hellip; Sottocapitolo 1.2.3 di Futuro Fortissimo. 49 fonti, ~44 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "1.2 — Ambiente ed Energia | 🌿 Natura",
-      "description": "1.2 Ambiente ed Energia &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 73 fonti, ~39 min.",
+      "description": "1.2.3 &mdash; Geoingegneria e clima: La deglaciazione ha impiegato millenni per i suoi +4 &deg;C; noi&hellip; Sottocapitolo 1.2.3 di Futuro Fortissimo. 49 fonti, ~44 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-01-ambiente.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-01-2-4.html
+++ b/book/chapter-01-2-4.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>1.2 &mdash; Ambiente ed Energia | 🌿 Natura | Futuro Fortissimo</title>
-    <meta name="description" content="1.2 Ambiente ed Energia &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 73 fonti, ~39 min."/>
+    <meta name="description" content="1.2.4 &mdash; Alberi, acqua e biodiversit&agrave;: La fusione nucleare &egrave; la promessa perenne dell'energia: sempre&hellip; Sottocapitolo 1.2.4 di Futuro Fortissimo. 2 fonti, ~4 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-01-ambiente.html"/>
     <meta property="og:title" content="1.2 &mdash; Ambiente ed Energia | Natura"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="1.2 Ambiente ed Energia &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 73 fonti, ~39 min."/>
+    <meta property="og:description" content="1.2.4 &mdash; Alberi, acqua e biodiversit&agrave;: La fusione nucleare &egrave; la promessa perenne dell'energia: sempre&hellip; Sottocapitolo 1.2.4 di Futuro Fortissimo. 2 fonti, ~4 min."/>
     <meta property="article:section" content="Natura"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="1.2 — Ambiente ed Energia | 🌿 Natura"/>
-    <meta name="twitter:description" content="1.2 Ambiente ed Energia &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 73 fonti, ~39 min."/>
+    <meta name="twitter:description" content="1.2.4 &mdash; Alberi, acqua e biodiversit&agrave;: La fusione nucleare &egrave; la promessa perenne dell'energia: sempre&hellip; Sottocapitolo 1.2.4 di Futuro Fortissimo. 2 fonti, ~4 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "1.2 — Ambiente ed Energia | 🌿 Natura",
-      "description": "1.2 Ambiente ed Energia &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 73 fonti, ~39 min.",
+      "description": "1.2.4 &mdash; Alberi, acqua e biodiversit&agrave;: La fusione nucleare &egrave; la promessa perenne dell'energia: sempre&hellip; Sottocapitolo 1.2.4 di Futuro Fortissimo. 2 fonti, ~4 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-01-ambiente.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-01-3-1.html
+++ b/book/chapter-01-3-1.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>1.3 &mdash; Cibo e Fashion | 🌿 Natura | Futuro Fortissimo</title>
-    <meta name="description" content="1.3 Cibo e Fashion &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 53 fonti, ~28 min."/>
+    <meta name="description" content="1.3.1 &mdash; Dal microbioma al piatto: 100 grammi di proteine, 40 grammi di fibre, micronutrienti&hellip; Sottocapitolo 1.3.1 di Futuro Fortissimo. 15 fonti, ~11 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-01-cibo.html"/>
     <meta property="og:title" content="1.3 &mdash; Cibo e Fashion | Natura"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="1.3 Cibo e Fashion &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 53 fonti, ~28 min."/>
+    <meta property="og:description" content="1.3.1 &mdash; Dal microbioma al piatto: 100 grammi di proteine, 40 grammi di fibre, micronutrienti&hellip; Sottocapitolo 1.3.1 di Futuro Fortissimo. 15 fonti, ~11 min."/>
     <meta property="article:section" content="Natura"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="1.3 — Cibo e Fashion | 🌿 Natura"/>
-    <meta name="twitter:description" content="1.3 Cibo e Fashion &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 53 fonti, ~28 min."/>
+    <meta name="twitter:description" content="1.3.1 &mdash; Dal microbioma al piatto: 100 grammi di proteine, 40 grammi di fibre, micronutrienti&hellip; Sottocapitolo 1.3.1 di Futuro Fortissimo. 15 fonti, ~11 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "1.3 — Cibo e Fashion | 🌿 Natura",
-      "description": "1.3 Cibo e Fashion &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 53 fonti, ~28 min.",
+      "description": "1.3.1 &mdash; Dal microbioma al piatto: 100 grammi di proteine, 40 grammi di fibre, micronutrienti&hellip; Sottocapitolo 1.3.1 di Futuro Fortissimo. 15 fonti, ~11 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-01-cibo.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-01-3-2.html
+++ b/book/chapter-01-3-2.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>1.3 &mdash; Cibo e Fashion | 🌿 Natura | Futuro Fortissimo</title>
-    <meta name="description" content="1.3 Cibo e Fashion &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 53 fonti, ~28 min."/>
+    <meta name="description" content="1.3.2 &mdash; Calorie, peso e metabolismo: Il panino integrale richiede quasi il doppio dell'energia per&hellip; Sottocapitolo 1.3.2 di Futuro Fortissimo. 30 fonti, ~18 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-01-cibo.html"/>
     <meta property="og:title" content="1.3 &mdash; Cibo e Fashion | Natura"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="1.3 Cibo e Fashion &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 53 fonti, ~28 min."/>
+    <meta property="og:description" content="1.3.2 &mdash; Calorie, peso e metabolismo: Il panino integrale richiede quasi il doppio dell'energia per&hellip; Sottocapitolo 1.3.2 di Futuro Fortissimo. 30 fonti, ~18 min."/>
     <meta property="article:section" content="Natura"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="1.3 — Cibo e Fashion | 🌿 Natura"/>
-    <meta name="twitter:description" content="1.3 Cibo e Fashion &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 53 fonti, ~28 min."/>
+    <meta name="twitter:description" content="1.3.2 &mdash; Calorie, peso e metabolismo: Il panino integrale richiede quasi il doppio dell'energia per&hellip; Sottocapitolo 1.3.2 di Futuro Fortissimo. 30 fonti, ~18 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "1.3 — Cibo e Fashion | 🌿 Natura",
-      "description": "1.3 Cibo e Fashion &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 53 fonti, ~28 min.",
+      "description": "1.3.2 &mdash; Calorie, peso e metabolismo: Il panino integrale richiede quasi il doppio dell'energia per&hellip; Sottocapitolo 1.3.2 di Futuro Fortissimo. 30 fonti, ~18 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-01-cibo.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-01-3-3.html
+++ b/book/chapter-01-3-3.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>1.3 &mdash; Cibo e Fashion | 🌿 Natura | Futuro Fortissimo</title>
-    <meta name="description" content="1.3 Cibo e Fashion &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 53 fonti, ~28 min."/>
+    <meta name="description" content="1.3.3 &mdash; L'armadio sostenibile: Toccare una quercia, rispetto a marmo e metallo, riduce la pressione&hellip; Sottocapitolo 1.3.3 di Futuro Fortissimo. 0 fonti, ~8 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-01-cibo.html"/>
     <meta property="og:title" content="1.3 &mdash; Cibo e Fashion | Natura"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="1.3 Cibo e Fashion &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 53 fonti, ~28 min."/>
+    <meta property="og:description" content="1.3.3 &mdash; L'armadio sostenibile: Toccare una quercia, rispetto a marmo e metallo, riduce la pressione&hellip; Sottocapitolo 1.3.3 di Futuro Fortissimo. 0 fonti, ~8 min."/>
     <meta property="article:section" content="Natura"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="1.3 — Cibo e Fashion | 🌿 Natura"/>
-    <meta name="twitter:description" content="1.3 Cibo e Fashion &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 53 fonti, ~28 min."/>
+    <meta name="twitter:description" content="1.3.3 &mdash; L'armadio sostenibile: Toccare una quercia, rispetto a marmo e metallo, riduce la pressione&hellip; Sottocapitolo 1.3.3 di Futuro Fortissimo. 0 fonti, ~8 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "1.3 — Cibo e Fashion | 🌿 Natura",
-      "description": "1.3 Cibo e Fashion &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 53 fonti, ~28 min.",
+      "description": "1.3.3 &mdash; L'armadio sostenibile: Toccare una quercia, rispetto a marmo e metallo, riduce la pressione&hellip; Sottocapitolo 1.3.3 di Futuro Fortissimo. 0 fonti, ~8 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-01-cibo.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-01-3-4.html
+++ b/book/chapter-01-3-4.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>1.3 &mdash; Cibo e Fashion | 🌿 Natura | Futuro Fortissimo</title>
-    <meta name="description" content="1.3 Cibo e Fashion &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 53 fonti, ~28 min."/>
+    <meta name="description" content="1.3.4 &mdash; Il corpo elettrico: C&rsquo;&egrave; un filo elettrico che attraversa la storia del corpo umano, e parte&hellip; Sottocapitolo 1.3.4 di Futuro Fortissimo. 10 fonti, ~8 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-01-cibo.html"/>
     <meta property="og:title" content="1.3 &mdash; Cibo e Fashion | Natura"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="1.3 Cibo e Fashion &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 53 fonti, ~28 min."/>
+    <meta property="og:description" content="1.3.4 &mdash; Il corpo elettrico: C&rsquo;&egrave; un filo elettrico che attraversa la storia del corpo umano, e parte&hellip; Sottocapitolo 1.3.4 di Futuro Fortissimo. 10 fonti, ~8 min."/>
     <meta property="article:section" content="Natura"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="1.3 — Cibo e Fashion | 🌿 Natura"/>
-    <meta name="twitter:description" content="1.3 Cibo e Fashion &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 53 fonti, ~28 min."/>
+    <meta name="twitter:description" content="1.3.4 &mdash; Il corpo elettrico: C&rsquo;&egrave; un filo elettrico che attraversa la storia del corpo umano, e parte&hellip; Sottocapitolo 1.3.4 di Futuro Fortissimo. 10 fonti, ~8 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "1.3 — Cibo e Fashion | 🌿 Natura",
-      "description": "1.3 Cibo e Fashion &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 53 fonti, ~28 min.",
+      "description": "1.3.4 &mdash; Il corpo elettrico: C&rsquo;&egrave; un filo elettrico che attraversa la storia del corpo umano, e parte&hellip; Sottocapitolo 1.3.4 di Futuro Fortissimo. 10 fonti, ~8 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-01-cibo.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-01-ambiente.html
+++ b/book/chapter-01-ambiente.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>1.2 &mdash; Ambiente ed Energia | 🌿 Natura | Futuro Fortissimo</title>
-    <meta name="description" content="1.2 Ambiente ed Energia &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 73 fonti, ~39 min."/>
+    <meta name="description" content="1.2 &mdash; Ambiente ed Energia (La carta di credito invisibile, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 84 fonti, ~69 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-01-ambiente.html"/>
     <meta property="og:title" content="1.2 &mdash; Ambiente ed Energia | Natura"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="1.2 Ambiente ed Energia &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 73 fonti, ~39 min."/>
+    <meta property="og:description" content="1.2 &mdash; Ambiente ed Energia (La carta di credito invisibile, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 84 fonti, ~69 min."/>
     <meta property="article:section" content="Natura"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="1.2 — Ambiente ed Energia | 🌿 Natura"/>
-    <meta name="twitter:description" content="1.2 Ambiente ed Energia &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 73 fonti, ~39 min."/>
+    <meta name="twitter:description" content="1.2 &mdash; Ambiente ed Energia (La carta di credito invisibile, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 84 fonti, ~69 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "1.2 — Ambiente ed Energia | 🌿 Natura",
-      "description": "1.2 Ambiente ed Energia &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 73 fonti, ~39 min.",
+      "description": "1.2 &mdash; Ambiente ed Energia (La carta di credito invisibile, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 84 fonti, ~69 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-01-ambiente.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-01-cibo.html
+++ b/book/chapter-01-cibo.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>1.3 &mdash; Cibo e Fashion | 🌿 Natura | Futuro Fortissimo</title>
-    <meta name="description" content="1.3 Cibo e Fashion &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 53 fonti, ~28 min."/>
+    <meta name="description" content="1.3 &mdash; Cibo e Fashion (Dal microbioma al piatto, Calorie, peso e metabolismo, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 53 fonti, ~46 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-01-cibo.html"/>
     <meta property="og:title" content="1.3 &mdash; Cibo e Fashion | Natura"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="1.3 Cibo e Fashion &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 53 fonti, ~28 min."/>
+    <meta property="og:description" content="1.3 &mdash; Cibo e Fashion (Dal microbioma al piatto, Calorie, peso e metabolismo, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 53 fonti, ~46 min."/>
     <meta property="article:section" content="Natura"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="1.3 — Cibo e Fashion | 🌿 Natura"/>
-    <meta name="twitter:description" content="1.3 Cibo e Fashion &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 53 fonti, ~28 min."/>
+    <meta name="twitter:description" content="1.3 &mdash; Cibo e Fashion (Dal microbioma al piatto, Calorie, peso e metabolismo, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 53 fonti, ~46 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "1.3 — Cibo e Fashion | 🌿 Natura",
-      "description": "1.3 Cibo e Fashion &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 53 fonti, ~28 min.",
+      "description": "1.3 &mdash; Cibo e Fashion (Dal microbioma al piatto, Calorie, peso e metabolismo, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 53 fonti, ~46 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-01-cibo.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-01-mobilita.html
+++ b/book/chapter-01-mobilita.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>1.1 &mdash; Mobilità e Città | 🌿 Natura | Futuro Fortissimo</title>
-    <meta name="description" content="1.1 Mobilità e Città &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 15 fonti, ~8 min."/>
+    <meta name="description" content="1.1 &mdash; Mobilit&agrave; e Citt&agrave; (L'euthym&igrave;crona del pendolare, La citt&agrave; a 15 minuti, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 18 fonti, ~16 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-01-mobilita.html"/>
     <meta property="og:title" content="1.1 &mdash; Mobilità e Città | Natura"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="1.1 Mobilità e Città &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 15 fonti, ~8 min."/>
+    <meta property="og:description" content="1.1 &mdash; Mobilit&agrave; e Citt&agrave; (L'euthym&igrave;crona del pendolare, La citt&agrave; a 15 minuti, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 18 fonti, ~16 min."/>
     <meta property="article:section" content="Natura"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="1.1 — Mobilità e Città | 🌿 Natura"/>
-    <meta name="twitter:description" content="1.1 Mobilità e Città &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 15 fonti, ~8 min."/>
+    <meta name="twitter:description" content="1.1 &mdash; Mobilit&agrave; e Citt&agrave; (L'euthym&igrave;crona del pendolare, La citt&agrave; a 15 minuti, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 18 fonti, ~16 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "1.1 — Mobilità e Città | 🌿 Natura",
-      "description": "1.1 Mobilità e Città &mdash; Capitolo 1 (Natura) del libro Futuro Fortissimo. 15 fonti, ~8 min.",
+      "description": "1.1 &mdash; Mobilit&agrave; e Citt&agrave; (L'euthym&igrave;crona del pendolare, La citt&agrave; a 15 minuti, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 18 fonti, ~16 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-01-mobilita.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-02-1-1.html
+++ b/book/chapter-02-1-1.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>2.1 &mdash; Robotica e AI | 💻 Tecnologia | Futuro Fortissimo</title>
-    <meta name="description" content="2.1 Robotica e AI &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 70 fonti, ~33 min."/>
+    <meta name="description" content="2.1.1 &mdash; L'economia del compute: In tre mesi, NVIDIA ha incassato 57 miliardi di dollari con un&hellip; Sottocapitolo 2.1.1 di Futuro Fortissimo. 27 fonti, ~12 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-02-robotica.html"/>
     <meta property="og:title" content="2.1 &mdash; Robotica e AI | Tecnologia"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="2.1 Robotica e AI &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 70 fonti, ~33 min."/>
+    <meta property="og:description" content="2.1.1 &mdash; L'economia del compute: In tre mesi, NVIDIA ha incassato 57 miliardi di dollari con un&hellip; Sottocapitolo 2.1.1 di Futuro Fortissimo. 27 fonti, ~12 min."/>
     <meta property="article:section" content="Tecnologia"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="2.1 — Robotica e AI | 💻 Tecnologia"/>
-    <meta name="twitter:description" content="2.1 Robotica e AI &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 70 fonti, ~33 min."/>
+    <meta name="twitter:description" content="2.1.1 &mdash; L'economia del compute: In tre mesi, NVIDIA ha incassato 57 miliardi di dollari con un&hellip; Sottocapitolo 2.1.1 di Futuro Fortissimo. 27 fonti, ~12 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "2.1 — Robotica e AI | 💻 Tecnologia",
-      "description": "2.1 Robotica e AI &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 70 fonti, ~33 min.",
+      "description": "2.1.1 &mdash; L'economia del compute: In tre mesi, NVIDIA ha incassato 57 miliardi di dollari con un&hellip; Sottocapitolo 2.1.1 di Futuro Fortissimo. 27 fonti, ~12 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-02-robotica.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-02-1-2.html
+++ b/book/chapter-02-1-2.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>2.1 &mdash; Robotica e AI | 💻 Tecnologia | Futuro Fortissimo</title>
-    <meta name="description" content="2.1 Robotica e AI &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 70 fonti, ~33 min."/>
+    <meta name="description" content="2.1.2 &mdash; La singolarit&agrave; gentile: L'economista Tyler Cowen, in un sondaggio Polymarket del 2025&hellip; Sottocapitolo 2.1.2 di Futuro Fortissimo. 18 fonti, ~9 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-02-robotica.html"/>
     <meta property="og:title" content="2.1 &mdash; Robotica e AI | Tecnologia"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="2.1 Robotica e AI &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 70 fonti, ~33 min."/>
+    <meta property="og:description" content="2.1.2 &mdash; La singolarit&agrave; gentile: L'economista Tyler Cowen, in un sondaggio Polymarket del 2025&hellip; Sottocapitolo 2.1.2 di Futuro Fortissimo. 18 fonti, ~9 min."/>
     <meta property="article:section" content="Tecnologia"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="2.1 — Robotica e AI | 💻 Tecnologia"/>
-    <meta name="twitter:description" content="2.1 Robotica e AI &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 70 fonti, ~33 min."/>
+    <meta name="twitter:description" content="2.1.2 &mdash; La singolarit&agrave; gentile: L'economista Tyler Cowen, in un sondaggio Polymarket del 2025&hellip; Sottocapitolo 2.1.2 di Futuro Fortissimo. 18 fonti, ~9 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "2.1 — Robotica e AI | 💻 Tecnologia",
-      "description": "2.1 Robotica e AI &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 70 fonti, ~33 min.",
+      "description": "2.1.2 &mdash; La singolarit&agrave; gentile: L'economista Tyler Cowen, in un sondaggio Polymarket del 2025&hellip; Sottocapitolo 2.1.2 di Futuro Fortissimo. 18 fonti, ~9 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-02-robotica.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-02-1-3.html
+++ b/book/chapter-02-1-3.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>2.1 &mdash; Robotica e AI | 💻 Tecnologia | Futuro Fortissimo</title>
-    <meta name="description" content="2.1 Robotica e AI &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 70 fonti, ~33 min."/>
+    <meta name="description" content="2.1.3 &mdash; Robot e biomimetica: Sakana AI ha creato The AI Scientist &mdash; un sistema che genera&hellip; Sottocapitolo 2.1.3 di Futuro Fortissimo. 18 fonti, ~11 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-02-robotica.html"/>
     <meta property="og:title" content="2.1 &mdash; Robotica e AI | Tecnologia"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="2.1 Robotica e AI &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 70 fonti, ~33 min."/>
+    <meta property="og:description" content="2.1.3 &mdash; Robot e biomimetica: Sakana AI ha creato The AI Scientist &mdash; un sistema che genera&hellip; Sottocapitolo 2.1.3 di Futuro Fortissimo. 18 fonti, ~11 min."/>
     <meta property="article:section" content="Tecnologia"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="2.1 — Robotica e AI | 💻 Tecnologia"/>
-    <meta name="twitter:description" content="2.1 Robotica e AI &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 70 fonti, ~33 min."/>
+    <meta name="twitter:description" content="2.1.3 &mdash; Robot e biomimetica: Sakana AI ha creato The AI Scientist &mdash; un sistema che genera&hellip; Sottocapitolo 2.1.3 di Futuro Fortissimo. 18 fonti, ~11 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "2.1 — Robotica e AI | 💻 Tecnologia",
-      "description": "2.1 Robotica e AI &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 70 fonti, ~33 min.",
+      "description": "2.1.3 &mdash; Robot e biomimetica: Sakana AI ha creato The AI Scientist &mdash; un sistema che genera&hellip; Sottocapitolo 2.1.3 di Futuro Fortissimo. 18 fonti, ~11 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-02-robotica.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-02-1-4.html
+++ b/book/chapter-02-1-4.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>2.1 &mdash; Robotica e AI | 💻 Tecnologia | Futuro Fortissimo</title>
-    <meta name="description" content="2.1 Robotica e AI &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 70 fonti, ~33 min."/>
+    <meta name="description" content="2.1.4 &mdash; Miniaturizzazione e ricorsivit&agrave;: Su Nature, un team ha dimostrato come trovare un antidoto&hellip; Sottocapitolo 2.1.4 di Futuro Fortissimo. 25 fonti, ~28 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-02-robotica.html"/>
     <meta property="og:title" content="2.1 &mdash; Robotica e AI | Tecnologia"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="2.1 Robotica e AI &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 70 fonti, ~33 min."/>
+    <meta property="og:description" content="2.1.4 &mdash; Miniaturizzazione e ricorsivit&agrave;: Su Nature, un team ha dimostrato come trovare un antidoto&hellip; Sottocapitolo 2.1.4 di Futuro Fortissimo. 25 fonti, ~28 min."/>
     <meta property="article:section" content="Tecnologia"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="2.1 — Robotica e AI | 💻 Tecnologia"/>
-    <meta name="twitter:description" content="2.1 Robotica e AI &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 70 fonti, ~33 min."/>
+    <meta name="twitter:description" content="2.1.4 &mdash; Miniaturizzazione e ricorsivit&agrave;: Su Nature, un team ha dimostrato come trovare un antidoto&hellip; Sottocapitolo 2.1.4 di Futuro Fortissimo. 25 fonti, ~28 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "2.1 — Robotica e AI | 💻 Tecnologia",
-      "description": "2.1 Robotica e AI &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 70 fonti, ~33 min.",
+      "description": "2.1.4 &mdash; Miniaturizzazione e ricorsivit&agrave;: Su Nature, un team ha dimostrato come trovare un antidoto&hellip; Sottocapitolo 2.1.4 di Futuro Fortissimo. 25 fonti, ~28 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-02-robotica.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-02-2-1.html
+++ b/book/chapter-02-2-1.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>2.2 &mdash; Metaverso e Criptovalute | 💻 Tecnologia | Futuro Fortissimo</title>
-    <meta name="description" content="2.2 Metaverso e Criptovalute &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 29 fonti, ~12 min."/>
+    <meta name="description" content="2.2.1 &mdash; Il metaverso trasformato: Mark Zuckerberg ha investito 13,7 miliardi di dollari nel&hellip; Sottocapitolo 2.2.1 di Futuro Fortissimo. 17 fonti, ~18 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-02-metaverso.html"/>
     <meta property="og:title" content="2.2 &mdash; Metaverso e Criptovalute | Tecnologia"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="2.2 Metaverso e Criptovalute &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 29 fonti, ~12 min."/>
+    <meta property="og:description" content="2.2.1 &mdash; Il metaverso trasformato: Mark Zuckerberg ha investito 13,7 miliardi di dollari nel&hellip; Sottocapitolo 2.2.1 di Futuro Fortissimo. 17 fonti, ~18 min."/>
     <meta property="article:section" content="Tecnologia"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="2.2 — Metaverso e Criptovalute | 💻 Tecnologia"/>
-    <meta name="twitter:description" content="2.2 Metaverso e Criptovalute &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 29 fonti, ~12 min."/>
+    <meta name="twitter:description" content="2.2.1 &mdash; Il metaverso trasformato: Mark Zuckerberg ha investito 13,7 miliardi di dollari nel&hellip; Sottocapitolo 2.2.1 di Futuro Fortissimo. 17 fonti, ~18 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "2.2 — Metaverso e Criptovalute | 💻 Tecnologia",
-      "description": "2.2 Metaverso e Criptovalute &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 29 fonti, ~12 min.",
+      "description": "2.2.1 &mdash; Il metaverso trasformato: Mark Zuckerberg ha investito 13,7 miliardi di dollari nel&hellip; Sottocapitolo 2.2.1 di Futuro Fortissimo. 17 fonti, ~18 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-02-metaverso.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-02-2-2.html
+++ b/book/chapter-02-2-2.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>2.2 &mdash; Metaverso e Criptovalute | 💻 Tecnologia | Futuro Fortissimo</title>
-    <meta name="description" content="2.2 Metaverso e Criptovalute &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 29 fonti, ~12 min."/>
+    <meta name="description" content="2.2.2 &mdash; Propriet&agrave; digitale e blockchain: Ma dietro l'interfaccia c'&egrave; un problema strutturale: chi&hellip; Sottocapitolo 2.2.2 di Futuro Fortissimo. 5 fonti, ~4 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-02-metaverso.html"/>
     <meta property="og:title" content="2.2 &mdash; Metaverso e Criptovalute | Tecnologia"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="2.2 Metaverso e Criptovalute &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 29 fonti, ~12 min."/>
+    <meta property="og:description" content="2.2.2 &mdash; Propriet&agrave; digitale e blockchain: Ma dietro l'interfaccia c'&egrave; un problema strutturale: chi&hellip; Sottocapitolo 2.2.2 di Futuro Fortissimo. 5 fonti, ~4 min."/>
     <meta property="article:section" content="Tecnologia"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="2.2 — Metaverso e Criptovalute | 💻 Tecnologia"/>
-    <meta name="twitter:description" content="2.2 Metaverso e Criptovalute &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 29 fonti, ~12 min."/>
+    <meta name="twitter:description" content="2.2.2 &mdash; Propriet&agrave; digitale e blockchain: Ma dietro l'interfaccia c'&egrave; un problema strutturale: chi&hellip; Sottocapitolo 2.2.2 di Futuro Fortissimo. 5 fonti, ~4 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "2.2 — Metaverso e Criptovalute | 💻 Tecnologia",
-      "description": "2.2 Metaverso e Criptovalute &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 29 fonti, ~12 min.",
+      "description": "2.2.2 &mdash; Propriet&agrave; digitale e blockchain: Ma dietro l'interfaccia c'&egrave; un problema strutturale: chi&hellip; Sottocapitolo 2.2.2 di Futuro Fortissimo. 5 fonti, ~4 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-02-metaverso.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-02-2-3.html
+++ b/book/chapter-02-2-3.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>2.2 &mdash; Metaverso e Criptovalute | 💻 Tecnologia | Futuro Fortissimo</title>
-    <meta name="description" content="2.2 Metaverso e Criptovalute &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 29 fonti, ~12 min."/>
+    <meta name="description" content="2.2.3 &mdash; La geopolitica delle criptovalute: Nel 2011, Cina e Giappone detenevano il 23% del debito&hellip; Sottocapitolo 2.2.3 di Futuro Fortissimo. 12 fonti, ~6 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-02-metaverso.html"/>
     <meta property="og:title" content="2.2 &mdash; Metaverso e Criptovalute | Tecnologia"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="2.2 Metaverso e Criptovalute &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 29 fonti, ~12 min."/>
+    <meta property="og:description" content="2.2.3 &mdash; La geopolitica delle criptovalute: Nel 2011, Cina e Giappone detenevano il 23% del debito&hellip; Sottocapitolo 2.2.3 di Futuro Fortissimo. 12 fonti, ~6 min."/>
     <meta property="article:section" content="Tecnologia"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="2.2 — Metaverso e Criptovalute | 💻 Tecnologia"/>
-    <meta name="twitter:description" content="2.2 Metaverso e Criptovalute &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 29 fonti, ~12 min."/>
+    <meta name="twitter:description" content="2.2.3 &mdash; La geopolitica delle criptovalute: Nel 2011, Cina e Giappone detenevano il 23% del debito&hellip; Sottocapitolo 2.2.3 di Futuro Fortissimo. 12 fonti, ~6 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "2.2 — Metaverso e Criptovalute | 💻 Tecnologia",
-      "description": "2.2 Metaverso e Criptovalute &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 29 fonti, ~12 min.",
+      "description": "2.2.3 &mdash; La geopolitica delle criptovalute: Nel 2011, Cina e Giappone detenevano il 23% del debito&hellip; Sottocapitolo 2.2.3 di Futuro Fortissimo. 12 fonti, ~6 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-02-metaverso.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-02-2-4.html
+++ b/book/chapter-02-2-4.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>2.2 &mdash; Metaverso e Criptovalute | 💻 Tecnologia | Futuro Fortissimo</title>
-    <meta name="description" content="2.2 Metaverso e Criptovalute &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 29 fonti, ~12 min."/>
+    <meta name="description" content="2.2.4 &mdash; Cripto in guerra e simulazioni: Il 26 febbraio 2022, mentre i carri armati russi avanzavano&hellip; Sottocapitolo 2.2.4 di Futuro Fortissimo. 0 fonti, ~3 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-02-metaverso.html"/>
     <meta property="og:title" content="2.2 &mdash; Metaverso e Criptovalute | Tecnologia"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="2.2 Metaverso e Criptovalute &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 29 fonti, ~12 min."/>
+    <meta property="og:description" content="2.2.4 &mdash; Cripto in guerra e simulazioni: Il 26 febbraio 2022, mentre i carri armati russi avanzavano&hellip; Sottocapitolo 2.2.4 di Futuro Fortissimo. 0 fonti, ~3 min."/>
     <meta property="article:section" content="Tecnologia"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="2.2 — Metaverso e Criptovalute | 💻 Tecnologia"/>
-    <meta name="twitter:description" content="2.2 Metaverso e Criptovalute &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 29 fonti, ~12 min."/>
+    <meta name="twitter:description" content="2.2.4 &mdash; Cripto in guerra e simulazioni: Il 26 febbraio 2022, mentre i carri armati russi avanzavano&hellip; Sottocapitolo 2.2.4 di Futuro Fortissimo. 0 fonti, ~3 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "2.2 — Metaverso e Criptovalute | 💻 Tecnologia",
-      "description": "2.2 Metaverso e Criptovalute &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 29 fonti, ~12 min.",
+      "description": "2.2.4 &mdash; Cripto in guerra e simulazioni: Il 26 febbraio 2022, mentre i carri armati russi avanzavano&hellip; Sottocapitolo 2.2.4 di Futuro Fortissimo. 0 fonti, ~3 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-02-metaverso.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-02-3-1.html
+++ b/book/chapter-02-3-1.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>2.3 &mdash; Prodotti di consumo | 💻 Tecnologia | Futuro Fortissimo</title>
-    <meta name="description" content="2.3 Prodotti di consumo &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 42 fonti, ~16 min."/>
+    <meta name="description" content="2.3.1 &mdash; AI medica in tasca: Un mercoled&igrave; sera di novembre, mi sono rotto la clavicola cadendo dalla&hellip; Sottocapitolo 2.3.1 di Futuro Fortissimo. 1 fonti, ~2 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-02-prodotti.html"/>
     <meta property="og:title" content="2.3 &mdash; Prodotti di consumo | Tecnologia"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="2.3 Prodotti di consumo &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 42 fonti, ~16 min."/>
+    <meta property="og:description" content="2.3.1 &mdash; AI medica in tasca: Un mercoled&igrave; sera di novembre, mi sono rotto la clavicola cadendo dalla&hellip; Sottocapitolo 2.3.1 di Futuro Fortissimo. 1 fonti, ~2 min."/>
     <meta property="article:section" content="Tecnologia"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="2.3 — Prodotti di consumo | 💻 Tecnologia"/>
-    <meta name="twitter:description" content="2.3 Prodotti di consumo &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 42 fonti, ~16 min."/>
+    <meta name="twitter:description" content="2.3.1 &mdash; AI medica in tasca: Un mercoled&igrave; sera di novembre, mi sono rotto la clavicola cadendo dalla&hellip; Sottocapitolo 2.3.1 di Futuro Fortissimo. 1 fonti, ~2 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "2.3 — Prodotti di consumo | 💻 Tecnologia",
-      "description": "2.3 Prodotti di consumo &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 42 fonti, ~16 min.",
+      "description": "2.3.1 &mdash; AI medica in tasca: Un mercoled&igrave; sera di novembre, mi sono rotto la clavicola cadendo dalla&hellip; Sottocapitolo 2.3.1 di Futuro Fortissimo. 1 fonti, ~2 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-02-prodotti.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-02-3-2.html
+++ b/book/chapter-02-3-2.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>2.3 &mdash; Prodotti di consumo | 💻 Tecnologia | Futuro Fortissimo</title>
-    <meta name="description" content="2.3 Prodotti di consumo &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 42 fonti, ~16 min."/>
+    <meta name="description" content="2.3.2 &mdash; Intelligenze aliene e agenti: Qui si apre il passaggio successivo: non solo AI che&hellip; Sottocapitolo 2.3.2 di Futuro Fortissimo. 11 fonti, ~12 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-02-prodotti.html"/>
     <meta property="og:title" content="2.3 &mdash; Prodotti di consumo | Tecnologia"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="2.3 Prodotti di consumo &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 42 fonti, ~16 min."/>
+    <meta property="og:description" content="2.3.2 &mdash; Intelligenze aliene e agenti: Qui si apre il passaggio successivo: non solo AI che&hellip; Sottocapitolo 2.3.2 di Futuro Fortissimo. 11 fonti, ~12 min."/>
     <meta property="article:section" content="Tecnologia"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="2.3 — Prodotti di consumo | 💻 Tecnologia"/>
-    <meta name="twitter:description" content="2.3 Prodotti di consumo &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 42 fonti, ~16 min."/>
+    <meta name="twitter:description" content="2.3.2 &mdash; Intelligenze aliene e agenti: Qui si apre il passaggio successivo: non solo AI che&hellip; Sottocapitolo 2.3.2 di Futuro Fortissimo. 11 fonti, ~12 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "2.3 — Prodotti di consumo | 💻 Tecnologia",
-      "description": "2.3 Prodotti di consumo &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 42 fonti, ~16 min.",
+      "description": "2.3.2 &mdash; Intelligenze aliene e agenti: Qui si apre il passaggio successivo: non solo AI che&hellip; Sottocapitolo 2.3.2 di Futuro Fortissimo. 11 fonti, ~12 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-02-prodotti.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-02-3-3.html
+++ b/book/chapter-02-3-3.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>2.3 &mdash; Prodotti di consumo | 💻 Tecnologia | Futuro Fortissimo</title>
-    <meta name="description" content="2.3 Prodotti di consumo &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 42 fonti, ~16 min."/>
+    <meta name="description" content="2.3.3 &mdash; Videogiochi e creativit&agrave;: TSMC produce il 92% dei chip sotto i 7 nanometri; un blocco di&hellip; Sottocapitolo 2.3.3 di Futuro Fortissimo. 15 fonti, ~9 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-02-prodotti.html"/>
     <meta property="og:title" content="2.3 &mdash; Prodotti di consumo | Tecnologia"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="2.3 Prodotti di consumo &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 42 fonti, ~16 min."/>
+    <meta property="og:description" content="2.3.3 &mdash; Videogiochi e creativit&agrave;: TSMC produce il 92% dei chip sotto i 7 nanometri; un blocco di&hellip; Sottocapitolo 2.3.3 di Futuro Fortissimo. 15 fonti, ~9 min."/>
     <meta property="article:section" content="Tecnologia"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="2.3 — Prodotti di consumo | 💻 Tecnologia"/>
-    <meta name="twitter:description" content="2.3 Prodotti di consumo &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 42 fonti, ~16 min."/>
+    <meta name="twitter:description" content="2.3.3 &mdash; Videogiochi e creativit&agrave;: TSMC produce il 92% dei chip sotto i 7 nanometri; un blocco di&hellip; Sottocapitolo 2.3.3 di Futuro Fortissimo. 15 fonti, ~9 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "2.3 — Prodotti di consumo | 💻 Tecnologia",
-      "description": "2.3 Prodotti di consumo &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 42 fonti, ~16 min.",
+      "description": "2.3.3 &mdash; Videogiochi e creativit&agrave;: TSMC produce il 92% dei chip sotto i 7 nanometri; un blocco di&hellip; Sottocapitolo 2.3.3 di Futuro Fortissimo. 15 fonti, ~9 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-02-prodotti.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-02-3-4.html
+++ b/book/chapter-02-3-4.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>2.3 &mdash; Prodotti di consumo | 💻 Tecnologia | Futuro Fortissimo</title>
-    <meta name="description" content="2.3 Prodotti di consumo &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 42 fonti, ~16 min."/>
+    <meta name="description" content="2.3.4 &mdash; Il collo di bottiglia fisico: Un cheeseburger McDonald's equivale all'energia di 80.000&hellip; Sottocapitolo 2.3.4 di Futuro Fortissimo. 12 fonti, ~12 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-02-prodotti.html"/>
     <meta property="og:title" content="2.3 &mdash; Prodotti di consumo | Tecnologia"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="2.3 Prodotti di consumo &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 42 fonti, ~16 min."/>
+    <meta property="og:description" content="2.3.4 &mdash; Il collo di bottiglia fisico: Un cheeseburger McDonald's equivale all'energia di 80.000&hellip; Sottocapitolo 2.3.4 di Futuro Fortissimo. 12 fonti, ~12 min."/>
     <meta property="article:section" content="Tecnologia"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="2.3 — Prodotti di consumo | 💻 Tecnologia"/>
-    <meta name="twitter:description" content="2.3 Prodotti di consumo &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 42 fonti, ~16 min."/>
+    <meta name="twitter:description" content="2.3.4 &mdash; Il collo di bottiglia fisico: Un cheeseburger McDonald's equivale all'energia di 80.000&hellip; Sottocapitolo 2.3.4 di Futuro Fortissimo. 12 fonti, ~12 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "2.3 — Prodotti di consumo | 💻 Tecnologia",
-      "description": "2.3 Prodotti di consumo &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 42 fonti, ~16 min.",
+      "description": "2.3.4 &mdash; Il collo di bottiglia fisico: Un cheeseburger McDonald's equivale all'energia di 80.000&hellip; Sottocapitolo 2.3.4 di Futuro Fortissimo. 12 fonti, ~12 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-02-prodotti.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-02-metaverso.html
+++ b/book/chapter-02-metaverso.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>2.2 &mdash; Metaverso e Criptovalute | 💻 Tecnologia | Futuro Fortissimo</title>
-    <meta name="description" content="2.2 Metaverso e Criptovalute &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 29 fonti, ~12 min."/>
+    <meta name="description" content="2.2 &mdash; Metaverso e Criptovalute (Il metaverso trasformato, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 34 fonti, ~30 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-02-metaverso.html"/>
     <meta property="og:title" content="2.2 &mdash; Metaverso e Criptovalute | Tecnologia"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="2.2 Metaverso e Criptovalute &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 29 fonti, ~12 min."/>
+    <meta property="og:description" content="2.2 &mdash; Metaverso e Criptovalute (Il metaverso trasformato, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 34 fonti, ~30 min."/>
     <meta property="article:section" content="Tecnologia"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="2.2 — Metaverso e Criptovalute | 💻 Tecnologia"/>
-    <meta name="twitter:description" content="2.2 Metaverso e Criptovalute &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 29 fonti, ~12 min."/>
+    <meta name="twitter:description" content="2.2 &mdash; Metaverso e Criptovalute (Il metaverso trasformato, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 34 fonti, ~30 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "2.2 — Metaverso e Criptovalute | 💻 Tecnologia",
-      "description": "2.2 Metaverso e Criptovalute &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 29 fonti, ~12 min.",
+      "description": "2.2 &mdash; Metaverso e Criptovalute (Il metaverso trasformato, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 34 fonti, ~30 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-02-metaverso.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-02-prodotti.html
+++ b/book/chapter-02-prodotti.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>2.3 &mdash; Prodotti di consumo | 💻 Tecnologia | Futuro Fortissimo</title>
-    <meta name="description" content="2.3 Prodotti di consumo &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 42 fonti, ~16 min."/>
+    <meta name="description" content="2.3 &mdash; Prodotti di consumo (AI medica in tasca, Intelligenze aliene e agenti, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 41 fonti, ~35 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-02-prodotti.html"/>
     <meta property="og:title" content="2.3 &mdash; Prodotti di consumo | Tecnologia"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="2.3 Prodotti di consumo &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 42 fonti, ~16 min."/>
+    <meta property="og:description" content="2.3 &mdash; Prodotti di consumo (AI medica in tasca, Intelligenze aliene e agenti, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 41 fonti, ~35 min."/>
     <meta property="article:section" content="Tecnologia"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="2.3 — Prodotti di consumo | 💻 Tecnologia"/>
-    <meta name="twitter:description" content="2.3 Prodotti di consumo &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 42 fonti, ~16 min."/>
+    <meta name="twitter:description" content="2.3 &mdash; Prodotti di consumo (AI medica in tasca, Intelligenze aliene e agenti, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 41 fonti, ~35 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "2.3 — Prodotti di consumo | 💻 Tecnologia",
-      "description": "2.3 Prodotti di consumo &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 42 fonti, ~16 min.",
+      "description": "2.3 &mdash; Prodotti di consumo (AI medica in tasca, Intelligenze aliene e agenti, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 41 fonti, ~35 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-02-prodotti.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-02-robotica.html
+++ b/book/chapter-02-robotica.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>2.1 &mdash; Robotica e AI | 💻 Tecnologia | Futuro Fortissimo</title>
-    <meta name="description" content="2.1 Robotica e AI &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 70 fonti, ~33 min."/>
+    <meta name="description" content="2.1 &mdash; Robotica e AI (L'economia del compute, La singolarit&agrave; gentile, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 88 fonti, ~61 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-02-robotica.html"/>
     <meta property="og:title" content="2.1 &mdash; Robotica e AI | Tecnologia"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="2.1 Robotica e AI &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 70 fonti, ~33 min."/>
+    <meta property="og:description" content="2.1 &mdash; Robotica e AI (L'economia del compute, La singolarit&agrave; gentile, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 88 fonti, ~61 min."/>
     <meta property="article:section" content="Tecnologia"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="2.1 — Robotica e AI | 💻 Tecnologia"/>
-    <meta name="twitter:description" content="2.1 Robotica e AI &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 70 fonti, ~33 min."/>
+    <meta name="twitter:description" content="2.1 &mdash; Robotica e AI (L'economia del compute, La singolarit&agrave; gentile, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 88 fonti, ~61 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "2.1 — Robotica e AI | 💻 Tecnologia",
-      "description": "2.1 Robotica e AI &mdash; Capitolo 2 (Tecnologia) del libro Futuro Fortissimo. 70 fonti, ~33 min.",
+      "description": "2.1 &mdash; Robotica e AI (L'economia del compute, La singolarit&agrave; gentile, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 88 fonti, ~61 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-02-robotica.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-03-1-1.html
+++ b/book/chapter-03-1-1.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>3.1 &mdash; Psicologia e Wellbeing | ❤️ Società | Futuro Fortissimo</title>
-    <meta name="description" content="3.1 Psicologia e Wellbeing &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 54 fonti, ~23 min."/>
+    <meta name="description" content="3.1.1 &mdash; Nominare per guarire: Secondo McKinsey, i manager nel flow sono cinque volte pi&ugrave; produttivi. Sottocapitolo 3.1.1 di Futuro Fortissimo. 6 fonti, ~3 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-03-psicologia.html"/>
     <meta property="og:title" content="3.1 &mdash; Psicologia e Wellbeing | Società"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="3.1 Psicologia e Wellbeing &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 54 fonti, ~23 min."/>
+    <meta property="og:description" content="3.1.1 &mdash; Nominare per guarire: Secondo McKinsey, i manager nel flow sono cinque volte pi&ugrave; produttivi. Sottocapitolo 3.1.1 di Futuro Fortissimo. 6 fonti, ~3 min."/>
     <meta property="article:section" content="Società"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="3.1 — Psicologia e Wellbeing | ❤️ Società"/>
-    <meta name="twitter:description" content="3.1 Psicologia e Wellbeing &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 54 fonti, ~23 min."/>
+    <meta name="twitter:description" content="3.1.1 &mdash; Nominare per guarire: Secondo McKinsey, i manager nel flow sono cinque volte pi&ugrave; produttivi. Sottocapitolo 3.1.1 di Futuro Fortissimo. 6 fonti, ~3 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "3.1 — Psicologia e Wellbeing | ❤️ Società",
-      "description": "3.1 Psicologia e Wellbeing &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 54 fonti, ~23 min.",
+      "description": "3.1.1 &mdash; Nominare per guarire: Secondo McKinsey, i manager nel flow sono cinque volte pi&ugrave; produttivi. Sottocapitolo 3.1.1 di Futuro Fortissimo. 6 fonti, ~3 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-03-psicologia.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-03-1-2.html
+++ b/book/chapter-03-1-2.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>3.1 &mdash; Psicologia e Wellbeing | ❤️ Società | Futuro Fortissimo</title>
-    <meta name="description" content="3.1 Psicologia e Wellbeing &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 54 fonti, ~23 min."/>
+    <meta name="description" content="3.1.2 &mdash; Tempo e finitudine: L'intelligenza fluida declina dopo i 40, ma l'intelligenza&hellip; Sottocapitolo 3.1.2 di Futuro Fortissimo. 16 fonti, ~14 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-03-psicologia.html"/>
     <meta property="og:title" content="3.1 &mdash; Psicologia e Wellbeing | Società"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="3.1 Psicologia e Wellbeing &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 54 fonti, ~23 min."/>
+    <meta property="og:description" content="3.1.2 &mdash; Tempo e finitudine: L'intelligenza fluida declina dopo i 40, ma l'intelligenza&hellip; Sottocapitolo 3.1.2 di Futuro Fortissimo. 16 fonti, ~14 min."/>
     <meta property="article:section" content="Società"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="3.1 — Psicologia e Wellbeing | ❤️ Società"/>
-    <meta name="twitter:description" content="3.1 Psicologia e Wellbeing &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 54 fonti, ~23 min."/>
+    <meta name="twitter:description" content="3.1.2 &mdash; Tempo e finitudine: L'intelligenza fluida declina dopo i 40, ma l'intelligenza&hellip; Sottocapitolo 3.1.2 di Futuro Fortissimo. 16 fonti, ~14 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "3.1 — Psicologia e Wellbeing | ❤️ Società",
-      "description": "3.1 Psicologia e Wellbeing &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 54 fonti, ~23 min.",
+      "description": "3.1.2 &mdash; Tempo e finitudine: L'intelligenza fluida declina dopo i 40, ma l'intelligenza&hellip; Sottocapitolo 3.1.2 di Futuro Fortissimo. 16 fonti, ~14 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-03-psicologia.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-03-1-3.html
+++ b/book/chapter-03-1-3.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>3.1 &mdash; Psicologia e Wellbeing | ❤️ Società | Futuro Fortissimo</title>
-    <meta name="description" content="3.1 Psicologia e Wellbeing &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 54 fonti, ~23 min."/>
+    <meta name="description" content="3.1.3 &mdash; Attenzione e stimolo: Il 60% dei laureati di Harvard finisce in consulenza, finanza o Big&hellip; Sottocapitolo 3.1.3 di Futuro Fortissimo. 17 fonti, ~12 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-03-psicologia.html"/>
     <meta property="og:title" content="3.1 &mdash; Psicologia e Wellbeing | Società"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="3.1 Psicologia e Wellbeing &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 54 fonti, ~23 min."/>
+    <meta property="og:description" content="3.1.3 &mdash; Attenzione e stimolo: Il 60% dei laureati di Harvard finisce in consulenza, finanza o Big&hellip; Sottocapitolo 3.1.3 di Futuro Fortissimo. 17 fonti, ~12 min."/>
     <meta property="article:section" content="Società"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="3.1 — Psicologia e Wellbeing | ❤️ Società"/>
-    <meta name="twitter:description" content="3.1 Psicologia e Wellbeing &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 54 fonti, ~23 min."/>
+    <meta name="twitter:description" content="3.1.3 &mdash; Attenzione e stimolo: Il 60% dei laureati di Harvard finisce in consulenza, finanza o Big&hellip; Sottocapitolo 3.1.3 di Futuro Fortissimo. 17 fonti, ~12 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "3.1 — Psicologia e Wellbeing | ❤️ Società",
-      "description": "3.1 Psicologia e Wellbeing &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 54 fonti, ~23 min.",
+      "description": "3.1.3 &mdash; Attenzione e stimolo: Il 60% dei laureati di Harvard finisce in consulenza, finanza o Big&hellip; Sottocapitolo 3.1.3 di Futuro Fortissimo. 17 fonti, ~12 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-03-psicologia.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-03-1-4.html
+++ b/book/chapter-03-1-4.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>3.1 &mdash; Psicologia e Wellbeing | ❤️ Società | Futuro Fortissimo</title>
-    <meta name="description" content="3.1 Psicologia e Wellbeing &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 54 fonti, ~23 min."/>
+    <meta name="description" content="3.1.4 &mdash; Noia, silenzio e routine: Negli ultimi 70 anni la percentuale di proprietari di case e di&hellip; Sottocapitolo 3.1.4 di Futuro Fortissimo. 19 fonti, ~22 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-03-psicologia.html"/>
     <meta property="og:title" content="3.1 &mdash; Psicologia e Wellbeing | Società"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="3.1 Psicologia e Wellbeing &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 54 fonti, ~23 min."/>
+    <meta property="og:description" content="3.1.4 &mdash; Noia, silenzio e routine: Negli ultimi 70 anni la percentuale di proprietari di case e di&hellip; Sottocapitolo 3.1.4 di Futuro Fortissimo. 19 fonti, ~22 min."/>
     <meta property="article:section" content="Società"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="3.1 — Psicologia e Wellbeing | ❤️ Società"/>
-    <meta name="twitter:description" content="3.1 Psicologia e Wellbeing &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 54 fonti, ~23 min."/>
+    <meta name="twitter:description" content="3.1.4 &mdash; Noia, silenzio e routine: Negli ultimi 70 anni la percentuale di proprietari di case e di&hellip; Sottocapitolo 3.1.4 di Futuro Fortissimo. 19 fonti, ~22 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "3.1 — Psicologia e Wellbeing | ❤️ Società",
-      "description": "3.1 Psicologia e Wellbeing &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 54 fonti, ~23 min.",
+      "description": "3.1.4 &mdash; Noia, silenzio e routine: Negli ultimi 70 anni la percentuale di proprietari di case e di&hellip; Sottocapitolo 3.1.4 di Futuro Fortissimo. 19 fonti, ~22 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-03-psicologia.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-03-2-1.html
+++ b/book/chapter-03-2-1.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>3.2 &mdash; Alimentazione e Sport | ❤️ Società | Futuro Fortissimo</title>
-    <meta name="description" content="3.2 Alimentazione e Sport &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 26 fonti, ~10 min."/>
+    <meta name="description" content="3.2.1 &mdash; VO₂max e longevit&agrave;: Chi si muove regolarmente allunga la vita anche mangiando male; chi non&hellip; Sottocapitolo 3.2.1 di Futuro Fortissimo. 16 fonti, ~9 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-03-alimentazione.html"/>
     <meta property="og:title" content="3.2 &mdash; Alimentazione e Sport | Società"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="3.2 Alimentazione e Sport &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 26 fonti, ~10 min."/>
+    <meta property="og:description" content="3.2.1 &mdash; VO₂max e longevit&agrave;: Chi si muove regolarmente allunga la vita anche mangiando male; chi non&hellip; Sottocapitolo 3.2.1 di Futuro Fortissimo. 16 fonti, ~9 min."/>
     <meta property="article:section" content="Società"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="3.2 — Alimentazione e Sport | ❤️ Società"/>
-    <meta name="twitter:description" content="3.2 Alimentazione e Sport &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 26 fonti, ~10 min."/>
+    <meta name="twitter:description" content="3.2.1 &mdash; VO₂max e longevit&agrave;: Chi si muove regolarmente allunga la vita anche mangiando male; chi non&hellip; Sottocapitolo 3.2.1 di Futuro Fortissimo. 16 fonti, ~9 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "3.2 — Alimentazione e Sport | ❤️ Società",
-      "description": "3.2 Alimentazione e Sport &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 26 fonti, ~10 min.",
+      "description": "3.2.1 &mdash; VO₂max e longevit&agrave;: Chi si muove regolarmente allunga la vita anche mangiando male; chi non&hellip; Sottocapitolo 3.2.1 di Futuro Fortissimo. 16 fonti, ~9 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-03-alimentazione.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-03-2-2.html
+++ b/book/chapter-03-2-2.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>3.2 &mdash; Alimentazione e Sport | ❤️ Società | Futuro Fortissimo</title>
-    <meta name="description" content="3.2 Alimentazione e Sport &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 26 fonti, ~10 min."/>
+    <meta name="description" content="3.2.2 &mdash; Flow e limiti estremi: C&rsquo;&egrave; un principio di progettazione personale che attraversa tutti&hellip; Sottocapitolo 3.2.2 di Futuro Fortissimo. 8 fonti, ~3 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-03-alimentazione.html"/>
     <meta property="og:title" content="3.2 &mdash; Alimentazione e Sport | Società"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="3.2 Alimentazione e Sport &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 26 fonti, ~10 min."/>
+    <meta property="og:description" content="3.2.2 &mdash; Flow e limiti estremi: C&rsquo;&egrave; un principio di progettazione personale che attraversa tutti&hellip; Sottocapitolo 3.2.2 di Futuro Fortissimo. 8 fonti, ~3 min."/>
     <meta property="article:section" content="Società"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="3.2 — Alimentazione e Sport | ❤️ Società"/>
-    <meta name="twitter:description" content="3.2 Alimentazione e Sport &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 26 fonti, ~10 min."/>
+    <meta name="twitter:description" content="3.2.2 &mdash; Flow e limiti estremi: C&rsquo;&egrave; un principio di progettazione personale che attraversa tutti&hellip; Sottocapitolo 3.2.2 di Futuro Fortissimo. 8 fonti, ~3 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "3.2 — Alimentazione e Sport | ❤️ Società",
-      "description": "3.2 Alimentazione e Sport &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 26 fonti, ~10 min.",
+      "description": "3.2.2 &mdash; Flow e limiti estremi: C&rsquo;&egrave; un principio di progettazione personale che attraversa tutti&hellip; Sottocapitolo 3.2.2 di Futuro Fortissimo. 8 fonti, ~3 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-03-alimentazione.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-03-2-3.html
+++ b/book/chapter-03-2-3.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>3.2 &mdash; Alimentazione e Sport | ❤️ Società | Futuro Fortissimo</title>
-    <meta name="description" content="3.2 Alimentazione e Sport &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 26 fonti, ~10 min."/>
+    <meta name="description" content="3.2.3 &mdash; Chimica del corpo: La fatica mentale riduce la performance atletica anche quando i&hellip; Sottocapitolo 3.2.3 di Futuro Fortissimo. 12 fonti, ~5 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-03-alimentazione.html"/>
     <meta property="og:title" content="3.2 &mdash; Alimentazione e Sport | Società"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="3.2 Alimentazione e Sport &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 26 fonti, ~10 min."/>
+    <meta property="og:description" content="3.2.3 &mdash; Chimica del corpo: La fatica mentale riduce la performance atletica anche quando i&hellip; Sottocapitolo 3.2.3 di Futuro Fortissimo. 12 fonti, ~5 min."/>
     <meta property="article:section" content="Società"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="3.2 — Alimentazione e Sport | ❤️ Società"/>
-    <meta name="twitter:description" content="3.2 Alimentazione e Sport &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 26 fonti, ~10 min."/>
+    <meta name="twitter:description" content="3.2.3 &mdash; Chimica del corpo: La fatica mentale riduce la performance atletica anche quando i&hellip; Sottocapitolo 3.2.3 di Futuro Fortissimo. 12 fonti, ~5 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "3.2 — Alimentazione e Sport | ❤️ Società",
-      "description": "3.2 Alimentazione e Sport &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 26 fonti, ~10 min.",
+      "description": "3.2.3 &mdash; Chimica del corpo: La fatica mentale riduce la performance atletica anche quando i&hellip; Sottocapitolo 3.2.3 di Futuro Fortissimo. 12 fonti, ~5 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-03-alimentazione.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-03-2-4.html
+++ b/book/chapter-03-2-4.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>3.2 &mdash; Alimentazione e Sport | ❤️ Società | Futuro Fortissimo</title>
-    <meta name="description" content="3.2 Alimentazione e Sport &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 26 fonti, ~10 min."/>
+    <meta name="description" content="3.2.4 &mdash; Respiro e sonno: James Nestor, in Breath: The New Science of a Lost Art , rivela che la&hellip; Sottocapitolo 3.2.4 di Futuro Fortissimo. 2 fonti, ~2 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-03-alimentazione.html"/>
     <meta property="og:title" content="3.2 &mdash; Alimentazione e Sport | Società"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="3.2 Alimentazione e Sport &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 26 fonti, ~10 min."/>
+    <meta property="og:description" content="3.2.4 &mdash; Respiro e sonno: James Nestor, in Breath: The New Science of a Lost Art , rivela che la&hellip; Sottocapitolo 3.2.4 di Futuro Fortissimo. 2 fonti, ~2 min."/>
     <meta property="article:section" content="Società"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="3.2 — Alimentazione e Sport | ❤️ Società"/>
-    <meta name="twitter:description" content="3.2 Alimentazione e Sport &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 26 fonti, ~10 min."/>
+    <meta name="twitter:description" content="3.2.4 &mdash; Respiro e sonno: James Nestor, in Breath: The New Science of a Lost Art , rivela che la&hellip; Sottocapitolo 3.2.4 di Futuro Fortissimo. 2 fonti, ~2 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "3.2 — Alimentazione e Sport | ❤️ Società",
-      "description": "3.2 Alimentazione e Sport &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 26 fonti, ~10 min.",
+      "description": "3.2.4 &mdash; Respiro e sonno: James Nestor, in Breath: The New Science of a Lost Art , rivela che la&hellip; Sottocapitolo 3.2.4 di Futuro Fortissimo. 2 fonti, ~2 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-03-alimentazione.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-03-3-1.html
+++ b/book/chapter-03-3-1.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>3.3 &mdash; Cultura, Politica e Demografia | ❤️ Società | Futuro Fortissimo</title>
-    <meta name="description" content="3.3 Cultura, Politica e Demografia &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 61 fonti, ~26 min."/>
+    <meta name="description" content="3.3.1 &mdash; Lavoro e identit&agrave;: Paul Millerd aveva uno stipendio a sei cifre e un piano di carriera&hellip; Sottocapitolo 3.3.1 di Futuro Fortissimo. 4 fonti, ~9 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-03-cultura.html"/>
     <meta property="og:title" content="3.3 &mdash; Cultura, Politica e Demografia | Società"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="3.3 Cultura, Politica e Demografia &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 61 fonti, ~26 min."/>
+    <meta property="og:description" content="3.3.1 &mdash; Lavoro e identit&agrave;: Paul Millerd aveva uno stipendio a sei cifre e un piano di carriera&hellip; Sottocapitolo 3.3.1 di Futuro Fortissimo. 4 fonti, ~9 min."/>
     <meta property="article:section" content="Società"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="3.3 — Cultura, Politica e Demografia | ❤️ Società"/>
-    <meta name="twitter:description" content="3.3 Cultura, Politica e Demografia &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 61 fonti, ~26 min."/>
+    <meta name="twitter:description" content="3.3.1 &mdash; Lavoro e identit&agrave;: Paul Millerd aveva uno stipendio a sei cifre e un piano di carriera&hellip; Sottocapitolo 3.3.1 di Futuro Fortissimo. 4 fonti, ~9 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "3.3 — Cultura, Politica e Demografia | ❤️ Società",
-      "description": "3.3 Cultura, Politica e Demografia &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 61 fonti, ~26 min.",
+      "description": "3.3.1 &mdash; Lavoro e identit&agrave;: Paul Millerd aveva uno stipendio a sei cifre e un piano di carriera&hellip; Sottocapitolo 3.3.1 di Futuro Fortissimo. 4 fonti, ~9 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-03-cultura.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-03-3-2.html
+++ b/book/chapter-03-3-2.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>3.3 &mdash; Cultura, Politica e Demografia | ❤️ Società | Futuro Fortissimo</title>
-    <meta name="description" content="3.3 Cultura, Politica e Demografia &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 61 fonti, ~26 min."/>
+    <meta name="description" content="3.3.2 &mdash; Solitudine e demografia: In Corea del Sud il tasso di fertilit&agrave; &egrave; sceso a 0,72 figli per&hellip; Sottocapitolo 3.3.2 di Futuro Fortissimo. 10 fonti, ~10 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-03-cultura.html"/>
     <meta property="og:title" content="3.3 &mdash; Cultura, Politica e Demografia | Società"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="3.3 Cultura, Politica e Demografia &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 61 fonti, ~26 min."/>
+    <meta property="og:description" content="3.3.2 &mdash; Solitudine e demografia: In Corea del Sud il tasso di fertilit&agrave; &egrave; sceso a 0,72 figli per&hellip; Sottocapitolo 3.3.2 di Futuro Fortissimo. 10 fonti, ~10 min."/>
     <meta property="article:section" content="Società"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="3.3 — Cultura, Politica e Demografia | ❤️ Società"/>
-    <meta name="twitter:description" content="3.3 Cultura, Politica e Demografia &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 61 fonti, ~26 min."/>
+    <meta name="twitter:description" content="3.3.2 &mdash; Solitudine e demografia: In Corea del Sud il tasso di fertilit&agrave; &egrave; sceso a 0,72 figli per&hellip; Sottocapitolo 3.3.2 di Futuro Fortissimo. 10 fonti, ~10 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "3.3 — Cultura, Politica e Demografia | ❤️ Società",
-      "description": "3.3 Cultura, Politica e Demografia &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 61 fonti, ~26 min.",
+      "description": "3.3.2 &mdash; Solitudine e demografia: In Corea del Sud il tasso di fertilit&agrave; &egrave; sceso a 0,72 figli per&hellip; Sottocapitolo 3.3.2 di Futuro Fortissimo. 10 fonti, ~10 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-03-cultura.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-03-3-3.html
+++ b/book/chapter-03-3-3.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>3.3 &mdash; Cultura, Politica e Demografia | ❤️ Società | Futuro Fortissimo</title>
-    <meta name="description" content="3.3 Cultura, Politica e Demografia &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 61 fonti, ~26 min."/>
+    <meta name="description" content="3.3.3 &mdash; Economia e geopolitica: La burocrazia &egrave; stata il primo algoritmo della storia: ha risolto&hellip; Sottocapitolo 3.3.3 di Futuro Fortissimo. 14 fonti, ~9 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-03-cultura.html"/>
     <meta property="og:title" content="3.3 &mdash; Cultura, Politica e Demografia | Società"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="3.3 Cultura, Politica e Demografia &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 61 fonti, ~26 min."/>
+    <meta property="og:description" content="3.3.3 &mdash; Economia e geopolitica: La burocrazia &egrave; stata il primo algoritmo della storia: ha risolto&hellip; Sottocapitolo 3.3.3 di Futuro Fortissimo. 14 fonti, ~9 min."/>
     <meta property="article:section" content="Società"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="3.3 — Cultura, Politica e Demografia | ❤️ Società"/>
-    <meta name="twitter:description" content="3.3 Cultura, Politica e Demografia &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 61 fonti, ~26 min."/>
+    <meta name="twitter:description" content="3.3.3 &mdash; Economia e geopolitica: La burocrazia &egrave; stata il primo algoritmo della storia: ha risolto&hellip; Sottocapitolo 3.3.3 di Futuro Fortissimo. 14 fonti, ~9 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "3.3 — Cultura, Politica e Demografia | ❤️ Società",
-      "description": "3.3 Cultura, Politica e Demografia &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 61 fonti, ~26 min.",
+      "description": "3.3.3 &mdash; Economia e geopolitica: La burocrazia &egrave; stata il primo algoritmo della storia: ha risolto&hellip; Sottocapitolo 3.3.3 di Futuro Fortissimo. 14 fonti, ~9 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-03-cultura.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-03-3-4.html
+++ b/book/chapter-03-3-4.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>3.3 &mdash; Cultura, Politica e Demografia | ❤️ Società | Futuro Fortissimo</title>
-    <meta name="description" content="3.3 Cultura, Politica e Demografia &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 61 fonti, ~26 min."/>
+    <meta name="description" content="3.3.4 &mdash; Arte, previsioni e futuro: Dagli anni Ottanta le parole &ldquo;progresso&rdquo; e &ldquo;futuro&rdquo; compaiono&hellip; Sottocapitolo 3.3.4 di Futuro Fortissimo. 13 fonti, ~26 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-03-cultura.html"/>
     <meta property="og:title" content="3.3 &mdash; Cultura, Politica e Demografia | Società"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="3.3 Cultura, Politica e Demografia &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 61 fonti, ~26 min."/>
+    <meta property="og:description" content="3.3.4 &mdash; Arte, previsioni e futuro: Dagli anni Ottanta le parole &ldquo;progresso&rdquo; e &ldquo;futuro&rdquo; compaiono&hellip; Sottocapitolo 3.3.4 di Futuro Fortissimo. 13 fonti, ~26 min."/>
     <meta property="article:section" content="Società"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="3.3 — Cultura, Politica e Demografia | ❤️ Società"/>
-    <meta name="twitter:description" content="3.3 Cultura, Politica e Demografia &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 61 fonti, ~26 min."/>
+    <meta name="twitter:description" content="3.3.4 &mdash; Arte, previsioni e futuro: Dagli anni Ottanta le parole &ldquo;progresso&rdquo; e &ldquo;futuro&rdquo; compaiono&hellip; Sottocapitolo 3.3.4 di Futuro Fortissimo. 13 fonti, ~26 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "3.3 — Cultura, Politica e Demografia | ❤️ Società",
-      "description": "3.3 Cultura, Politica e Demografia &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 61 fonti, ~26 min.",
+      "description": "3.3.4 &mdash; Arte, previsioni e futuro: Dagli anni Ottanta le parole &ldquo;progresso&rdquo; e &ldquo;futuro&rdquo; compaiono&hellip; Sottocapitolo 3.3.4 di Futuro Fortissimo. 13 fonti, ~26 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-03-cultura.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-03-alimentazione.html
+++ b/book/chapter-03-alimentazione.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>3.2 &mdash; Alimentazione e Sport | ❤️ Società | Futuro Fortissimo</title>
-    <meta name="description" content="3.2 Alimentazione e Sport &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 26 fonti, ~10 min."/>
+    <meta name="description" content="3.2 &mdash; Alimentazione e Sport (VO₂max e longevit&agrave;, Flow e limiti estremi, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 38 fonti, ~20 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-03-alimentazione.html"/>
     <meta property="og:title" content="3.2 &mdash; Alimentazione e Sport | Società"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="3.2 Alimentazione e Sport &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 26 fonti, ~10 min."/>
+    <meta property="og:description" content="3.2 &mdash; Alimentazione e Sport (VO₂max e longevit&agrave;, Flow e limiti estremi, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 38 fonti, ~20 min."/>
     <meta property="article:section" content="Società"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="3.2 — Alimentazione e Sport | ❤️ Società"/>
-    <meta name="twitter:description" content="3.2 Alimentazione e Sport &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 26 fonti, ~10 min."/>
+    <meta name="twitter:description" content="3.2 &mdash; Alimentazione e Sport (VO₂max e longevit&agrave;, Flow e limiti estremi, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 38 fonti, ~20 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "3.2 — Alimentazione e Sport | ❤️ Società",
-      "description": "3.2 Alimentazione e Sport &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 26 fonti, ~10 min.",
+      "description": "3.2 &mdash; Alimentazione e Sport (VO₂max e longevit&agrave;, Flow e limiti estremi, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 38 fonti, ~20 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-03-alimentazione.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-03-cultura.html
+++ b/book/chapter-03-cultura.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>3.3 &mdash; Cultura, Politica e Demografia | ❤️ Società | Futuro Fortissimo</title>
-    <meta name="description" content="3.3 Cultura, Politica e Demografia &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 61 fonti, ~26 min."/>
+    <meta name="description" content="3.3 &mdash; Cultura, Politica e Demografia (Lavoro e identit&agrave;, Solitudine e demografia, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 42 fonti, ~55 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-03-cultura.html"/>
     <meta property="og:title" content="3.3 &mdash; Cultura, Politica e Demografia | Società"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="3.3 Cultura, Politica e Demografia &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 61 fonti, ~26 min."/>
+    <meta property="og:description" content="3.3 &mdash; Cultura, Politica e Demografia (Lavoro e identit&agrave;, Solitudine e demografia, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 42 fonti, ~55 min."/>
     <meta property="article:section" content="Società"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="3.3 — Cultura, Politica e Demografia | ❤️ Società"/>
-    <meta name="twitter:description" content="3.3 Cultura, Politica e Demografia &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 61 fonti, ~26 min."/>
+    <meta name="twitter:description" content="3.3 &mdash; Cultura, Politica e Demografia (Lavoro e identit&agrave;, Solitudine e demografia, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 42 fonti, ~55 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "3.3 — Cultura, Politica e Demografia | ❤️ Società",
-      "description": "3.3 Cultura, Politica e Demografia &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 61 fonti, ~26 min.",
+      "description": "3.3 &mdash; Cultura, Politica e Demografia (Lavoro e identit&agrave;, Solitudine e demografia, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 42 fonti, ~55 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-03-cultura.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },

--- a/book/chapter-03-psicologia.html
+++ b/book/chapter-03-psicologia.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>3.1 &mdash; Psicologia e Wellbeing | ❤️ Società | Futuro Fortissimo</title>
-    <meta name="description" content="3.1 Psicologia e Wellbeing &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 54 fonti, ~23 min."/>
+    <meta name="description" content="3.1 &mdash; Psicologia e Wellbeing (Nominare per guarire, Tempo e finitudine, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 58 fonti, ~51 min."/>
     <link rel="canonical" href="https://futurofortissimo.github.io/book/chapter-03-psicologia.html"/>
     <meta property="og:title" content="3.1 &mdash; Psicologia e Wellbeing | Società"/>
     <meta property="og:type" content="article"/>
@@ -21,15 +21,15 @@
 
     <meta property="og:site_name" content="Futuro Fortissimo"/>
     <meta property="og:locale" content="it_IT"/>
-    <meta property="og:description" content="3.1 Psicologia e Wellbeing &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 54 fonti, ~23 min."/>
+    <meta property="og:description" content="3.1 &mdash; Psicologia e Wellbeing (Nominare per guarire, Tempo e finitudine, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 58 fonti, ~51 min."/>
     <meta property="article:section" content="Società"/>
-    <meta property="article:modified_time" content="2026-04-20"/>
+    <meta property="article:modified_time" content="2026-04-21"/>
 
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@micmer"/>
     <meta name="twitter:creator" content="@micmer"/>
     <meta name="twitter:title" content="3.1 — Psicologia e Wellbeing | ❤️ Società"/>
-    <meta name="twitter:description" content="3.1 Psicologia e Wellbeing &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 54 fonti, ~23 min."/>
+    <meta name="twitter:description" content="3.1 &mdash; Psicologia e Wellbeing (Nominare per guarire, Tempo e finitudine, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 58 fonti, ~51 min."/>
     <meta name="twitter:image" content="https://futurofortissimo.github.io/logo.png"/>
 
     <script type="application/ld+json">
@@ -37,11 +37,11 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "3.1 — Psicologia e Wellbeing | ❤️ Società",
-      "description": "3.1 Psicologia e Wellbeing &mdash; Capitolo 3 (Società) del libro Futuro Fortissimo. 54 fonti, ~23 min.",
+      "description": "3.1 &mdash; Psicologia e Wellbeing (Nominare per guarire, Tempo e finitudine, &hellip;). Introduzione + 4 sottocapitoli di Futuro Fortissimo. 58 fonti, ~51 min.",
       "author": { "@type": "Person", "name": "Michele Merelli", "url": "https://futurofortissimo.substack.com/" },
       "publisher": { "@type": "Organization", "name": "Futuro Fortissimo", "url": "https://futurofortissimo.github.io/" },
       "datePublished": "2024-01-01",
-      "dateModified": "2026-04-20",
+      "dateModified": "2026-04-21",
       "inLanguage": "it",
       "mainEntityOfPage": { "@type": "WebPage", "@id": "https://futurofortissimo.github.io/book/chapter-03-psicologia.html" },
       "isPartOf": { "@type": "Book", "name": "Futuro Fortissimo — Tre Macro Temi", "url": "https://futurofortissimo.github.io/book/" },


### PR DESCRIPTION
## Summary
- Fixes stale `N fonti, ~M min` metadata on all 45 book chapter pages after the recent split into independent sub-pages. Every sub-page in a section previously carried the same counts copied from the parent; now each page reports its own data.
- Rewrites the description concept (4 fields per page: `meta[name=description]`, `og:description`, `twitter:description`, JSON-LD `description`) to reflect the split structure, keeping the rendered text under 160 chars for Google.
- Bumps `article:modified_time` and JSON-LD `dateModified` to 2026-04-21.

## Count logic (uniform per page)
- `fonti` = distinct `<li id="fonte-N">` entries in the page bibliography.
- `min`  = `max(1, round(word_count(<article>) / 220))`.

## Description templates
- **Sub-page**: `N.M.P — {title}: {concept}. Sottocapitolo N.M.P di Futuro Fortissimo. {fonti} fonti, ~{min} min.`
- **Parent page**: `N.M — {section} ({sub titles}). Introduzione + 4 sottocapitoli di Futuro Fortissimo. {fonti} fonti, ~{min} min.`

## Example diffs (old → new)
- `chapter-01-mobilita.html` parent: `15 fonti, ~8 min` → **`18 fonti, ~16 min`** + new parenthesised sub list.
- `chapter-01-1-1.html` sub: `15 fonti, ~8 min` (copied from parent) → **`2 fonti, ~2 min`** + concept line pulled from the page's own pull-quote.
- `chapter-01-2-3.html` sub: `73 fonti, ~39 min` (copied) → **`49 fonti, ~44 min`** (actual page data).
- `chapter-02-robotica.html` parent: `70 fonti, ~33 min` → **`88 fonti, ~61 min`** (bibliography now aggregates all 4 subs).

## Pages where the count is 0
- `chapter-01-3-3.html` → 0 fonti (the page genuinely has no `Fonti esterne` block; preserved honestly).
- `chapter-02-2-4.html` → 0 fonti (same reason). Worth re-checking whether a bibliography should be added after the 10-parti rewrite.

## Scope
- 9 parent pages + 36 sub-pages = **45 files**, all diffs are exactly 6 meta/JSON-LD lines replaced + 6 added.
- `data.js`, `notes.json`, `index.html`, `index.js`, `App.js` and anything under `backup-2026-03-12/` are untouched.
- Generated by `scripts/update_chapter_meta.py` (untracked in this PR).

## Test plan
- [ ] Skim `book/chapter-01-mobilita.html` and `book/chapter-01-1-1.html` in a browser — descriptions render with correct entities.
- [ ] Paste the new `meta[name=description]` of a sample page into the Google Rich Results test and confirm it parses cleanly.
- [ ] Spot-check 2 parent pages to confirm the aggregated fonti/min matches the sum of their 4 subs (modulo shared citations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)