### PR TITLE
PR 5/10: substack-editorial style migration

### DIFF
--- a/book/chapter-01-1-1.html
+++ b/book/chapter-01-1-1.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="natura" data-chapter="01-1-1">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-01-1-2.html
+++ b/book/chapter-01-1-2.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="natura" data-chapter="01-1-2">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-01-1-3.html
+++ b/book/chapter-01-1-3.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="natura" data-chapter="01-1-3">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-01-1-4.html
+++ b/book/chapter-01-1-4.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="natura" data-chapter="01-1-4">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-01-2-1.html
+++ b/book/chapter-01-2-1.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="natura" data-chapter="01-2-1">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-01-2-2.html
+++ b/book/chapter-01-2-2.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="natura" data-chapter="01-2-2">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-01-2-3.html
+++ b/book/chapter-01-2-3.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="natura" data-chapter="01-2-3">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-01-2-4.html
+++ b/book/chapter-01-2-4.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="natura" data-chapter="01-2-4">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-01-3-1.html
+++ b/book/chapter-01-3-1.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="natura" data-chapter="01-3-1">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-01-3-2.html
+++ b/book/chapter-01-3-2.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="natura" data-chapter="01-3-2">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-01-3-3.html
+++ b/book/chapter-01-3-3.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="natura" data-chapter="01-3-3">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-01-3-4.html
+++ b/book/chapter-01-3-4.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="natura" data-chapter="01-3-4">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-01-ambiente.html
+++ b/book/chapter-01-ambiente.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="natura" data-chapter="ambiente">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-01-cibo.html
+++ b/book/chapter-01-cibo.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="natura" data-chapter="cibo">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-01-mobilita.html
+++ b/book/chapter-01-mobilita.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="natura" data-chapter="mobilita">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-01.html
+++ b/book/chapter-01.html
@@ -98,8 +98,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="natura" data-chapter="01">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-02-1-1.html
+++ b/book/chapter-02-1-1.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="tech" data-chapter="02-1-1">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-02-1-2.html
+++ b/book/chapter-02-1-2.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="tech" data-chapter="02-1-2">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-02-1-3.html
+++ b/book/chapter-02-1-3.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="tech" data-chapter="02-1-3">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-02-1-4.html
+++ b/book/chapter-02-1-4.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="tech" data-chapter="02-1-4">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-02-2-1.html
+++ b/book/chapter-02-2-1.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="tech" data-chapter="02-2-1">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-02-2-2.html
+++ b/book/chapter-02-2-2.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="tech" data-chapter="02-2-2">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-02-2-3.html
+++ b/book/chapter-02-2-3.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="tech" data-chapter="02-2-3">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-02-2-4.html
+++ b/book/chapter-02-2-4.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="tech" data-chapter="02-2-4">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-02-3-1.html
+++ b/book/chapter-02-3-1.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="tech" data-chapter="02-3-1">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-02-3-2.html
+++ b/book/chapter-02-3-2.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="tech" data-chapter="02-3-2">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-02-3-3.html
+++ b/book/chapter-02-3-3.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="tech" data-chapter="02-3-3">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-02-3-4.html
+++ b/book/chapter-02-3-4.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="tech" data-chapter="02-3-4">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-02-metaverso.html
+++ b/book/chapter-02-metaverso.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="tech" data-chapter="metaverso">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-02-prodotti.html
+++ b/book/chapter-02-prodotti.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="tech" data-chapter="prodotti">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-02-robotica.html
+++ b/book/chapter-02-robotica.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="tech" data-chapter="robotica">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-02.html
+++ b/book/chapter-02.html
@@ -97,8 +97,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="tech" data-chapter="02">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-03-1-1.html
+++ b/book/chapter-03-1-1.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="corpo" data-chapter="03-1-1">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-03-1-2.html
+++ b/book/chapter-03-1-2.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="corpo" data-chapter="03-1-2">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-03-1-3.html
+++ b/book/chapter-03-1-3.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="corpo" data-chapter="03-1-3">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-03-1-4.html
+++ b/book/chapter-03-1-4.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="corpo" data-chapter="03-1-4">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-03-2-1.html
+++ b/book/chapter-03-2-1.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="corpo" data-chapter="03-2-1">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-03-2-2.html
+++ b/book/chapter-03-2-2.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="corpo" data-chapter="03-2-2">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-03-2-3.html
+++ b/book/chapter-03-2-3.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="corpo" data-chapter="03-2-3">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-03-2-4.html
+++ b/book/chapter-03-2-4.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="corpo" data-chapter="03-2-4">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-03-3-1.html
+++ b/book/chapter-03-3-1.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="corpo" data-chapter="03-3-1">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-03-3-2.html
+++ b/book/chapter-03-3-2.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="corpo" data-chapter="03-3-2">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-03-3-3.html
+++ b/book/chapter-03-3-3.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="corpo" data-chapter="03-3-3">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-03-3-4.html
+++ b/book/chapter-03-3-4.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="corpo" data-chapter="03-3-4">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-03-alimentazione.html
+++ b/book/chapter-03-alimentazione.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="corpo" data-chapter="alimentazione">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-03-cultura.html
+++ b/book/chapter-03-cultura.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="corpo" data-chapter="cultura">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-03-psicologia.html
+++ b/book/chapter-03-psicologia.html
@@ -123,8 +123,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="corpo" data-chapter="psicologia">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/chapter-03.html
+++ b/book/chapter-03.html
@@ -97,8 +97,9 @@ li[id^="fonte-"]:target{
 .ff-corpus-img img{ max-width: 100%; }
 .ff-svg-figure svg{ width:100%; height:auto; display:block; }
 </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased">
+<body class="antialiased editorial" data-macro="corpo" data-chapter="03">
 
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:#0a0a0a;color:#fff;">
     <div class="max-w-4xl mx-auto flex items-center justify-end gap-1 px-4 py-1">

--- a/book/ffxy-index.html
+++ b/book/ffxy-index.html
@@ -288,8 +288,9 @@
       display: inline-block;
     }
   </style>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body>
+<body class="editorial" data-macro="index" data-chapter="ffxy-index">
   <div class="container">
     <a href="/book/" class="back-link">&larr; Indice del libro</a>
     <h1>Indice ff.x.y</h1>

--- a/book/index.html
+++ b/book/index.html
@@ -469,8 +469,9 @@
   ]
 }
 </script>
+    <link rel="stylesheet" href="styles/editorial.css">
 </head>
-<body class="antialiased selection:bg-gray-900 selection:text-white no-round">
+<body class="antialiased selection:bg-gray-900 selection:text-white no-round editorial" data-macro="index" data-chapter="index">
 
   <!-- Language switcher bar -->
   <nav aria-label="Language" style="font-family:'IBM Plex Mono',monospace;font-size:0.6875rem;letter-spacing:0.16em;text-transform:uppercase;font-weight:700;background:var(--ff-black);color:#fff;">

--- a/book/styles/editorial.css
+++ b/book/styles/editorial.css
@@ -1,0 +1,421 @@
+/* =====================================================================
+ * FF Book — Substack Editorial Style (PR 5/10)
+ * ---------------------------------------------------------------------
+ * Strategy: class-level migration, activated via `body.editorial`.
+ * Legacy classes (.brutal-card, .keypoints, .fc, .note-highlight,
+ * .pull-quote, .citation) are re-styled in-place — no markup rewrite.
+ *
+ * Fonts: Lora (serif body), Inter (UI/headings), IBM Plex Mono (eyebrow).
+ * Palette base: crema #fbfaf7. Accent preserved per chapter.
+ * ===================================================================== */
+
+/* ---- Google Fonts (additive: Lora is new; Inter + Plex Mono already
+       loaded in chapter pages — duplicate @import is idempotent) ---- */
+@import url('https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600;700&display=swap');
+
+/* =====================================================================
+ * Root tokens (editorial-only, scoped under body.editorial)
+ * ===================================================================== */
+body.editorial{
+  /* Editorial palette */
+  --ed-bg:           #fbfaf7;   /* crema base */
+  --ed-bg-elev:      #ffffff;   /* card / pullquote background */
+  --ed-ink:          #1a1a1a;   /* testo principale */
+  --ed-ink-soft:     #434343;   /* testo secondario */
+  --ed-ink-mute:     #6b6b6b;   /* meta / caption */
+  --ed-rule:         #e5e1d8;   /* separatori sobri */
+  --ed-rule-strong:  #cfc9bb;
+
+  /* Accent — default verde (cap.1). Cap 2/3 override sotto. */
+  --ed-accent:       var(--accent, #2ecc71);
+  --ed-accent-soft:  color-mix(in srgb, var(--ed-accent) 22%, transparent);
+  --ed-accent-hair:  color-mix(in srgb, var(--ed-accent) 55%, transparent);
+
+  /* Typography */
+  --ed-serif:   'Lora', 'Georgia', 'Times New Roman', serif;
+  --ed-sans:    'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --ed-mono:    'IBM Plex Mono', 'SFMono-Regular', Consolas, monospace;
+}
+
+/* Per-chapter accent mapping (applicato a body.editorial)
+   Cap 1 — Natura:  verde
+   Cap 2 — Tech:    blu
+   Cap 3 — Corpo/Mente: rosso
+   Tutti i sub-capitoli ereditano via --accent già settato nelle pagine. */
+body.editorial[data-macro="natura"]   { --ed-accent: #2ecc71; }
+body.editorial[data-macro="tech"]     { --ed-accent: #4a90e2; }
+body.editorial[data-macro="corpo"]    { --ed-accent: #d0021b; }
+body.editorial[data-macro="index"]    { --ed-accent: #0a0a0a; }
+
+/* =====================================================================
+ * Base body / typography
+ * ===================================================================== */
+body.editorial{
+  background: var(--ed-bg) !important;
+  color: var(--ed-ink);
+  font-family: var(--ed-serif);
+  font-size: 1.05rem;
+  line-height: 1.72;
+  font-feature-settings: "kern" 1, "liga" 1, "onum" 1;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Neutralizza il grid background brutalista */
+body.editorial::before{
+  display: none !important;
+}
+
+/* Headings — Inter per heading, ma garanzia leggibilità */
+body.editorial h1,
+body.editorial h2,
+body.editorial h3,
+body.editorial h4{
+  font-family: var(--ed-sans);
+  letter-spacing: -0.01em;
+  color: var(--ed-ink);
+  font-weight: 700;
+  line-height: 1.25;
+}
+body.editorial h1{ font-size: clamp(1.9rem, 4.5vw, 2.6rem); }
+body.editorial h2{ font-size: clamp(1.45rem, 3.2vw, 1.8rem); margin-top: 1.6em; }
+body.editorial h3{ font-size: clamp(1.15rem, 2.6vw, 1.3rem); margin-top: 1.3em; }
+
+/* Prose */
+body.editorial .prose p,
+body.editorial .prose-lg p,
+body.editorial main p{
+  font-family: var(--ed-serif);
+  font-size: 1.05rem;
+  line-height: 1.72;
+  color: var(--ed-ink);
+  max-width: 68ch;
+  text-align: left;
+  margin-bottom: 1.15em;
+  /* Disabilita il justify brutalista su editoriale */
+  text-justify: auto;
+  hyphens: none;
+  -webkit-hyphens: none;
+}
+
+/* Drop-cap editoriale (se presente) */
+body.editorial .drop-cap::first-letter{
+  font-family: var(--ed-serif);
+  font-weight: 700;
+  color: var(--ed-ink);
+  font-size: clamp(3.2em, 6vw, 4em);
+  line-height: 0.85;
+  padding-right: 0.08em;
+  padding-top: 0.05em;
+  float: left;
+}
+
+/* =====================================================================
+ * Eyebrow — IBM Plex Mono uppercase
+ * ===================================================================== */
+body.editorial .ff-eyebrow,
+body.editorial .reading-time,
+body.editorial .chapter-num,
+body.editorial .eyebrow{
+  font-family: var(--ed-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--ed-ink-mute);
+}
+body.editorial .ff-eyebrow{
+  color: var(--ed-accent);
+}
+
+/* =====================================================================
+ * Brutal-card → editorial card
+ * Legacy class kept for MC gate compat; visually re-styled.
+ * ===================================================================== */
+body.editorial .brutal-card{
+  border: 1px solid var(--ed-rule) !important;
+  background: var(--ed-bg-elev) !important;
+  box-shadow: none !important;
+  border-radius: 4px;
+  padding: clamp(18px, 4vw, 28px);
+  position: relative;
+}
+/* Accent-bar editoriale: hair-line sul top */
+body.editorial .accent-bar::before{
+  height: 3px !important;
+  top: 0 !important;
+  left: 0 !important;
+  right: 0 !important;
+  background: var(--ed-accent) !important;
+  opacity: 0.85;
+}
+@media (max-width: 640px){
+  body.editorial .brutal-card{
+    border-width: 1px;
+    box-shadow: none;
+  }
+}
+
+/* Keypoints — eyebrow list editoriale */
+body.editorial .keypoints{
+  border-top: 1px solid var(--ed-rule);
+  border-bottom: 1px solid var(--ed-rule);
+  padding: 1em 0;
+  margin: 1.8em 0;
+  list-style: none;
+}
+body.editorial .keypoints li{
+  font-family: var(--ed-sans);
+  font-size: 0.95rem;
+  line-height: 1.55;
+  color: var(--ed-ink-soft);
+  padding: 0.35em 0 0.35em 1.2em;
+  position: relative;
+}
+body.editorial .keypoints li::before{
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.85em;
+  width: 0.65em;
+  height: 1px;
+  background: var(--ed-accent);
+}
+
+/* =====================================================================
+ * Rule between cards — border-top, not dark container
+ * ===================================================================== */
+body.editorial .sep,
+body.editorial hr{
+  height: 1px !important;
+  background: var(--ed-rule) !important;
+  border: 0;
+  margin: 2.4em 0 !important;
+}
+/* Sep con accent hair-line */
+body.editorial .sep{
+  background: linear-gradient(90deg, var(--ed-accent-hair), transparent 40%) !important;
+}
+
+/* =====================================================================
+ * Highlight — underline pastello soft (NO solid block)
+ * ===================================================================== */
+body.editorial mark.note-highlight,
+body.editorial .note-highlight{
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    transparent 70%,
+    var(--ed-accent-soft) 70%,
+    var(--ed-accent-soft) 92%,
+    transparent 92%
+  ) !important;
+  color: inherit !important;
+  padding: 0 1px;
+  font-style: normal;
+  border-radius: 0;
+}
+
+/* =====================================================================
+ * Cross-reference chip .fc — editorial chip-sottile
+ * ===================================================================== */
+body.editorial .prose .fc,
+body.editorial .fc{
+  font-family: var(--ed-sans);
+  font-size: 0.92em;
+  font-weight: 600;
+  color: var(--ed-accent);
+  text-decoration: none;
+  padding: 0.05em 0.4em;
+  border: 1px solid var(--ed-accent-hair);
+  border-radius: 3px;
+  background: transparent;
+  transition: background 0.15s, color 0.15s;
+  white-space: nowrap;
+  cursor: pointer;
+}
+body.editorial .fc:hover,
+body.editorial .fc:focus{
+  background: var(--ed-accent-soft);
+  text-decoration: none;
+  color: var(--ed-ink);
+}
+
+/* =====================================================================
+ * Links in prose — underline sobrio, accent color
+ * ===================================================================== */
+body.editorial .prose a,
+body.editorial main p a,
+body.editorial article a{
+  color: var(--ed-ink);
+  text-decoration: underline;
+  text-decoration-color: var(--ed-accent-hair);
+  text-decoration-thickness: 1.5px;
+  text-underline-offset: 3px;
+  transition: text-decoration-color 0.15s, color 0.15s;
+}
+body.editorial .prose a:hover,
+body.editorial main p a:hover,
+body.editorial article a:hover{
+  color: var(--ed-accent);
+  text-decoration-color: var(--ed-accent);
+}
+
+/* =====================================================================
+ * Pullquote — editoriale leggera, no heavy quote marks
+ * ===================================================================== */
+body.editorial .pull-quote,
+body.editorial blockquote.pullquote{
+  border: none !important;
+  background: transparent !important;
+  padding: 1.8em 1em !important;
+  margin: 2.4em auto !important;
+  max-width: 56ch;
+  text-align: left;
+  font-family: var(--ed-serif) !important;
+  font-size: clamp(1.18rem, 2.6vw, 1.38rem) !important;
+  font-weight: 500;
+  font-style: italic !important;
+  line-height: 1.45;
+  color: var(--ed-ink) !important;
+  border-left: 3px solid var(--ed-accent) !important;
+  padding-left: 1.4em !important;
+  letter-spacing: 0;
+}
+body.editorial .pull-quote::before,
+body.editorial .pull-quote::after{
+  display: none !important;   /* niente quote marks pesanti */
+  content: none !important;
+}
+
+/* Blockquote generico — editoriale, niente sfondo colorato */
+body.editorial blockquote:not(.pullquote):not(.pull-quote){
+  border-left: 3px solid var(--ed-rule-strong) !important;
+  padding: 0.2em 1.2em !important;
+  margin: 1.6em 0 !important;
+  background: transparent !important;
+  font-style: italic;
+  color: var(--ed-ink-soft);
+}
+
+/* =====================================================================
+ * Figures — bordi sottili con accent chapter-scoped
+ * ===================================================================== */
+body.editorial figure{
+  margin: 2.2em 0;
+}
+body.editorial figure img,
+body.editorial figure svg{
+  width: 100%;
+  height: auto;
+  border: 1px solid var(--ed-rule) !important;
+  border-top: 3px solid var(--ed-accent) !important;
+  box-shadow: none !important;
+  border-radius: 2px;
+  background: var(--ed-bg-elev);
+}
+body.editorial figcaption{
+  font-family: var(--ed-mono) !important;
+  font-size: 0.72rem !important;
+  color: var(--ed-ink-mute) !important;
+  letter-spacing: 0.06em !important;
+  margin-top: 0.6em !important;
+  line-height: 1.5;
+  text-transform: none;
+}
+
+/* =====================================================================
+ * Bibliografia — .fonti-esterne editoriale (complementa PR #425 :target)
+ * ===================================================================== */
+body.editorial .fonti-esterne,
+body.editorial .bibliography,
+body.editorial section[aria-label*="Fonti"]{
+  font-family: var(--ed-sans);
+  font-size: 0.92rem;
+  line-height: 1.55;
+  color: var(--ed-ink-soft);
+  border-top: 1px solid var(--ed-rule);
+  padding-top: 1.4em;
+  margin-top: 2.4em;
+}
+body.editorial .fonti-esterne h2,
+body.editorial .fonti-esterne h3{
+  font-family: var(--ed-mono);
+  font-size: 0.8rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--ed-ink-mute);
+  margin-bottom: 0.8em;
+}
+body.editorial .fonti-esterne ol,
+body.editorial .fonti-esterne ul{
+  padding-left: 1.4em;
+}
+body.editorial .fonti-esterne li{
+  margin-bottom: 0.5em;
+}
+body.editorial .fonti-esterne a{
+  color: var(--ed-accent);
+  text-decoration: underline;
+  text-decoration-color: var(--ed-accent-hair);
+}
+/* NON sovrascrivere PR #425 :target highlight (usa !important dove serve) */
+body.editorial li[id^="fonte-"]:target{
+  /* Lascia ereditare da PR #425; rinforza solo il border-radius editoriale */
+  border-radius: 4px;
+}
+
+/* =====================================================================
+ * Defensive: nascondi eventuali div.citation residui (banned style)
+ * ===================================================================== */
+body.editorial .citation,
+body.editorial div.citation{
+  background: transparent !important;
+  border: none !important;
+  border-left: 3px solid var(--ed-rule-strong) !important;
+  padding: 0.2em 1em !important;
+  color: var(--ed-ink-soft) !important;
+  font-style: italic;
+  box-shadow: none !important;
+}
+
+/* =====================================================================
+ * TOC / Navigation — sobrio
+ * ===================================================================== */
+body.editorial .toc-link{
+  border-left: 2px solid transparent;
+  transition: all 0.18s;
+  font-family: var(--ed-sans);
+}
+body.editorial .toc-link:hover,
+body.editorial .toc-link:focus{
+  border-left-color: var(--ed-accent);
+  padding-left: 10px;
+  color: var(--ed-accent);
+}
+
+/* =====================================================================
+ * Index / front page — preserva "Ultime aggiunte" toggle UX
+ * ===================================================================== */
+body.editorial.index-page .recent-additions,
+body.editorial [data-ultime-aggiunte]{
+  border: 1px solid var(--ed-rule);
+  background: var(--ed-bg-elev);
+  border-radius: 4px;
+}
+
+/* =====================================================================
+ * Print
+ * ===================================================================== */
+@media print{
+  body.editorial{
+    background: #fff !important;
+    color: #000;
+  }
+  body.editorial .brutal-card{
+    border: 1px solid #999 !important;
+    box-shadow: none !important;
+  }
+}
+
+/* Reduced motion: già gestito dalle pagine */

--- a/generated/style_migration_preview_2026-04-24.html
+++ b/generated/style_migration_preview_2026-04-24.html
@@ -1,0 +1,137 @@
+<!doctype html>
+<html lang="it">
+<head>
+<meta charset="utf-8">
+<title>PR 5/10 — Substack Editorial Style Migration Preview (2026-04-24)</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="stylesheet" href="../book/styles/editorial.css">
+<style>
+  body{background:#fbfaf7;color:#1a1a1a;font-family:'Lora',Georgia,serif;margin:0;padding:2em;max-width:1200px;margin:0 auto}
+  header{border-bottom:1px solid #e5e1d8;padding-bottom:1em;margin-bottom:2em}
+  h1{font-family:'Inter',sans-serif;font-weight:700;letter-spacing:-0.01em;margin:0 0 .4em 0}
+  .eyebrow{font-family:'IBM Plex Mono',monospace;font-size:.72rem;letter-spacing:.18em;text-transform:uppercase;color:#6b6b6b;margin-bottom:.4em}
+  .meta{color:#6b6b6b;font-size:.9rem;font-family:'Inter',sans-serif}
+  .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:1.2em;margin-top:1.5em}
+  .card{border:1px solid #e5e1d8;border-radius:4px;padding:1em 1.2em;background:#fff;transition:border-color .15s}
+  .card:hover{border-color:#cfc9bb}
+  .card a{color:#1a1a1a;text-decoration:none;display:block}
+  .card .chip{display:inline-block;font-family:'IBM Plex Mono',monospace;font-size:.68rem;letter-spacing:.12em;text-transform:uppercase;padding:.12em .5em;border-radius:3px;margin-bottom:.4em;font-weight:600}
+  .chip.natura{background:#e7f8ee;color:#156a38}
+  .chip.tech{background:#e6eff9;color:#1e3f67}
+  .chip.corpo{background:#fbe6e8;color:#7f0a16}
+  .chip.index{background:#eee;color:#333}
+  .card .title{font-family:'Inter',sans-serif;font-weight:600;font-size:.98rem;line-height:1.35;color:#1a1a1a}
+  section{margin-top:2.5em}
+  section h2{font-family:'Inter',sans-serif;font-size:1.2rem;border-top:1px solid #e5e1d8;padding-top:1.2em;margin-top:2em}
+  .legend{display:flex;gap:1em;flex-wrap:wrap;margin-top:.8em}
+  .legend .chip{font-family:'IBM Plex Mono',monospace;font-size:.7rem;padding:.2em .6em;border-radius:3px}
+  .demo{border:1px solid #e5e1d8;border-radius:4px;background:#fff;padding:1.5em;margin-top:1.5em}
+  .demo p{max-width:68ch;font-size:1.05rem;line-height:1.72}
+  mark.note-highlight{background:linear-gradient(180deg,transparent 0%,transparent 70%,rgba(46,204,113,.22) 70%,rgba(46,204,113,.22) 92%,transparent 92%);padding:0 1px}
+  .fc{font-family:'Inter',sans-serif;font-size:.92em;font-weight:600;color:#2ecc71;text-decoration:none;padding:.05em .4em;border:1px solid rgba(46,204,113,.55);border-radius:3px}
+  blockquote.pullquote{border:none;border-left:3px solid #2ecc71;padding:0;padding-left:1.4em;margin:1.6em 0;font-style:italic;font-family:'Lora',serif;font-size:1.25rem;color:#1a1a1a}
+</style>
+</head>
+<body>
+<header>
+  <div class="eyebrow">PR 5/10 — 2026-04-24</div>
+  <h1>Substack-Editorial Style Migration</h1>
+  <div class="meta">Migrazione classe-level su 48 capitoli + 2 index. Lora serif + Inter + IBM Plex Mono, palette crema #fbfaf7, accenti per macro-tema preservati.</div>
+  <div class="legend">
+    <span class="chip natura">Cap 1 — Natura (verde #2ecc71)</span>
+    <span class="chip tech">Cap 2 — Tech (blu #4a90e2)</span>
+    <span class="chip corpo">Cap 3 — Corpo/Mente (rosso #d0021b)</span>
+  </div>
+</header>
+
+<section>
+  <h2>Demo tipografica (in-page, stile editoriale)</h2>
+  <div class="demo">
+    <div class="eyebrow">ff.27.3 — anteprima stile</div>
+    <p>Una pagina editoriale non urla: respira. La prosa in <strong>Lora</strong> serif a 1.05rem con line-height 1.72 recupera la leggibilità di un pezzo lungo, mentre <mark class="note-highlight">il tratto evidenziato</mark> resta un gesto sobrio — un sottile wash pastello, non un blocco solido. Le cross-reference <a class="fc" href="#">ff.27.2</a> diventano chip leggeri, bordati dall'accent del capitolo, con hover che accende il wash ma non trasforma il ritmo visivo. I link inline mantengono l'<a href="#">underline sobrio</a> in colore accent, senza pesantezze barocche.</p>
+    <blockquote class="pullquote">Il pullquote editoriale: leggero, corsivo, senza virgolette enormi. Una pausa, non uno stop.</blockquote>
+    <p>Le card — ex <em>brutal-card</em> — conservano il nome classe per compatibilità gate MC, ma visivamente diventano contenitori a hair-line 1px con border-top accent da 3px: rule-line, non muro. La bibliografia <em>.fonti-esterne</em> rimane distinta, il <code>:target</code> highlight di PR #425 non viene sovrascritto.</p>
+  </div>
+</section>
+
+<section>
+  <h2>Navigazione capitoli migrati (50 pagine)</h2>
+  <div class="grid">
+    <div class="card"><a href="../book/chapter-01-1-1.html" target="_blank"><span class="chip natura">Natura · chapter-01-1-1</span><div class="title">1.1 — Mobilità e Città | 🌿 Natura</div></a></div>
+    <div class="card"><a href="../book/chapter-01-1-2.html" target="_blank"><span class="chip natura">Natura · chapter-01-1-2</span><div class="title">1.1 — Mobilità e Città | 🌿 Natura</div></a></div>
+    <div class="card"><a href="../book/chapter-01-1-3.html" target="_blank"><span class="chip natura">Natura · chapter-01-1-3</span><div class="title">1.1 — Mobilità e Città | 🌿 Natura</div></a></div>
+    <div class="card"><a href="../book/chapter-01-1-4.html" target="_blank"><span class="chip natura">Natura · chapter-01-1-4</span><div class="title">1.1 — Mobilità e Città | 🌿 Natura</div></a></div>
+    <div class="card"><a href="../book/chapter-01-2-1.html" target="_blank"><span class="chip natura">Natura · chapter-01-2-1</span><div class="title">1.2 — Ambiente ed Energia | 🌿 Natura</div></a></div>
+    <div class="card"><a href="../book/chapter-01-2-2.html" target="_blank"><span class="chip natura">Natura · chapter-01-2-2</span><div class="title">1.2 — Ambiente ed Energia | 🌿 Natura</div></a></div>
+    <div class="card"><a href="../book/chapter-01-2-3.html" target="_blank"><span class="chip natura">Natura · chapter-01-2-3</span><div class="title">1.2 — Ambiente ed Energia | 🌿 Natura</div></a></div>
+    <div class="card"><a href="../book/chapter-01-2-4.html" target="_blank"><span class="chip natura">Natura · chapter-01-2-4</span><div class="title">1.2 — Ambiente ed Energia | 🌿 Natura</div></a></div>
+    <div class="card"><a href="../book/chapter-01-3-1.html" target="_blank"><span class="chip natura">Natura · chapter-01-3-1</span><div class="title">1.3 — Cibo e Fashion | 🌿 Natura</div></a></div>
+    <div class="card"><a href="../book/chapter-01-3-2.html" target="_blank"><span class="chip natura">Natura · chapter-01-3-2</span><div class="title">1.3 — Cibo e Fashion | 🌿 Natura</div></a></div>
+    <div class="card"><a href="../book/chapter-01-3-3.html" target="_blank"><span class="chip natura">Natura · chapter-01-3-3</span><div class="title">1.3 — Cibo e Fashion | 🌿 Natura</div></a></div>
+    <div class="card"><a href="../book/chapter-01-3-4.html" target="_blank"><span class="chip natura">Natura · chapter-01-3-4</span><div class="title">1.3 — Cibo e Fashion | 🌿 Natura</div></a></div>
+    <div class="card"><a href="../book/chapter-01-ambiente.html" target="_blank"><span class="chip natura">Natura · chapter-01-ambiente</span><div class="title">1.2 — Ambiente ed Energia | 🌿 Natura</div></a></div>
+    <div class="card"><a href="../book/chapter-01-cibo.html" target="_blank"><span class="chip natura">Natura · chapter-01-cibo</span><div class="title">1.3 — Cibo e Fashion | 🌿 Natura</div></a></div>
+    <div class="card"><a href="../book/chapter-01-mobilita.html" target="_blank"><span class="chip natura">Natura · chapter-01-mobilita</span><div class="title">1.1 — Mobilità e Città | 🌿 Natura</div></a></div>
+    <div class="card"><a href="../book/chapter-01.html" target="_blank"><span class="chip natura">Natura · chapter-01</span><div class="title">Natura: mobilità, energia, cibo — Cap. 1</div></a></div>
+    <div class="card"><a href="../book/chapter-02-1-1.html" target="_blank"><span class="chip tech">Tech · chapter-02-1-1</span><div class="title">2.1 — Robotica e AI | 💻 Tecnologia</div></a></div>
+    <div class="card"><a href="../book/chapter-02-1-2.html" target="_blank"><span class="chip tech">Tech · chapter-02-1-2</span><div class="title">2.1 — Robotica e AI | 💻 Tecnologia</div></a></div>
+    <div class="card"><a href="../book/chapter-02-1-3.html" target="_blank"><span class="chip tech">Tech · chapter-02-1-3</span><div class="title">2.1 — Robotica e AI | 💻 Tecnologia</div></a></div>
+    <div class="card"><a href="../book/chapter-02-1-4.html" target="_blank"><span class="chip tech">Tech · chapter-02-1-4</span><div class="title">2.1 — Robotica e AI | 💻 Tecnologia</div></a></div>
+    <div class="card"><a href="../book/chapter-02-2-1.html" target="_blank"><span class="chip tech">Tech · chapter-02-2-1</span><div class="title">2.2 — Metaverso e Criptovalute | 💻 Tecnologia</div></a></div>
+    <div class="card"><a href="../book/chapter-02-2-2.html" target="_blank"><span class="chip tech">Tech · chapter-02-2-2</span><div class="title">2.2 — Metaverso e Criptovalute | 💻 Tecnologia</div></a></div>
+    <div class="card"><a href="../book/chapter-02-2-3.html" target="_blank"><span class="chip tech">Tech · chapter-02-2-3</span><div class="title">2.2 — Metaverso e Criptovalute | 💻 Tecnologia</div></a></div>
+    <div class="card"><a href="../book/chapter-02-2-4.html" target="_blank"><span class="chip tech">Tech · chapter-02-2-4</span><div class="title">2.2 — Metaverso e Criptovalute | 💻 Tecnologia</div></a></div>
+    <div class="card"><a href="../book/chapter-02-3-1.html" target="_blank"><span class="chip tech">Tech · chapter-02-3-1</span><div class="title">2.3 — Prodotti di consumo | 💻 Tecnologia</div></a></div>
+    <div class="card"><a href="../book/chapter-02-3-2.html" target="_blank"><span class="chip tech">Tech · chapter-02-3-2</span><div class="title">2.3 — Prodotti di consumo | 💻 Tecnologia</div></a></div>
+    <div class="card"><a href="../book/chapter-02-3-3.html" target="_blank"><span class="chip tech">Tech · chapter-02-3-3</span><div class="title">2.3 — Prodotti di consumo | 💻 Tecnologia</div></a></div>
+    <div class="card"><a href="../book/chapter-02-3-4.html" target="_blank"><span class="chip tech">Tech · chapter-02-3-4</span><div class="title">2.3 — Prodotti di consumo | 💻 Tecnologia</div></a></div>
+    <div class="card"><a href="../book/chapter-02-metaverso.html" target="_blank"><span class="chip tech">Tech · chapter-02-metaverso</span><div class="title">2.2 — Metaverso e Criptovalute | 💻 Tecnologia</div></a></div>
+    <div class="card"><a href="../book/chapter-02-prodotti.html" target="_blank"><span class="chip tech">Tech · chapter-02-prodotti</span><div class="title">2.3 — Prodotti di consumo | 💻 Tecnologia</div></a></div>
+    <div class="card"><a href="../book/chapter-02-robotica.html" target="_blank"><span class="chip tech">Tech · chapter-02-robotica</span><div class="title">2.1 — Robotica e AI | 💻 Tecnologia</div></a></div>
+    <div class="card"><a href="../book/chapter-02.html" target="_blank"><span class="chip tech">Tech · chapter-02</span><div class="title">Tecnologia: AI, robot, metaverso — Cap. 2</div></a></div>
+    <div class="card"><a href="../book/chapter-03-1-1.html" target="_blank"><span class="chip corpo">Corpo/Mente · chapter-03-1-1</span><div class="title">3.1 — Psicologia e Wellbeing | ❤️ Società</div></a></div>
+    <div class="card"><a href="../book/chapter-03-1-2.html" target="_blank"><span class="chip corpo">Corpo/Mente · chapter-03-1-2</span><div class="title">3.1 — Psicologia e Wellbeing | ❤️ Società</div></a></div>
+    <div class="card"><a href="../book/chapter-03-1-3.html" target="_blank"><span class="chip corpo">Corpo/Mente · chapter-03-1-3</span><div class="title">3.1 — Psicologia e Wellbeing | ❤️ Società</div></a></div>
+    <div class="card"><a href="../book/chapter-03-1-4.html" target="_blank"><span class="chip corpo">Corpo/Mente · chapter-03-1-4</span><div class="title">3.1 — Psicologia e Wellbeing | ❤️ Società</div></a></div>
+    <div class="card"><a href="../book/chapter-03-2-1.html" target="_blank"><span class="chip corpo">Corpo/Mente · chapter-03-2-1</span><div class="title">3.2 — Alimentazione e Sport | ❤️ Società</div></a></div>
+    <div class="card"><a href="../book/chapter-03-2-2.html" target="_blank"><span class="chip corpo">Corpo/Mente · chapter-03-2-2</span><div class="title">3.2 — Alimentazione e Sport | ❤️ Società</div></a></div>
+    <div class="card"><a href="../book/chapter-03-2-3.html" target="_blank"><span class="chip corpo">Corpo/Mente · chapter-03-2-3</span><div class="title">3.2 — Alimentazione e Sport | ❤️ Società</div></a></div>
+    <div class="card"><a href="../book/chapter-03-2-4.html" target="_blank"><span class="chip corpo">Corpo/Mente · chapter-03-2-4</span><div class="title">3.2 — Alimentazione e Sport | ❤️ Società</div></a></div>
+    <div class="card"><a href="../book/chapter-03-3-1.html" target="_blank"><span class="chip corpo">Corpo/Mente · chapter-03-3-1</span><div class="title">3.3 — Cultura, Politica e Demografia | ❤️ Società</div></a></div>
+    <div class="card"><a href="../book/chapter-03-3-2.html" target="_blank"><span class="chip corpo">Corpo/Mente · chapter-03-3-2</span><div class="title">3.3 — Cultura, Politica e Demografia | ❤️ Società</div></a></div>
+    <div class="card"><a href="../book/chapter-03-3-3.html" target="_blank"><span class="chip corpo">Corpo/Mente · chapter-03-3-3</span><div class="title">3.3 — Cultura, Politica e Demografia | ❤️ Società</div></a></div>
+    <div class="card"><a href="../book/chapter-03-3-4.html" target="_blank"><span class="chip corpo">Corpo/Mente · chapter-03-3-4</span><div class="title">3.3 — Cultura, Politica e Demografia | ❤️ Società</div></a></div>
+    <div class="card"><a href="../book/chapter-03-alimentazione.html" target="_blank"><span class="chip corpo">Corpo/Mente · chapter-03-alimentazione</span><div class="title">3.2 — Alimentazione e Sport | ❤️ Società</div></a></div>
+    <div class="card"><a href="../book/chapter-03-cultura.html" target="_blank"><span class="chip corpo">Corpo/Mente · chapter-03-cultura</span><div class="title">3.3 — Cultura, Politica e Demografia | ❤️ Società</div></a></div>
+    <div class="card"><a href="../book/chapter-03-psicologia.html" target="_blank"><span class="chip corpo">Corpo/Mente · chapter-03-psicologia</span><div class="title">3.1 — Psicologia e Wellbeing | ❤️ Società</div></a></div>
+    <div class="card"><a href="../book/chapter-03.html" target="_blank"><span class="chip corpo">Corpo/Mente · chapter-03</span><div class="title">Società: psicologia, corpo, cultura — Cap. 3</div></a></div>
+    <div class="card"><a href="../book/index.html" target="_blank"><span class="chip index">Index · index</span><div class="title">Futuro Fortissimo — Il libro | Tre saggi su Natura, Tecnologia, Società</div></a></div>
+    <div class="card"><a href="../book/ffxy-index.html" target="_blank"><span class="chip index">Index · ffxy-index</span><div class="title">Indice ff.x.y</div></a></div>
+  </div>
+</section>
+
+<section>
+  <h2>Mapping accenti</h2>
+  <div class="demo">
+    <ul style="font-family:'Inter',sans-serif;font-size:.95rem;color:#434343;line-height:1.8">
+      <li><strong>data-macro="natura"</strong> → 16 file — accent verde <code>#2ecc71</code></li>
+      <li><strong>data-macro="tech"</strong> → 16 file — accent blu <code>#4a90e2</code></li>
+      <li><strong>data-macro="corpo"</strong> → 16 file — accent rosso <code>#d0021b</code></li>
+      <li><strong>data-macro="index"</strong> → 2 file (book/index.html + ffxy-index.html) — accent neutro</li>
+    </ul>
+  </div>
+</section>
+
+<section>
+  <h2>Merge-safety</h2>
+  <div class="demo">
+    <ul style="font-family:'Inter',sans-serif;font-size:.95rem;color:#434343;line-height:1.8">
+      <li><strong>PR #424</strong> (backup-mined-corpus-fidelity): tocca <code>data.js</code> + nuovi sottocapitoli. PR 5 non tocca data.js né aggiunge subchapter markup → conflitti assenti.</li>
+      <li><strong>PR #425</strong> (parent ff.31/101/128 + bib v2 + figures): tocca heading/figure/bib all'interno dei capitoli e aggiunge CSS <code>:target</code> inline nei file HTML. PR 5 usa CSS esterno <code>styles/editorial.css</code> + attributi <code>class</code>/<code>data-*</code> sul body. Gli unici tocchi in-file di PR 5 sono: (a) <code>&lt;link&gt;</code> prima di <code>&lt;/head&gt;</code>, (b) attributi sul <code>&lt;body&gt;</code>. Merge 3-way risolve automaticamente.</li>
+      <li>Il CSS editorial è progettato per <em>complementare</em> il <code>:target</code> di PR #425 (non sovrascrive il background giallo, rinforza solo border-radius).</li>
+    </ul>
+  </div>
+</section>
+
+</body>
+</html>

--- a/scripts/pr5_apply_editorial.py
+++ b/scripts/pr5_apply_editorial.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+PR 5/10 — substack-editorial style migration.
+Class-level activation on all book/ HTML pages.
+
+Per page:
+  1) Inject <link rel="stylesheet" href="styles/editorial.css"> (or relative path) in <head>
+  2) Add class "editorial" to <body> + data-macro / data-chapter attributes
+  3) Leave content untouched.
+"""
+from __future__ import annotations
+import re
+from pathlib import Path
+
+BOOK_DIR = Path(__file__).resolve().parent.parent / "book"
+
+# Chapter-id macro-tema (cap 1/2/3) + per-chapter slug for data-chapter
+# cap 1 = natura (green), cap 2 = tech (blue), cap 3 = corpo (red)
+MACRO_BY_PREFIX = {
+    "chapter-01": "natura",
+    "chapter-02": "tech",
+    "chapter-03": "corpo",
+}
+
+# Slug per chapter-0X-<named>.html (leaf subchapters without X-Y-Z)
+NAMED_SLUGS = {
+    "chapter-01-mobilita": "mobilita",
+    "chapter-01-ambiente": "ambiente",
+    "chapter-01-cibo": "cibo",
+    "chapter-02-robotica": "robotica",
+    "chapter-02-metaverso": "metaverso",
+    "chapter-02-prodotti": "prodotti",
+    "chapter-03-alimentazione": "alimentazione",
+    "chapter-03-cultura": "cultura",
+    "chapter-03-psicologia": "psicologia",
+}
+
+LINK_TAG = '<link rel="stylesheet" href="styles/editorial.css">'
+INDEX_LINK_TAG = '<link rel="stylesheet" href="styles/editorial.css">'
+
+
+def detect_macro(fname: str) -> str:
+    for prefix, macro in MACRO_BY_PREFIX.items():
+        if fname.startswith(prefix):
+            return macro
+    return "index"
+
+
+def detect_chapter_slug(fname: str) -> str:
+    stem = fname.replace(".html", "")
+    if stem in NAMED_SLUGS:
+        return NAMED_SLUGS[stem]
+    # e.g. chapter-01-1-1 -> "1-1-1"
+    m = re.match(r"chapter-(\d+)(?:-(\d+))?(?:-(\d+))?$", stem)
+    if m:
+        parts = [p for p in m.groups() if p]
+        return "-".join(parts)
+    # index, ffxy-index, etc.
+    return stem
+
+
+def process_file(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    original = text
+    fname = path.name
+
+    changes = []
+
+    # --- 1) Inject stylesheet link in <head> if missing -------------------
+    if 'styles/editorial.css' not in text:
+        # Insert right before </head>
+        if '</head>' in text:
+            text = text.replace('</head>', f'    {LINK_TAG}\n</head>', 1)
+            changes.append("link+")
+        else:
+            return {"file": fname, "skipped": "no </head>"}
+
+    # --- 2) Add class="editorial" + data-macro + data-chapter to <body> ---
+    macro = detect_macro(fname)
+    slug = detect_chapter_slug(fname)
+
+    body_re = re.compile(r'<body([^>]*)>', re.IGNORECASE)
+    m = body_re.search(text)
+    if not m:
+        return {"file": fname, "skipped": "no <body>"}
+
+    attrs = m.group(1)
+
+    # Already migrated?
+    if 'class="editorial"' in attrs or "class='editorial'" in attrs \
+            or re.search(r'class\s*=\s*"[^"]*\beditorial\b', attrs) \
+            or re.search(r"class\s*=\s*'[^']*\beditorial\b", attrs):
+        # ensure data-macro present; otherwise add
+        if 'data-macro=' not in attrs:
+            new_attrs = attrs + f' data-macro="{macro}" data-chapter="{slug}"'
+            text = text[:m.start()] + f'<body{new_attrs}>' + text[m.end():]
+            changes.append("data+")
+    else:
+        # Add "editorial" to existing class, or create one
+        class_re = re.search(r'class\s*=\s*"([^"]*)"', attrs)
+        if class_re:
+            existing = class_re.group(1).strip()
+            new_class_val = f'{existing} editorial'.strip()
+            new_attrs = attrs.replace(class_re.group(0), f'class="{new_class_val}"', 1)
+        else:
+            new_attrs = f' class="editorial"' + attrs
+        # Append data attributes (guard against duplicates)
+        if 'data-macro=' not in new_attrs:
+            new_attrs = new_attrs + f' data-macro="{macro}" data-chapter="{slug}"'
+        text = text[:m.start()] + f'<body{new_attrs}>' + text[m.end():]
+        changes.append("body+")
+
+    if text != original:
+        path.write_text(text, encoding="utf-8")
+        return {"file": fname, "macro": macro, "slug": slug, "changes": changes}
+    return {"file": fname, "unchanged": True}
+
+
+def main():
+    report = []
+    targets = []
+    for p in sorted(BOOK_DIR.glob("chapter-*.html")):
+        targets.append(p)
+    # index + ffxy-index
+    for extra in ["index.html", "ffxy-index.html"]:
+        p = BOOK_DIR / extra
+        if p.exists():
+            targets.append(p)
+
+    for p in targets:
+        r = process_file(p)
+        report.append(r)
+
+    migrated = sum(1 for r in report if "changes" in r)
+    unchanged = sum(1 for r in report if r.get("unchanged"))
+    skipped = sum(1 for r in report if "skipped" in r)
+    print(f"Total targets : {len(targets)}")
+    print(f"Migrated      : {migrated}")
+    print(f"Unchanged     : {unchanged}")
+    print(f"Skipped       : {skipped}")
+    for r in report:
+        if "skipped" in r:
+            print("  SKIP", r["file"], r["skipped"])
+
+    # Print per-chapter accent mapping summary
+    macros = {}
+    for r in report:
+        m = r.get("macro")
+        if m:
+            macros.setdefault(m, 0)
+            macros[m] += 1
+    print("By macro:", macros)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pr5_build_preview_grid.py
+++ b/scripts/pr5_build_preview_grid.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Inject chapter grid into preview HTML."""
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+BOOK = ROOT / "book"
+PREVIEW = ROOT / "generated" / "style_migration_preview_2026-04-24.html"
+
+MACRO_BY_PREFIX = {
+    "chapter-01": ("natura", "Natura"),
+    "chapter-02": ("tech", "Tech"),
+    "chapter-03": ("corpo", "Corpo/Mente"),
+}
+
+def macro_of(fname: str):
+    for prefix, (m, label) in MACRO_BY_PREFIX.items():
+        if fname.startswith(prefix):
+            return m, label
+    return ("index", "Index")
+
+
+def extract_title(path: Path) -> str:
+    try:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        m = re.search(r'<title>(.*?)</title>', text, re.IGNORECASE | re.DOTALL)
+        if m:
+            t = m.group(1).strip()
+            t = re.sub(r'\s*\|\s*Futuro Fortissimo.*$', '', t)
+            t = re.sub(r'&mdash;', '—', t)
+            t = re.sub(r'&ndash;', '–', t)
+            t = re.sub(r'&hellip;', '…', t)
+            t = re.sub(r'&agrave;', 'à', t)
+            t = re.sub(r'&egrave;', 'è', t)
+            t = re.sub(r'&igrave;', 'ì', t)
+            t = re.sub(r'&ograve;', 'ò', t)
+            t = re.sub(r'&ugrave;', 'ù', t)
+            t = re.sub(r'&rsquo;', '’', t)
+            t = re.sub(r'&lsquo;', '‘', t)
+            t = re.sub(r'&ldquo;', '“', t)
+            t = re.sub(r'&rdquo;', '”', t)
+            return t[:110]
+    except Exception:
+        pass
+    return path.stem
+
+
+def main():
+    targets = sorted(BOOK.glob("chapter-*.html"))
+    for extra in ["index.html", "ffxy-index.html"]:
+        p = BOOK / extra
+        if p.exists():
+            targets.append(p)
+
+    cards = []
+    for p in targets:
+        macro, macro_label = macro_of(p.name)
+        title = extract_title(p)
+        href = f"../book/{p.name}"
+        cards.append(
+            f'    <div class="card"><a href="{href}" target="_blank">'
+            f'<span class="chip {macro}">{macro_label} · {p.stem}</span>'
+            f'<div class="title">{title}</div></a></div>'
+        )
+
+    grid = "\n".join(cards)
+    html = PREVIEW.read_text(encoding="utf-8")
+    html = html.replace("PLACEHOLDER_GRID", grid)
+    PREVIEW.write_text(html, encoding="utf-8")
+    print(f"Grid injected: {len(cards)} cards")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Obiettivo
Unificare la shell visiva del libro (48 capitoli + index) sullo stile **substack-editorial**: Lora serif body + Inter UI + IBM Plex Mono eyebrow, palette crema `#fbfaf7`, accenti per macro-tema preservati.

Riferimento: stile `draft_uscita` (robot-ricorda backend + editoriale frontend).

## Strategia — class-level, merge-safe
- **NEW** `book/styles/editorial.css` — single source of truth, tutto scoped sotto `body.editorial`. Ridefinisce le classi legacy (`.brutal-card`, `.keypoints`, `.note-highlight`, `.fc`, `.pull-quote`, `figure`, `.fonti-esterne`) senza rewrite del markup.
- Ogni pagina ottiene solo due mutazioni minime:
  1. `<link rel="stylesheet" href="styles/editorial.css">` prima di `</head>`
  2. `class="editorial"` + `data-macro="..."` + `data-chapter="..."` su `<body>`
- Nessuna modifica al contenuto. Nessun tocco a `data.js`.

## Accenti per macro-tema
- `data-macro="natura"` (16 file) → verde `#2ecc71`
- `data-macro="tech"` (16 file) → blu `#4a90e2`
- `data-macro="corpo"` (16 file) → rosso `#d0021b`
- `data-macro="index"` (2 file) → neutro

## Merge-safety
- **PR #424** (`inject/2026-04-24-backup-mined-corpus-fidelity`): tocca `data.js` + nuovi sottocapitoli. PR 5 non incrocia nessuno di questi path.
- **PR #425** (`sync/parent-ff31-ff101-ff128`): tocca heading/figure/bib all'interno dei capitoli + aggiunge CSS `:target` inline. PR 5 tocca solo `<head>` (un `<link>`) + `<body>` (attributi). 3-way merge risolve automaticamente. Il CSS editorial è progettato per complementare il `:target` di PR #425 (rinforza `border-radius`, non sovrascrive il background).

## Deliverables
- `book/styles/editorial.css` (320+ righe, token + ~35 selettori)
- 48 chapter + 2 index HTML aggiornati (link + class + data-*)
- `scripts/pr5_apply_editorial.py` (migration script idempotente)
- `scripts/pr5_build_preview_grid.py` (preview builder)
- `generated/style_migration_preview_2026-04-24.html` — preview navigabile con demo tipografica + griglia 50 pagine

## Test plan
- [ ] Aprire `generated/style_migration_preview_2026-04-24.html` e verificare tipografia demo
- [ ] Campionare 3 capitoli (uno per macro) e confrontare before/after in browser
- [ ] Verificare che `:target` highlight bibliografia (PR #425) continui a funzionare dopo merge
- [ ] Verificare rendering su mobile (crema + hair-line, no grid-pattern residuo)
- [ ] MC gate compat: `.brutal-card` / `.keypoints` ancora presenti nel markup

🤖 Generated with [Claude Code](https://claude.com/claude-code)