### PR TITLE
sync: add ff.149 to corpus TXT (RSS sync 2026-04-24)

### DIFF
--- a/futuro_fortissimo_full_data.txt
+++ b/futuro_fortissimo_full_data.txt
@@ -1,5 +1,141 @@
 [
     {
+        "url": "https://fortissimo.substack.com/p/ff149-come-essere-solari",
+        "title": "🎼 ff.149 Come essere solari",
+        "subtitle": "L'abbondanza è qui, basta mettere gli occhiali da sole",
+        "keypoints": [
+            "Se chiude lo stretto di Hormuz, vince il Mar del Nord (Norvegia)?",
+            "Indipendenza energetica, ma non dalla Cina?",
+            "Maximo: un robot che installa un pannello al minuto"
+        ],
+        "subchapters": [
+            {
+                "title": "3️⃣ ff.149.1 Dammi tre parole…",
+                "link": "https://fortissimo.substack.com/i/ff149-come-essere-solari/ff-dammi-tre-parole",
+                "content": "La prima uscita di futuro fortissimo sul clima, e sulle energie rinnovabili, era in un freddo marzo di quattro anni fa ( 🎼 ff.12 Sole, cuore e amore ). Freddo marzo, si intende, a Bergamo. Nel sud-ovest degli Stati Uniti, quest’anno, un’ondata di calore ha fatto segnare temperature come a metà giugno. Insomma, un sole (cuore e amore) che scalda il nostro pianeta e i nostri oceani sempre più, anche per la riduzione delle emissioni (dei solfiti, nella fattispecie 🕳️ ff.56.2 Siamo già geo-ingegneri ). Fermarsi a quello che “vediamo” oggi è miope (sì, dovrebbe far ridere): il futuro è una proiezione dell’oggi, non un’interpolazione del ieri. Con questa proverò a mettere in luce (solare) gli ultimi sviluppi che fanno sperare in un futuro diverso. Migliore. Ma prima…",
+                "images": [
+                    {
+                        "src": "https://substack-post-media.s3.amazonaws.com/public/images/2cfb99ce-775e-4f4a-962b-20b8dbcc5b97_873x454.png",
+                        "caption": ""
+                    }
+                ],
+                "references": [],
+                "connections": [
+                    {
+                        "text": "🎼 ff.12 Sole, cuore e amore",
+                        "url": "https://fortissimo.substack.com/p/-ff12-sole-cuore-e-amore"
+                    },
+                    {
+                        "text": "🕳️ ff.56.2 Siamo già geo-ingegneri",
+                        "url": "https://fortissimo.substack.com/i/105434036/ff562-siamo-gia-geo-ingegneri"
+                    }
+                ]
+            },
+            {
+                "title": "🧮 ff.149.2 Una questione di ore…",
+                "link": "https://fortissimo.substack.com/i/ff149-come-essere-solari/ff-una-questione-di-ore",
+                "content": "… una breve guida energetica, per mettere numeri ed etichette (d’altronde, 🎼 ff.32 I numeri non mentono ). Un’ora sola ti vorrei. Innanzitutto, ricordo l’unità di misura della potenza (W, spesso in GW) e energia prodotta/consumata (spesso TWh). La loro relazione: 1 GW che “produce” per un anno (8760 ore) = 8.76 TWh. E, quantificando l’energia: 1 GW = 450.000 famiglie italiane 510 GW (aggiunti nel 2025) = produzione elettrica India + Brasile 2.392 GW = solare totale = 10% elettricità mondiale Elettricità = 20% energia mondiale",
+                "images": [],
+                "references": [],
+                "connections": [
+                    {
+                        "text": "🎼 ff.32 I numeri non mentono",
+                        "url": "https://fortissimo.substack.com/p/-ff32-i-numeri-non-mentono"
+                    }
+                ]
+            },
+            {
+                "title": "🃏 ff.149.3 Texas hold 'em",
+                "link": "https://fortissimo.substack.com/i/ff149-come-essere-solari/ff-texas-hold-em",
+                "content": "Con questi “righelli” alla mano, misuriamo gli ultimi sviluppi. In Texas - da sempre simbolo del petrolio americano - il 2025, ha visto un aumentato del 40% della produzione solare, con un picco di 7 TWh per agosto (~1GW di energia prodotta, ovvero le famose 450.000 famiglie italiane). Sì, il sole non brilla di notte. 15GW anche dal vento allora. Tanto che a marzo 2026 le rinnovabili coprono il 70% dell’elettricità texana . PS. Come in molte tecnologie innovative (batterie, pannelli solari, eolico) la Cina fa da padrone: le top aziende cinesi hanno contribuito per un +125GW di eolico (~25GW fuori dalla Cina). Non solo solare: anche il vento non scherza (via futuro fortissimo) E - laddove il sole non manca, in Africa - si sta pure compiendo una rivoluzione “araba”: guidano Nigeria, Algeria, Congo e Mozambico (1.5-0.4 GW di pannelli solari importati dalla Cina).",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!tpLg!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F2bcf308a-8d65-48d1-94fd-3d43761651c7_2886x1843.jpeg",
+                        "caption": ""
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!3V34!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F00340294-6a11-492e-bd7a-d3692835f4d2_1152x1368.jpeg",
+                        "caption": "Non solo solare: anche il vento non scherza (via futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "a marzo 2026 le rinnovabili coprono il 70% dell’elettricità texana",
+                        "url": "https://x.com/SimonMahan/status/2034634362029817987"
+                    },
+                    {
+                        "text": "Non solo solare: anche il vento non scherza",
+                        "url": "https://www.semafor.com/newsletter/04/14/2026/semafor-energy-china-to-the-rescue?utm_source=newslettershare&amp;utm_medium=net+zero&amp;utm_campaign=flagshipnumbered2#d"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🤖 ff.149.4 Andare al Maximo",
+                "link": "https://fortissimo.substack.com/i/ff149-come-essere-solari/ff-andare-al-maximo",
+                "content": "Il motivo di queste accelerazioni? Ormai, produrre elettricità rinnovabile è tecnologicamente vantaggioso. Un collo di bottiglia è l’installazione. Ma anche qui ci soccorre un altro trend caro a futuro fortissimo: la robotica. Maximo (sviluppato da AES, azienda supportata da NVIDIA) ha appena completato l’installazione di 100 MW di pannelli solari in California (installando l’equivalente dello 0.5% della produzione del Texas in 7 mesi ). Maximo installa un pannello al minuto. Quindi, ogni mese, 2.500 famiglie italiane: 480 pannelli al giorno (60 min x 8h) x 20 giorni di lavoro = 9600 pannelli x produzione di un pannello = 500 W = 4.8 MW",
+                "images": [],
+                "references": [
+                    {
+                        "text": "100 MW di pannelli solari in California",
+                        "url": "https://electrek.co/2026/03/29/this-friendly-robot-just-installed-100-mw-of-solar-power/"
+                    },
+                    {
+                        "text": "dello 0.5% della produzione del Texas in 7 mesi",
+                        "url": "https://cleantechnica.com/2026/03/25/more-solar-power-2x-faster-with-maximo-robots/"
+                    }
+                ],
+                "connections": []
+            },
+            {
+                "title": "🗽 ff.149.5 Libertà (da gas e petrolio)",
+                "link": "https://fortissimo.substack.com/i/ff149-come-essere-solari/ff-liberta-da-gas-e-petrolio",
+                "content": "Il solare è anche un’opportunità per ridurre la dipendenza da gas (Russia) o petrolio (Iran). Una dipendenza che - ai tempi della guerra in Ucraina o della chiusura dello stretto di Hormuz - fa male a tanti Paesi, a parte ovviamente la Norvegia… Da Prof G Media Ad esempio, l’Egitto ha visto raddoppiare il costo dell’energia in due mesi e potrebbe salvarsi solo con l’eolico cinese . Ma la stessa Cina, per ridurre la dipendenza da import esterni, sta pensando di bloccare gli export del solare . Quindi, chi vincerà? Maximo o Trump? Ai posteri l’ardua sentenza. Il progetto Sun Day , per finanziare un pianeta supportato dal sole (via futuro fortissimo) ☕",
+                "images": [
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!FWe2!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F9e9d3162-27d5-480c-b67f-74bafba8c171_2501x2514.png",
+                        "caption": "Da Prof G Media"
+                    },
+                    {
+                        "src": "https://substackcdn.com/image/fetch/$s_!SdWX!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F70238a53-e130-4b02-9952-708d17bf2abe_309x234.png",
+                        "caption": "Il progetto Sun Day, per finanziare un pianeta supportato dal sole (via futuro fortissimo)"
+                    }
+                ],
+                "references": [
+                    {
+                        "text": "Da Prof G Media",
+                        "url": "https://www.profgmedia.com/p/how-the-iran-war-is-reordering-global?utm_source=substack&amp;publication_id=7157411&amp;post_id=191066432&amp;utm_medium=email&amp;utm_content=share&amp;utm_campaign=email-share&amp;triggerShare=true&amp;isFreemail=true&amp;r=bruig&amp;triedRedirect=true"
+                    },
+                    {
+                        "text": "l’Egitto ha visto raddoppiare il costo dell’energia in due mesi e potrebbe salvarsi solo con l’eolico cinese",
+                        "url": "https://www.semafor.com/article/04/14/2026/the-iran-war-sent-energy-prices-soaring-china-is-stepping-in?utm_medium=net+zero&amp;utm_campaign=flagshipnumbered2&amp;utm_source=newslettercta"
+                    },
+                    {
+                        "text": "Cina, per ridurre la dipendenza da import esterni, sta pensando di bloccare gli export del solare",
+                        "url": "https://www.reuters.com/legal/litigation/china-weighs-curbs-exports-solar-manufacturing-equipment-us-2026-04-15/?utm_source=semafor"
+                    },
+                    {
+                        "text": "Il progetto Sun Day",
+                        "url": "https://www.sunday.earth/"
+                    },
+                    {
+                        "text": "supporta con un caffè",
+                        "url": "https://www.paypal.com/paypalme/MicheleMerelli"
+                    },
+                    {
+                        "text": "futuro fortissimo",
+                        "url": "https://futurofortissimo.github.io/"
+                    },
+                    {
+                        "text": "michele merelli",
+                        "url": "https://www.linkedin.com/in/michelemerelli/"
+                    }
+                ],
+                "connections": []
+            }
+        ]
+    },
+    {
         "url": "https://fortissimo.substack.com/p/ff148-il-mito-dellai",
         "title": "🎼 ff.148 Il \"Mito\" dell'AI",
         "subtitle": "Claude Mythos, autografi e world models",


### PR DESCRIPTION
## Summary
- Corpus TXT was stale at ff.148 while `data.js` already had ff.149 (commit 201498f). This PR prepends the ff.149 entry to `futuro_fortissimo_full_data.txt` so corpus and data.js match.
- 156 → 157 entries. No other content touched.
- Part of the every-10-days RSS sync loop (next due 2026-04-24).

## Test plan
- [ ] diff is additive only (confirmed locally: `1 file changed, 137 insertions(+), 1 deletion(-)`)
- [ ] corpus `[0].url` now points to `ff149-come-essere-solari`